### PR TITLE
feat: calculate new device id for >226 and >108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1]
+## [1.3.0]
+
+### Breaking Change
+
+- Previously hm2mqtt published its own data to the `hame_energy/{deviceType}/` or `marstek_energy/{deviceType}` topic. From 1.3.0 onwards the topic changed to `hm2mqtt/{deviceType}`
 
 ### Added
 
-- Venus: Add BMS information sensors including:
+- **B2500**: Better support for devices with firmware >=226 (for HMA, HMF or HMK) or >=108 (for HMJ):
+  - Automatically calculate new encrypted device ID: No need to wait for 20 minutes to get the encrypted id. Instead, just enter the MAC address.
+- **Venus**: Add BMS information sensors including:
   - Cell voltages (up to 16 cells)
   - Cell temperatures (up to 4 sensors)
   - BMS version, SOC, SOH, capacity

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -1,5 +1,6 @@
 import { DeviceManager } from './deviceManager';
 import { MqttConfig } from './types';
+import { calculateNewVersionTopicId } from './utils/crypt';
 
 describe('DeviceManager', () => {
   const mockConfig: MqttConfig = {
@@ -14,6 +15,11 @@ describe('DeviceManager', () => {
         deviceType: 'HMA-1',
         deviceId: 'test456',
         topicPrefix: 'custom_prefix',
+      },
+      {
+        deviceType: 'HMA-1',
+        deviceId: 'test7890abcd', // 12-character MAC address
+        topicPrefix: 'marstek_energy', // Indicates we need to use the new encrypted device ID
       },
     ],
   };
@@ -31,10 +37,10 @@ describe('DeviceManager', () => {
     const topics = deviceManager.getDeviceTopics(device);
     expect(topics).toBeDefined();
     expect(topics?.deviceTopic).toBe('hame_energy/HMA-1/device/test123/ctrl');
-    expect(topics?.publishTopic).toBe('hame_energy/HMA-1/device/test123');
+    expect(topics?.publishTopic).toBe('hm2mqtt/HMA-1/device/test123');
     expect(topics?.deviceControlTopic).toBe('hame_energy/HMA-1/App/test123/ctrl');
-    expect(topics?.controlSubscriptionTopic).toBe('hame_energy/HMA-1/control/test123');
-    expect(topics?.availabilityTopic).toBe('hame_energy/HMA-1/availability/test123');
+    expect(topics?.controlSubscriptionTopic).toBe('hm2mqtt/HMA-1/control/test123');
+    expect(topics?.availabilityTopic).toBe('hm2mqtt/HMA-1/availability/test123');
   });
 
   it('should use custom topic prefix when specified', () => {
@@ -42,9 +48,24 @@ describe('DeviceManager', () => {
     const topics = deviceManager.getDeviceTopics(device);
     expect(topics).toBeDefined();
     expect(topics?.deviceTopic).toBe('custom_prefix/HMA-1/device/test456/ctrl');
-    expect(topics?.publishTopic).toBe('custom_prefix/HMA-1/device/test456');
+    expect(topics?.publishTopic).toBe('hm2mqtt/HMA-1/device/test456');
     expect(topics?.deviceControlTopic).toBe('custom_prefix/HMA-1/App/test456/ctrl');
-    expect(topics?.controlSubscriptionTopic).toBe('custom_prefix/HMA-1/control/test456');
-    expect(topics?.availabilityTopic).toBe('custom_prefix/HMA-1/availability/test456');
+    expect(topics?.controlSubscriptionTopic).toBe('hm2mqtt/HMA-1/control/test456');
+    expect(topics?.availabilityTopic).toBe('hm2mqtt/HMA-1/availability/test456');
+  });
+
+  it('should use encrypted device ID when topic prefix is marstek_energy', () => {
+    const device = mockConfig.devices[2];
+    const topics = deviceManager.getDeviceTopics(device);
+    expect(topics).toBeDefined();
+    expect(topics?.deviceTopic).toBe(
+      `marstek_energy/HMA-1/device/${calculateNewVersionTopicId(device.deviceId)}/ctrl`,
+    );
+    expect(topics?.publishTopic).toBe(`hm2mqtt/HMA-1/device/test7890abcd`);
+    expect(topics?.deviceControlTopic).toBe(
+      `marstek_energy/HMA-1/App/${calculateNewVersionTopicId(device.deviceId)}/ctrl`,
+    );
+    expect(topics?.controlSubscriptionTopic).toBe(`hm2mqtt/HMA-1/control/test7890abcd`);
+    expect(topics?.availabilityTopic).toBe(`hm2mqtt/HMA-1/availability/test7890abcd`);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -143,7 +143,7 @@ describe('MQTT Client', () => {
 
     // Check that the parsed data was published
     expect(mockClient.publish).toHaveBeenCalledWith(
-      expect.stringContaining('hame_energy/HMA-1/device/testdevice/data'),
+      expect.stringContaining('hm2mqtt/HMA-1/device/testdevice/data'),
       expect.any(String),
       expect.any(Object),
       expect.any(Function),
@@ -176,7 +176,7 @@ describe('MQTT Client', () => {
     mockClient.publish.mockClear();
 
     // Trigger a message event with a control topic message
-    const controlTopic = 'hame_energy/HMA-1/control/testdevice/charging-mode';
+    const controlTopic = 'hm2mqtt/HMA-1/control/testdevice/charging-mode';
     mockClient.triggerEvent('message', controlTopic, Buffer.from('chargeDischargeSimultaneously'));
 
     // Check that the command was published to the control topic
@@ -223,7 +223,7 @@ describe('MQTT Client', () => {
     );
 
     // Trigger a message event with a time period setting
-    const controlTopic = 'hame_energy/HMA-1/control/testdevice/time-period/1/enabled';
+    const controlTopic = 'hm2mqtt/HMA-1/control/testdevice/time-period/1/enabled';
     mockClient.triggerEvent('message', controlTopic, Buffer.from('true'));
 
     // Check that the command was published to the control topic with the expected parameters

--- a/src/utils/crypt.test.ts
+++ b/src/utils/crypt.test.ts
@@ -1,0 +1,12 @@
+import { calculateNewVersionTopicId } from './crypt';
+
+describe('crypt', () => {
+  it.each`
+    input             | output
+    ${'badbeefbadbe'} | ${'e6a1f1765cdd26ff05e2afcc5df17a9b'}
+    ${'feeba7123456'} | ${'757a6deefc6ab2b3764d61e64fb2a931'}
+  `('should encrypt "$input" to the expected hex string', ({ input, output }) => {
+    const result = calculateNewVersionTopicId(input);
+    expect(result).toBe(output);
+  });
+});

--- a/src/utils/crypt.ts
+++ b/src/utils/crypt.ts
@@ -1,0 +1,11 @@
+import * as crypto from 'crypto';
+
+export function calculateNewVersionTopicId(mac: string): string {
+  const cipher = crypto.createCipheriv(
+    'aes-128-cbc',
+    Buffer.from('!@#$%^&*()_+{}[]'),
+    Buffer.alloc(16, 0),
+  );
+  const encrypted = Buffer.concat([cipher.update(mac, 'utf8'), cipher.final()]);
+  return encrypted.toString('hex');
+}


### PR DESCRIPTION
- **B2500**: Better support for devices with firmware >=226 (for HMA, HMF or HMK) or >=108 (for HMJ):
  - Automatically calculate new encrypted device ID: No need to wait for 20 minutes to get the encrypted id. Instead, just enter the MAC address.
- Previously hm2mqtt published its own data to the `hame_energy/{deviceType}/` or `marstek_energy/{deviceType}` topic. From 1.3.0 onwards the topic changed to `hm2mqtt/{deviceType}`