### PR TITLE
feat: remove topic prefix setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **B2500**: Better support for devices with firmware >=226 (for HMA, HMF or HMK) or >=108 (for HMJ):
   - Automatically calculate new encrypted device ID: No need to wait for 20 minutes to get the encrypted id. Instead, just enter the MAC address.
+  - Remove the need to manually enter the topicPrefix
 - **Venus**: Add BMS information sensors including:
   - Cell voltages (up to 16 cells)
   - Cell temperatures (up to 4 sensors)

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Configure multiple devices by adding more environment variables:
 # Example with devices using different firmware versions:
 docker run -d --name hm2mqtt \
   -e MQTT_BROKER_URL=mqtt://your-broker:1883 \
-  -e DEVICE_0=HMA-1:001a2b3c4d5e \  # Firmware <226 (for HMA, HMF or HMK) or <108 (for HMJ)
-  -e DEVICE_1=HMA-1:001a2b3c4d5e:marstek_energy \  # Firmware >=226 (for HMA, HMF or HMK) or >=108 (for HMJ)
+  -e DEVICE_0=HMA-1:001a2b3c4d5e \
+  -e DEVICE_1=HMA-1:001a2b3c4d5e \
   ghcr.io/tomquist/hm2mqtt:latest
 ```
 
@@ -88,10 +88,7 @@ services:
       - POLL_CELL_DATA=true
       - POLL_EXTRA_BATTERY_DATA=true
       - POLL_CALIBRATION_DATA=true
-      # For firmware <226 (for HMA, HMF or HMK) or <108 (for HMJ):
       - DEVICE_0=HMA-1:0019aa0d4dcb  # 12-character MAC address
-      # For firmware >=226 (for HMA, HMF or HMK) or >=108 (for HMJ):
-      # - DEVICE_0=HMA-1:0019aa0d4dcb:marstek_energy # Set the topic prefix
 ```
 
 ### Manual Installation
@@ -122,10 +119,7 @@ services:
    POLL_CELL_DATA=false
    POLL_EXTRA_BATTERY_DATA=false
    POLL_CALIBRATION_DATA=false
-   # For firmware <226 (for HMA, HMF or HMK) or <108 (for HMJ):
    DEVICE_0=HMA-1:001a2b3c4d5e  # 12-character MAC address
-   # For firmware >=226 (for HMA, HMF or HMK) or >=108 (for HMJ):
-   # DEVICE_0=HMA-1:001a2b3c4d5e:marstek_energy  # 12-character MAC address
    ```
 
 5. Run the application:
@@ -158,7 +152,6 @@ responseTimeout: 30000  # Timeout for device responses in milliseconds
 devices:
   - deviceType: "HMA-1"
     deviceId: "your-device-mac"
-    topicPrefix: "marstek_energy"  # Required for B2500 devices with firmware version >=226 (for HMA, HMF or HMK) or >=108 (for HMJ)
 ```
 
 The device id is the MAC address of the device in lowercase, without colons.
@@ -166,10 +159,6 @@ The device id is the MAC address of the device in lowercase, without colons.
 **Important Note for B2500 Devices:**
 - Use the MAC address shown in the Marstek/PowerZero app's device list or in the Bluetooth configuration tool
 - **Important:** Do not use the WiFi interface MAC address - it must be the one shown in the app or Bluetooth tool
-- For B2500 devices with firmware version >=226 (for HMA, HMF or HMK) or >=108 (for HMJ):
-  - You must set `topicPrefix: "marstek_energy"` in the device configuration
-- For B2500 devices with firmware version <226 (for HMA, HMF or HMK) or <108 (for HMJ):
-  - Leave the `topicPrefix` empty or omit it (it will use the default "hame_energy" prefix)
 
 The device type can be one of the following:
 - HMB-X: (e.g. HMB-1, HMB-2, ...) B2500 storage v1
@@ -267,16 +256,10 @@ hm2mqtt/{device_type}/control/{device_mac}/{command}
 ### Examples
 
 ```
-# Refresh data from a B2500 device for firmware <226 (for HMA, HMF or HMK) or <108 (for HMJ)
+# Refresh data from a B2500 device
 mosquitto_pub -t "hm2mqtt/HMA-1/control/abcdef123456/refresh" -m ""
 
-# Refresh data from a B2500 device for firmware >=226 (for HMA, HMF or HMK) or >=108 (for HMJ)
-mosquitto_pub -t "hm2mqtt/HMA-1/control/abcdef123456/refresh" -m ""
-
-# Set charging mode for B2500 for firmware <226 (for HMA, HMF or HMK) or <108 (for HMJ)
-mosquitto_pub -t "hm2mqtt/HMA-1/control/abcdef123456/charging-mode" -m "chargeThenDischarge"
-
-# Set charging mode for B2500 for firmware >=226 (for HMA, HMF or HMK) or >=108 (for HMJ)
+# Set charging mode for B2500
 mosquitto_pub -t "hm2mqtt/HMA-1/control/abcdef123456/charging-mode" -m "chargeThenDischarge"
 
 # Enable timer period 1 on Venus device

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -35,4 +35,3 @@ schema:
   devices:
     - deviceType: str
       deviceId: str
-      topicPrefix: str?

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -119,22 +119,11 @@ if bashio::config.exists 'devices'; then
             if bashio::config.exists "devices[${i}].deviceType" && bashio::config.exists "devices[${i}].deviceId"; then
                 DEVICE_TYPE=$(bashio::config "devices[${i}].deviceType")
                 DEVICE_ID=$(bashio::config "devices[${i}].deviceId")
-                TOPIC_PREFIX=""
-
-                # Get topic prefix if it exists
-                if bashio::config.exists "devices[${i}].topicPrefix"; then
-                    TOPIC_PREFIX=$(bashio::config "devices[${i}].topicPrefix")
-                fi
 
                 # Skip if either value is empty
                 if [ -n "$DEVICE_TYPE" ] && [ -n "$DEVICE_ID" ]; then
-                    if [ -n "$TOPIC_PREFIX" ]; then
-                        export "DEVICE_${i}=${DEVICE_TYPE}:${DEVICE_ID}:${TOPIC_PREFIX}"
-                        bashio::log.info "Configured device $((i + 1)): ${DEVICE_TYPE}:${DEVICE_ID} with topic prefix: ${TOPIC_PREFIX}"
-                    else
-                        export "DEVICE_${i}=${DEVICE_TYPE}:${DEVICE_ID}"
-                        bashio::log.info "Configured device $((i + 1)): ${DEVICE_TYPE}:${DEVICE_ID}"
-                    fi
+                    export "DEVICE_${i}=${DEVICE_TYPE}:${DEVICE_ID}"
+                    bashio::log.info "Configured device $((i + 1)): ${DEVICE_TYPE}:${DEVICE_ID}"
                 else
                     bashio::log.warning "Device ${i} has empty deviceType or deviceId"
                 fi

--- a/ha_addon/test_env.sh
+++ b/ha_addon/test_env.sh
@@ -84,13 +84,12 @@ run_test "Configuration with firmware >= 226" \
         "devices": [
             {
                 "deviceType": "HMA-1",
-                "deviceId": "1234567890abcdef1234567890abcdef",
-                "topicPrefix": "marstek_energy"
+                "deviceId": "1234567890abcdef1234567890abcdef"
             }
         ]
     }' \
     "MQTT_BROKER_URL=mqtt://test:1883
-DEVICE_0=HMA-1:1234567890abcdef1234567890abcdef:marstek_energy"
+DEVICE_0=HMA-1:1234567890abcdef1234567890abcdef"
 
 # Test 3: Multiple devices with different firmware versions
 run_test "Multiple devices with different firmware versions" \
@@ -103,14 +102,13 @@ run_test "Multiple devices with different firmware versions" \
             },
             {
                 "deviceType": "HMA-1",
-                "deviceId": "1234567890abcdef1234567890abcdef",
-                "topicPrefix": "marstek_energy"
+                "deviceId": "1234567890abcdef1234567890abcdef"
             }
         ]
     }' \
     "MQTT_BROKER_URL=mqtt://test:1883
 DEVICE_0=HMA-1:001a2b3c4d5e
-DEVICE_1=HMA-1:1234567890abcdef1234567890abcdef:marstek_energy"
+DEVICE_1=HMA-1:1234567890abcdef1234567890abcdef"
 
 # Test 4: Additional configuration options
 run_test "Additional configuration options" \

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -16,4 +16,4 @@ configuration:
     description: "Aktiviere Abruf zusätzlicher Batteriedaten (nur verfügbar für B2500)"
   devices:
     name: "Geräte"
-    description: "Liste der Energiespeichergeräte, mit denen eine Verbindung hergestellt werden soll. Für jedes Gerät angeben: deviceType (z.B. HMA-1 für B2500 v2, HMB-1 für B2500 v1, HMG-50 für Venus), deviceId (bei Firmware < 226: 12-stellige MAC-Adresse aus der App, nicht WLAN-MAC; bei Firmware >= 226: 32-stellige Geräte-ID aus dem MQTT-Topic) und topicPrefix (bei Firmware >= 226: muss 'marstek_energy' sein; bei Firmware < 226: leer lassen)"
+    description: "Liste der Energiespeichergeräte, mit denen eine Verbindung hergestellt werden soll. Für jedes Gerät angeben: deviceType (z.B. HMA-1 für B2500 v2, HMB-1 für B2500 v1, HMG-50 für Venus), deviceId (12-stellige MAC-Adresse aus der App, nicht WLAN-MAC"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -16,4 +16,4 @@ configuration:
     description: "Enable extra battery data reporting (only available on B2500 devices)"
   devices:
     name: Devices
-    description: "List of energy storage devices to connect to. For each device, specify: deviceType (e.g. HMA-1 for B2500 v2, HMB-1 for B2500 v1, HMG-50 for Venus), deviceId (for firmware < 226: 12-character MAC address from app, not WiFi MAC; for firmware >= 226: 32-character device ID from MQTT topic), and topicPrefix (for firmware >= 226: must be 'marstek_energy'; for firmware < 226: leave empty)"
+    description: "List of energy storage devices to connect to. For each device, specify: deviceType (e.g. HMA-1 for B2500 v2, HMB-1 for B2500 v1, HMG-50 for Venus), deviceId (12-character MAC address from app, not WiFi MAC)"

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -11,16 +11,6 @@ describe('DeviceManager', () => {
         deviceType: 'HMA-1',
         deviceId: 'test123',
       },
-      {
-        deviceType: 'HMA-1',
-        deviceId: 'test456',
-        topicPrefix: 'custom_prefix',
-      },
-      {
-        deviceType: 'HMA-1',
-        deviceId: 'test7890abcd', // 12-character MAC address
-        topicPrefix: 'marstek_energy', // Indicates we need to use the new encrypted device ID
-      },
     ],
   };
 
@@ -32,40 +22,20 @@ describe('DeviceManager', () => {
     deviceManager = new DeviceManager(mockConfig, mockOnUpdateState);
   });
 
-  it('should initialize with default topic prefix', () => {
+  it('should initialize with correct topics', () => {
     const device = mockConfig.devices[0];
     const topics = deviceManager.getDeviceTopics(device);
     expect(topics).toBeDefined();
-    expect(topics?.deviceTopic).toBe('hame_energy/HMA-1/device/test123/ctrl');
-    expect(topics?.publishTopic).toBe('hm2mqtt/HMA-1/device/test123');
-    expect(topics?.deviceControlTopic).toBe('hame_energy/HMA-1/App/test123/ctrl');
-    expect(topics?.controlSubscriptionTopic).toBe('hm2mqtt/HMA-1/control/test123');
-    expect(topics?.availabilityTopic).toBe('hm2mqtt/HMA-1/availability/test123');
-  });
-
-  it('should use custom topic prefix when specified', () => {
-    const device = mockConfig.devices[1];
-    const topics = deviceManager.getDeviceTopics(device);
-    expect(topics).toBeDefined();
-    expect(topics?.deviceTopic).toBe('custom_prefix/HMA-1/device/test456/ctrl');
-    expect(topics?.publishTopic).toBe('hm2mqtt/HMA-1/device/test456');
-    expect(topics?.deviceControlTopic).toBe('custom_prefix/HMA-1/App/test456/ctrl');
-    expect(topics?.controlSubscriptionTopic).toBe('hm2mqtt/HMA-1/control/test456');
-    expect(topics?.availabilityTopic).toBe('hm2mqtt/HMA-1/availability/test456');
-  });
-
-  it('should use encrypted device ID when topic prefix is marstek_energy', () => {
-    const device = mockConfig.devices[2];
-    const topics = deviceManager.getDeviceTopics(device);
-    expect(topics).toBeDefined();
-    expect(topics?.deviceTopic).toBe(
+    expect(topics?.deviceTopicOld).toBe('hame_energy/HMA-1/device/test123/ctrl');
+    expect(topics?.deviceTopicNew).toBe(
       `marstek_energy/HMA-1/device/${calculateNewVersionTopicId(device.deviceId)}/ctrl`,
     );
-    expect(topics?.publishTopic).toBe(`hm2mqtt/HMA-1/device/test7890abcd`);
-    expect(topics?.deviceControlTopic).toBe(
+    expect(topics?.publishTopic).toBe('hm2mqtt/HMA-1/device/test123');
+    expect(topics?.deviceControlTopicOld).toBe('hame_energy/HMA-1/App/test123/ctrl');
+    expect(topics?.deviceControlTopicNew).toBe(
       `marstek_energy/HMA-1/App/${calculateNewVersionTopicId(device.deviceId)}/ctrl`,
     );
-    expect(topics?.controlSubscriptionTopic).toBe(`hm2mqtt/HMA-1/control/test7890abcd`);
-    expect(topics?.availabilityTopic).toBe(`hm2mqtt/HMA-1/availability/test7890abcd`);
+    expect(topics?.controlSubscriptionTopic).toBe('hm2mqtt/HMA-1/control/test123');
+    expect(topics?.availabilityTopic).toBe('hm2mqtt/HMA-1/availability/test123');
   });
 });

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -1,6 +1,6 @@
 import { Device, MqttConfig } from './types';
 import { getDeviceDefinition } from './deviceDefinition';
-import { calculateNewVersionTopicId } from './utils/crypt';
+import { calculateNewVersionTopicId, decryptNewVersionTopicId } from './utils/crypt';
 
 /**
  * Interface for device state data
@@ -10,9 +10,12 @@ export type DeviceStateData = object;
  * Device topic structure
  */
 export interface DeviceTopics {
-  deviceTopic: string;
+  deviceTopicOld: string;
+  deviceTopicNew: string;
+  deviceControlTopicOld: string;
+  deviceControlTopicNew: string;
+
   publishTopic: string;
-  deviceControlTopic: string;
   controlSubscriptionTopic: string;
   availabilityTopic: string;
 }
@@ -47,19 +50,15 @@ export class DeviceManager {
       }
       const deviceKey = this.getDeviceKey(device);
       console.log(`Initializing topics for device: ${deviceKey}`);
-      const topicPrefix = device.topicPrefix ?? 'hame_energy';
-      const deviceId = device.deviceId;
-      let deviceTopicDeviceId = deviceId;
-      // If the topicPrefix is marstek_energy, the deviceId must use the new encrypted format
-      // Auto-convert the deviceId to the new format if needed
-      if (deviceId.length === 12 && topicPrefix === 'marstek_energy') {
-        deviceTopicDeviceId = calculateNewVersionTopicId(deviceId);
-      }
+      let deviceId = device.deviceId;
+      let deviceIdNew = calculateNewVersionTopicId(deviceId);
 
       this.deviceTopics[deviceKey] = {
-        deviceTopic: `${topicPrefix}/${device.deviceType}/device/${deviceTopicDeviceId}/ctrl`,
+        deviceTopicOld: `hame_energy/${device.deviceType}/device/${deviceId}/ctrl`,
+        deviceTopicNew: `marstek_energy/${device.deviceType}/device/${deviceIdNew}/ctrl`,
+        deviceControlTopicOld: `hame_energy/${device.deviceType}/App/${deviceId}/ctrl`,
+        deviceControlTopicNew: `marstek_energy/${device.deviceType}/App/${deviceIdNew}/ctrl`,
         publishTopic: `hm2mqtt/${device.deviceType}/device/${device.deviceId}`,
-        deviceControlTopic: `${topicPrefix}/${device.deviceType}/App/${deviceTopicDeviceId}/ctrl`,
         controlSubscriptionTopic: `hm2mqtt/${device.deviceType}/control/${device.deviceId}`,
         availabilityTopic: `hm2mqtt/${device.deviceType}/availability/${device.deviceId}`,
       };
@@ -233,7 +232,7 @@ export class DeviceManager {
       const deviceKey = this.getDeviceKey(device);
       const topics = this.deviceTopics[deviceKey];
 
-      if (topic === topics.deviceTopic) {
+      if (topic === topics.deviceTopicOld || topic === topics.deviceTopicNew) {
         return { device, topicType: 'device' };
       } else if (topic.startsWith(topics.controlSubscriptionTopic)) {
         return { device, topicType: 'control' };

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -7,17 +7,21 @@ describe('Home Assistant Discovery', () => {
   test('should generate discovery configs for a device', () => {
     const deviceType = 'HMA-1';
     const deviceId = 'test123';
-    const deviceTopic = 'hame_energy/HMA-1/device/test123/ctrl';
+    const deviceTopicOld = 'hame_energy/HMA-1/device/test123/ctrl';
+    const deviceTopicNew = 'marstek_energy/HMA-1/device/test123/ctrl';
     const publishTopic = 'hame_energy/HMA-1/device/test123/data';
-    const deviceControlTopic = 'hame_energy/HMA-1/App/test123/ctrl';
+    const deviceControlTopicOld = 'hame_energy/HMA-1/App/test123/ctrl';
+    const deviceControlTopicNew = 'marstek_energy/HMA-1/App/test123/ctrl';
     const controlSubscriptionTopic = 'hame_energy/HMA-1/control/test123/control';
     const availabilityTopic = 'hame_energy/HMA-1/availability/test123';
 
     // Make sure to pass the availability topic
     let device: Device = { deviceType, deviceId };
     let deviceTopics: DeviceTopics = {
-      deviceTopic,
-      deviceControlTopic,
+      deviceTopicOld,
+      deviceTopicNew,
+      deviceControlTopicOld,
+      deviceControlTopicNew,
       availabilityTopic,
       controlSubscriptionTopic,
       publishTopic,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,20 +47,16 @@ function parseDeviceConfigurations(): Device[] {
         const parts = value.split(':');
         const deviceType = parts[0];
         const deviceId = parts[1];
-        const topicPrefix = parts[2]; // Optional topic prefix
 
         if (deviceType && deviceId) {
-          console.log(
-            `Adding device: ${deviceType}:${deviceId}${topicPrefix ? ` with topic prefix: ${topicPrefix}` : ''} from ${key}=${value}`,
-          );
+          console.log(`Adding device: ${deviceType}:${deviceId} from ${key}=${value}`);
           devices.push({
             deviceType,
             deviceId,
-            ...(topicPrefix && { topicPrefix }), // Only add topicPrefix if it exists
           });
         } else {
           console.warn(
-            `Invalid device format for ${key}=${value}, expected format: deviceType:deviceId[:topicPrefix]`,
+            `Invalid device format for ${key}=${value}, expected format: deviceType:deviceId`,
           );
         }
       }
@@ -88,7 +84,7 @@ function parseDeviceConfigurations(): Device[] {
         {
           devices: [
             { deviceType: 'HMA-1', deviceId: '12345' },
-            { deviceType: 'HMA-1', deviceId: '67890', topicPrefix: 'marstek_energy' },
+            { deviceType: 'HMA-1', deviceId: '67890' },
           ],
           pollingInterval: 60,
           responseTimeout: 30,
@@ -248,8 +244,10 @@ function main() {
         return;
       }
 
-      mqttClient
-        .publish(topics.deviceControlTopic, payload, { qos: 1 })
+      Promise.all([
+        mqttClient.publish(topics.deviceControlTopicOld, payload, { qos: 1 }),
+        mqttClient.publish(topics.deviceControlTopicNew, payload, { qos: 1 }),
+      ])
         .then(() => {
           // Request updated device data after sending a command
           // Wait a short delay to allow the device to process the command

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,7 +209,6 @@ export interface B2500V2BatteryData {
 export interface Device {
   deviceType: string;
   deviceId: string;
-  topicPrefix?: string; // Optional topic prefix, defaults to 'hame_energy'
 }
 
 /**

--- a/src/utils/crypt.test.ts
+++ b/src/utils/crypt.test.ts
@@ -1,4 +1,4 @@
-import { calculateNewVersionTopicId } from './crypt';
+import { calculateNewVersionTopicId, decryptNewVersionTopicId } from './crypt';
 
 describe('crypt', () => {
   it.each`
@@ -8,5 +8,8 @@ describe('crypt', () => {
   `('should encrypt "$input" to the expected hex string', ({ input, output }) => {
     const result = calculateNewVersionTopicId(input);
     expect(result).toBe(output);
+
+    const decrypted = decryptNewVersionTopicId(result);
+    expect(decrypted).toBe(input);
   });
 });

--- a/src/utils/crypt.ts
+++ b/src/utils/crypt.ts
@@ -1,11 +1,16 @@
 import * as crypto from 'crypto';
 
+const key = Buffer.from('!@#$%^&*()_+{}[]');
+const iv = Buffer.alloc(16, 0);
 export function calculateNewVersionTopicId(mac: string): string {
-  const cipher = crypto.createCipheriv(
-    'aes-128-cbc',
-    Buffer.from('!@#$%^&*()_+{}[]'),
-    Buffer.alloc(16, 0),
-  );
+  const cipher = crypto.createCipheriv('aes-128-cbc', key, iv);
   const encrypted = Buffer.concat([cipher.update(mac, 'utf8'), cipher.final()]);
   return encrypted.toString('hex');
+}
+
+export function decryptNewVersionTopicId(encrypted: string): string {
+  const cipher = crypto.createDecipheriv('aes-128-cbc', key, iv);
+  return Buffer.concat([cipher.update(Buffer.from(encrypted, 'hex')), cipher.final()]).toString(
+    'utf8',
+  );
 }


### PR DESCRIPTION
This removes the topic prefix setting and instead we now calculate the new device id automatically and send a request and subscribe on the old and new topic simultaneously.