### PR TITLE
Fix time period weekday bug when changing power settings

### DIFF
--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -855,7 +855,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
 
             params.bt = period.startTime;
             params.et = period.endTime;
-            params.wk = period.weekday;
+            params.wk = weekdaySetToBitMask(period.weekday);
             params.vv = period.power;
             params.as = enabled ? 1 : 0;
 
@@ -894,7 +894,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
 
             params.bt = period.startTime;
             params.et = period.endTime;
-            params.wk = period.weekday;
+            params.wk = weekdaySetToBitMask(period.weekday);
             params.vv = period.power;
             params.as = period.enabled ? 1 : 0;
 
@@ -933,7 +933,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
 
             params.bt = period.startTime;
             params.et = period.endTime;
-            params.wk = period.weekday;
+            params.wk = weekdaySetToBitMask(period.weekday);
             params.vv = period.power;
             params.as = period.enabled ? 1 : 0;
 
@@ -970,7 +970,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
 
             params.bt = period.startTime;
             params.et = period.endTime;
-            params.wk = period.weekday;
+            params.wk = weekdaySetToBitMask(period.weekday);
             params.vv = period.power;
             params.as = period.enabled ? 1 : 0;
 


### PR DESCRIPTION
## Description

Fixes #61 - Time period days were changing unexpectedly when modifying power settings via MQTT.

## Problem

When users changed power settings (or start/end times, or enabled status) for time periods via MQTT, the selected weekdays would change unexpectedly. This was caused by incorrect handling of the weekday parameter in the time period command handlers.

## Root Cause

The device expects weekday values as numeric bitmasks (e.g., 127 for all days), but most command handlers were passing the weekday as a string (e.g., "0123456") without converting it to the expected format.

## Solution

Updated all time period command handlers to properly convert weekday strings to bitmasks using the existing `weekdaySetToBitMask()` function:

- ✅ Time period enabled handler
- ✅ Time period start-time handler  
- ✅ Time period end-time handler
- ✅ Time period power handler

The weekday handler was already correctly using this conversion.

## Changes

- `src/device/venus.ts`: Changed `params.wk = period.weekday;` to `params.wk = weekdaySetToBitMask(period.weekday);` in 4 command handlers

## Testing

This fix ensures that when users send MQTT commands like:
```
Topic: hm2mqtt/HMG-50/control/macaddress/time-period/3/power
Payload: 500
```

The weekday selection will remain unchanged, as expected.

## Impact

- 🐛 **Bug Fix**: Resolves unexpected weekday changes
- 🔧 **No Breaking Changes**: Maintains existing API compatibility
- ✅ **Backwards Compatible**: No impact on existing configurations