### PR TITLE
Add state_class measurement to power sensors for Home Assistant statistics

### DIFF
--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -165,6 +165,7 @@ export function registerBaseMessage({
       name: 'Input 1 Power',
       device_class: 'power',
       unit_of_measurement: 'W',
+      state_class: 'measurement',
     }),
   );
   field({
@@ -178,6 +179,7 @@ export function registerBaseMessage({
       name: 'Input 2 Power',
       device_class: 'power',
       unit_of_measurement: 'W',
+      state_class: 'measurement',
     }),
   );
   field({
@@ -194,6 +196,7 @@ export function registerBaseMessage({
       name: 'Total Input Power',
       device_class: 'power',
       unit_of_measurement: 'W',
+      state_class: 'measurement',
     }),
   );
 
@@ -230,6 +233,7 @@ export function registerBaseMessage({
         name: `Output ${outputNumber} Power`,
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
   }
@@ -248,6 +252,7 @@ export function registerBaseMessage({
       name: 'Total Output Power',
       device_class: 'power',
       unit_of_measurement: 'W',
+      state_class: 'measurement',
     }),
   );
 

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -406,6 +406,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'CT Automatic Power Size',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
     field({
@@ -419,6 +420,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'CT Transmitted Power',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
     field({
@@ -529,6 +531,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'CT Clip Power 1',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
     field({
@@ -542,6 +545,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'CT Clip Power 2',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
     field({
@@ -555,6 +559,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'CT Clip Power 3',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
     field({
@@ -568,6 +573,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Micro Inverter Power',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
 
@@ -583,6 +589,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Rated Output Power',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
     field({
@@ -596,6 +603,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Rated Input Power',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
     field({

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -365,6 +365,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Combined Power',
         device_class: 'power',
         unit_of_measurement: 'W',
+        state_class: 'measurement',
       }),
     );
 


### PR DESCRIPTION
Fixes #62

Added `state_class: 'measurement'` to all power sensors to enable Home Assistant's long-term statistics and Energy Dashboard support.