### PR TITLE
Add topic prefix config for Home Assistant addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ services:
 |----------|-------------|-------------------------|
 | `MQTT_BROKER_URL` | MQTT broker URL | `mqtt://localhost:1883` |
 | `MQTT_CLIENT_ID` | MQTT client ID | `hm2mqtt-{random}`      |
+| `MQTT_TOPIC_PREFIX` | Base MQTT topic prefix for published data | `hm2mqtt` |
 | `MQTT_USERNAME` | MQTT username | -                       |
 | `MQTT_PASSWORD` | MQTT password | -                       |
 | `MQTT_POLLING_INTERVAL` | Interval between device polls in seconds | `60`                 |
@@ -189,6 +190,7 @@ services:
 pollingInterval: 60  # Interval between device polls in seconds
 responseTimeout: 30  # Timeout for device responses in seconds
 allowedConsecutiveTimeouts: 3  # Number of consecutive timeouts before a device is marked offline
+topicPrefix: hm2mqtt  # Base MQTT topic prefix for published data
 devices:
   - deviceType: "HMA-1"
     deviceId: "your-device-mac"
@@ -268,6 +270,7 @@ DEVICE_2=HMB-1:device3mac
 
 ```yaml
 mqttProxyEnabled: true
+topicPrefix: hm2mqtt
 devices:
   - deviceType: "HMA-1"
     deviceId: "device1-mac"
@@ -345,7 +348,7 @@ docker run -e MQTT_BROKER_URL=mqtt://your-broker:1883 -e DEVICE_0=HMA-1:your-dev
 
 ### Device Data Topic
 
-Your device data is published to the following MQTT topic:
+Your device data is published to the following MQTT topic (prefix configurable via `MQTT_TOPIC_PREFIX`):
 
 ```
 hm2mqtt/{device_type}/device/{device_mac}/data
@@ -355,7 +358,7 @@ This topic contains the current state of your device in JSON format, including b
 
 ### Control Topics
 
-You can control your device by publishing messages to specific MQTT topics. The base topic pattern for commands is:
+You can control your device by publishing messages to specific MQTT topics. The base topic pattern for commands is (using the same prefix):
 
 ```
 hm2mqtt/{device_type}/control/{device_mac}/{command}

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -24,6 +24,7 @@ options:
   enableCalibrationData: false
   enableExtraBatteryData: false
   allowedConsecutiveTimeouts: 3
+  topicPrefix: hm2mqtt
   mqttProxyEnabled: false
   devices:
     - deviceType: "HMA-1"
@@ -36,6 +37,7 @@ schema:
   enableCalibrationData: bool
   enableExtraBatteryData: bool
   allowedConsecutiveTimeouts: int?
+  topicPrefix: str?
   debug: bool?
   mqttProxyEnabled: bool?
   devices:

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -100,11 +100,13 @@ export POLL_CALIBRATION_DATA=$(bashio::config 'enableCalibrationData' "false")
 export POLL_EXTRA_BATTERY_DATA=$(bashio::config 'enableExtraBatteryData' "false")
 export DEBUG=$(bashio::config 'debug' "false")
 export MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS=$(bashio::config 'allowedConsecutiveTimeouts' "3")
+export MQTT_TOPIC_PREFIX=$(bashio::config 'topicPrefix' "hm2mqtt")
 export MQTT_PROXY_ENABLED=$(bashio::config 'mqttProxyEnabled' "false")
 bashio::log.info "MQTT allowed consecutive timeouts: ${MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS}"
 bashio::log.info "MQTT proxy enabled: ${MQTT_PROXY_ENABLED}"
 bashio::log.info "MQTT polling interval: ${MQTT_POLLING_INTERVAL} seconds"
 bashio::log.info "MQTT response timeout: ${MQTT_RESPONSE_TIMEOUT} seconds"
+bashio::log.info "MQTT topic prefix: ${MQTT_TOPIC_PREFIX}"
 
 # Process devices using Bashio functions properly
 bashio::log.info "Configuring devices..."

--- a/ha_addon/test_env.sh
+++ b/ha_addon/test_env.sh
@@ -75,6 +75,7 @@ run_test "Basic configuration (firmware < 226)" \
         ]
     }' \
     "MQTT_BROKER_URL=mqtt://test:1883
+MQTT_TOPIC_PREFIX=hm2mqtt
 DEVICE_0=HMA-1:001a2b3c4d5e"
 
 # Test 2: Configuration with firmware >= 226
@@ -89,6 +90,7 @@ run_test "Configuration with firmware >= 226" \
         ]
     }' \
     "MQTT_BROKER_URL=mqtt://test:1883
+MQTT_TOPIC_PREFIX=hm2mqtt
 DEVICE_0=HMA-1:1234567890abcdef1234567890abcdef"
 
 # Test 3: Multiple devices with different firmware versions
@@ -107,6 +109,7 @@ run_test "Multiple devices with different firmware versions" \
         ]
     }' \
     "MQTT_BROKER_URL=mqtt://test:1883
+MQTT_TOPIC_PREFIX=hm2mqtt
 DEVICE_0=HMA-1:001a2b3c4d5e
 DEVICE_1=HMA-1:1234567890abcdef1234567890abcdef"
 
@@ -119,6 +122,7 @@ run_test "Additional configuration options" \
         "enableCellData": true,
         "enableCalibrationData": true,
         "enableExtraBatteryData": true,
+        "topicPrefix": "custom",
         "devices": [
             {
                 "deviceType": "HMA-1",
@@ -127,6 +131,7 @@ run_test "Additional configuration options" \
         ]
     }' \
     "MQTT_BROKER_URL=mqtt://test:1883
+MQTT_TOPIC_PREFIX=custom
 MQTT_POLLING_INTERVAL=30
 MQTT_RESPONSE_TIMEOUT=15
 POLL_CELL_DATA=true

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -17,6 +17,9 @@ configuration:
   allowedConsecutiveTimeouts:
     name: Maximale aufeinanderfolgende Timeouts
     description: "Anzahl aufeinanderfolgender Timeouts, bevor ein Gerät als offline markiert wird (Standard: 3)"
+  topicPrefix:
+    name: MQTT-Topic-Präfix
+    description: "Basis-MQTT-Präfix für veröffentlichte Daten (Standard: hm2mqtt)"
   mqttProxyEnabled:
     name: MQTT Proxy aktivieren
     description: "MQTT Proxy-Server aktivieren um B2500 Client-ID-Konflikte zu lösen (Standard: false)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -17,6 +17,9 @@ configuration:
   allowedConsecutiveTimeouts:
     name: Allowed Consecutive Timeouts
     description: "Number of consecutive timeouts before a device is marked offline (default: 3)"
+  topicPrefix:
+    name: MQTT Topic Prefix
+    description: "Base MQTT topic prefix for published data (default: hm2mqtt)"
   mqttProxyEnabled:
     name: Enable MQTT Proxy
     description: "Enable MQTT proxy server to resolve B2500 client ID conflicts (default: false)"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Default base topic used for publishing and subscribing to hm2mqtt specific
+ * messages. This value is used when `MQTT_TOPIC_PREFIX` is not provided.
+ */
+export const DEFAULT_TOPIC_PREFIX = 'hm2mqtt';

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -7,6 +7,7 @@ import {
   B2500BaseDeviceData,
   B2500V1DeviceData,
 } from './types';
+import { DEFAULT_TOPIC_PREFIX } from './constants';
 
 describe('ControlHandler', () => {
   let controlHandler: ControlHandler;
@@ -33,6 +34,7 @@ describe('ControlHandler', () => {
     const config: MqttConfig = {
       brokerUrl: 'mqtt://test.mosquitto.org',
       clientId: 'test-client',
+      topicPrefix: DEFAULT_TOPIC_PREFIX,
       devices: [testDeviceV1, testDeviceV2],
       responseTimeout: 15000,
     };

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -1,11 +1,13 @@
 import { DeviceManager } from './deviceManager';
 import { MqttConfig } from './types';
+import { DEFAULT_TOPIC_PREFIX } from './constants';
 import { calculateNewVersionTopicId } from './utils/crypt';
 
 describe('DeviceManager', () => {
   const mockConfig: MqttConfig = {
     brokerUrl: 'mqtt://localhost',
     clientId: 'test-client',
+    topicPrefix: DEFAULT_TOPIC_PREFIX,
     devices: [
       {
         deviceType: 'HMA-1',
@@ -30,12 +32,25 @@ describe('DeviceManager', () => {
     expect(topics?.deviceTopicNew).toBe(
       `marstek_energy/HMA-1/device/${calculateNewVersionTopicId(device.deviceId)}/ctrl`,
     );
-    expect(topics?.publishTopic).toBe('hm2mqtt/HMA-1/device/test123');
+    expect(topics?.publishTopic).toBe(`${DEFAULT_TOPIC_PREFIX}/HMA-1/device/test123`);
     expect(topics?.deviceControlTopicOld).toBe('hame_energy/HMA-1/App/test123/ctrl');
     expect(topics?.deviceControlTopicNew).toBe(
       `marstek_energy/HMA-1/App/${calculateNewVersionTopicId(device.deviceId)}/ctrl`,
     );
-    expect(topics?.controlSubscriptionTopic).toBe('hm2mqtt/HMA-1/control/test123');
-    expect(topics?.availabilityTopic).toBe('hm2mqtt/HMA-1/availability/test123');
+    expect(topics?.controlSubscriptionTopic).toBe(`${DEFAULT_TOPIC_PREFIX}/HMA-1/control/test123`);
+    expect(topics?.availabilityTopic).toBe(`${DEFAULT_TOPIC_PREFIX}/HMA-1/availability/test123`);
+  });
+
+  it('should use custom topic prefix', () => {
+    const customConfig: MqttConfig = {
+      ...mockConfig,
+      topicPrefix: 'customPrefix',
+    };
+    const dm = new DeviceManager(customConfig, mockOnUpdateState);
+    const device = customConfig.devices[0];
+    const topics = dm.getDeviceTopics(device);
+    expect(topics?.publishTopic).toBe('customPrefix/HMA-1/device/test123');
+    expect(topics?.controlSubscriptionTopic).toBe('customPrefix/HMA-1/control/test123');
+    expect(topics?.availabilityTopic).toBe('customPrefix/HMA-1/availability/test123');
   });
 });

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -53,14 +53,15 @@ export class DeviceManager {
       let deviceId = device.deviceId;
       let deviceIdNew = calculateNewVersionTopicId(deviceId);
 
+      const prefix = this.config.topicPrefix;
       this.deviceTopics[deviceKey] = {
         deviceTopicOld: `hame_energy/${device.deviceType}/device/${deviceId}/ctrl`,
         deviceTopicNew: `marstek_energy/${device.deviceType}/device/${deviceIdNew}/ctrl`,
         deviceControlTopicOld: `hame_energy/${device.deviceType}/App/${deviceId}/ctrl`,
         deviceControlTopicNew: `marstek_energy/${device.deviceType}/App/${deviceIdNew}/ctrl`,
-        publishTopic: `hm2mqtt/${device.deviceType}/device/${device.deviceId}`,
-        controlSubscriptionTopic: `hm2mqtt/${device.deviceType}/control/${device.deviceId}`,
-        availabilityTopic: `hm2mqtt/${device.deviceType}/availability/${device.deviceId}`,
+        publishTopic: `${prefix}/${device.deviceType}/device/${device.deviceId}`,
+        controlSubscriptionTopic: `${prefix}/${device.deviceType}/control/${device.deviceId}`,
+        availabilityTopic: `${prefix}/${device.deviceType}/availability/${device.deviceId}`,
       };
 
       // Initialize response timeout tracker

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -2,6 +2,7 @@ import { generateDiscoveryConfigs } from './generateDiscoveryConfigs';
 import { Device } from './types';
 import { DeviceTopics } from './deviceManager';
 import { AdditionalDeviceInfo } from './deviceDefinition';
+import { DEFAULT_TOPIC_PREFIX } from './constants';
 
 describe('Home Assistant Discovery', () => {
   test('should generate discovery configs for a device', () => {
@@ -27,7 +28,12 @@ describe('Home Assistant Discovery', () => {
       publishTopic,
     };
     let additionalDeviceInfo: AdditionalDeviceInfo = {};
-    const configs = generateDiscoveryConfigs(device, deviceTopics, additionalDeviceInfo);
+    const configs = generateDiscoveryConfigs(
+      device,
+      deviceTopics,
+      additionalDeviceInfo,
+      DEFAULT_TOPIC_PREFIX,
+    );
 
     // Check that we have configs
     expect(configs.length).toBeGreaterThan(0);
@@ -132,7 +138,7 @@ describe('Home Assistant Discovery', () => {
     const { publishDiscoveryConfigs } = require('./generateDiscoveryConfigs');
 
     // Call the function with the mock client
-    publishDiscoveryConfigs(mockClient, device, deviceTopics, {});
+    publishDiscoveryConfigs(mockClient, device, deviceTopics, {}, DEFAULT_TOPIC_PREFIX);
 
     // Check that publish was called
     expect(mockClient.publish).toHaveBeenCalled();
@@ -145,6 +151,6 @@ describe('Home Assistant Discovery', () => {
     };
 
     // Call with error client
-    publishDiscoveryConfigs(mockClientWithError, device, deviceTopics, {});
+    publishDiscoveryConfigs(mockClientWithError, device, deviceTopics, {}, DEFAULT_TOPIC_PREFIX);
   });
 });

--- a/src/generateDiscoveryConfigs.ts
+++ b/src/generateDiscoveryConfigs.ts
@@ -19,6 +19,7 @@ export function generateDiscoveryConfigs(
   device: Device,
   topics: DeviceTopics,
   additionalDeviceInfo: AdditionalDeviceInfo,
+  topicPrefix: string,
 ): Array<{ topic: string; config: HaDiscoveryConfig }> {
   const deviceDefinition = getDeviceDefinition(device.deviceType);
   const configs: Array<{ topic: string; config: any }> = [];
@@ -41,7 +42,7 @@ export function generateDiscoveryConfigs(
   const availabilityConfig = {
     availability: [
       {
-        topic: 'hm2mqtt/availability',
+        topic: `${topicPrefix}/availability`,
         payload_available: 'online',
         payload_not_available: 'offline',
       },
@@ -93,8 +94,9 @@ export function publishDiscoveryConfigs(
   device: Device,
   deviceTopics: DeviceTopics,
   additionalDeviceInfo: AdditionalDeviceInfo,
+  topicPrefix: string,
 ): void {
-  const configs = generateDiscoveryConfigs(device, deviceTopics, additionalDeviceInfo);
+  const configs = generateDiscoveryConfigs(device, deviceTopics, additionalDeviceInfo, topicPrefix);
 
   configs.forEach(({ topic, config }) => {
     let message = JSON.stringify(config);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_TOPIC_PREFIX } from './constants';
+
 beforeAll(() => {
   jest.clearAllMocks();
 });
@@ -70,6 +72,7 @@ jest.mock('dotenv', () => ({
     process.env.MQTT_PASSWORD = 'testpass';
     process.env.DEVICE_1 = 'HMA-1:testdevice';
     process.env.MQTT_POLLING_INTERVAL = '5000';
+    process.env.MQTT_TOPIC_PREFIX = DEFAULT_TOPIC_PREFIX;
   }),
 }));
 
@@ -85,6 +88,7 @@ describe('MQTT Client', () => {
     process.env.MQTT_PASSWORD = 'testpass';
     process.env.DEVICE_1 = 'HMA-1:testdevice';
     process.env.MQTT_POLLING_INTERVAL = '5000';
+    process.env.MQTT_TOPIC_PREFIX = DEFAULT_TOPIC_PREFIX;
   });
 
   test('should initialize MQTT client with correct options', () => {
@@ -142,8 +146,9 @@ describe('MQTT Client', () => {
     mockClient.triggerEvent('message', deviceTopic, message);
 
     // Check that the parsed data was published
+    const prefix = process.env.MQTT_TOPIC_PREFIX || DEFAULT_TOPIC_PREFIX;
     expect(mockClient.publish).toHaveBeenCalledWith(
-      expect.stringContaining('hm2mqtt/HMA-1/device/testdevice/data'),
+      expect.stringContaining(`${prefix}/HMA-1/device/testdevice/data`),
       expect.any(String),
       expect.any(Object),
       expect.any(Function),
@@ -176,7 +181,8 @@ describe('MQTT Client', () => {
     mockClient.publish.mockClear();
 
     // Trigger a message event with a control topic message
-    const controlTopic = 'hm2mqtt/HMA-1/control/testdevice/charging-mode';
+    const prefix = process.env.MQTT_TOPIC_PREFIX || DEFAULT_TOPIC_PREFIX;
+    const controlTopic = `${prefix}/HMA-1/control/testdevice/charging-mode`;
     mockClient.triggerEvent('message', controlTopic, Buffer.from('chargeDischargeSimultaneously'));
 
     // Check that the command was published to the control topic
@@ -223,7 +229,8 @@ describe('MQTT Client', () => {
     );
 
     // Trigger a message event with a time period setting
-    const controlTopic = 'hm2mqtt/HMA-1/control/testdevice/time-period/1/enabled';
+    const prefix = process.env.MQTT_TOPIC_PREFIX || DEFAULT_TOPIC_PREFIX;
+    const controlTopic = `${prefix}/HMA-1/control/testdevice/time-period/1/enabled`;
     mockClient.triggerEvent('message', controlTopic, Buffer.from('true'));
 
     // Check that the command was published to the control topic with the expected parameters

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 import { Device, MqttConfig } from './types';
+import { DEFAULT_TOPIC_PREFIX } from './constants';
 import { DeviceManager, DeviceStateData } from './deviceManager';
 import { MqttClient } from './mqttClient';
 import { ControlHandler } from './controlHandler';
@@ -118,6 +119,7 @@ function createMqttConfig(devices: Device[]): MqttConfig {
     clientId: process.env.MQTT_CLIENT_ID || `hm2mqtt-${Math.random().toString(16).slice(2, 8)}`,
     username: process.env.MQTT_USERNAME || undefined,
     password: process.env.MQTT_PASSWORD || undefined,
+    topicPrefix: process.env.MQTT_TOPIC_PREFIX || DEFAULT_TOPIC_PREFIX,
     devices,
     responseTimeout: parseInt(process.env.MQTT_RESPONSE_TIMEOUT || '15', 10) * 1000,
     allowedConsecutiveTimeouts: parseInt(process.env.MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS || '3', 10),

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -35,7 +35,7 @@ export class MqttClient {
       connectTimeout: 30000, // 30 seconds timeout
       // Set up last will message for availability
       will: {
-        topic: `hm2mqtt/availability`,
+        topic: `${this.config.topicPrefix}/availability`,
         payload: 'offline',
         qos: 1 as const,
         retain: true,
@@ -67,7 +67,7 @@ export class MqttClient {
     console.log('Connected to MQTT broker');
 
     // Publish global availability status
-    this.publish(`hm2mqtt/availability`, 'online', {
+    this.publish(`${this.config.topicPrefix}/availability`, 'online', {
       qos: 1,
       retain: true,
     });
@@ -197,7 +197,13 @@ export class MqttClient {
 
     if (topics) {
       let additionalDeviceInfo = this.getAdditionalDeviceInfo(device);
-      publishDiscoveryConfigs(this.client, device, topics, additionalDeviceInfo);
+      publishDiscoveryConfigs(
+        this.client,
+        device,
+        topics,
+        additionalDeviceInfo,
+        this.config.topicPrefix,
+      );
     }
   }
 
@@ -329,7 +335,12 @@ export class MqttClient {
     });
 
     // Publish global offline status
-    publishPromises.push(this.publish(`hm2mqtt/availability`, 'offline', { qos: 1, retain: true }));
+    publishPromises.push(
+      this.publish(`${this.config.topicPrefix}/availability`, 'offline', {
+        qos: 1,
+        retain: true,
+      }),
+    );
 
     // Wait for all publish operations to complete (with timeout)
     try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,11 @@ export interface MqttConfig {
   username?: string;
   password?: string;
   devices: Device[];
+  /**
+   * Base MQTT topic prefix used for publishing and subscribing to hm2mqtt
+   * specific topics (default: 'hm2mqtt')
+   */
+  topicPrefix: string;
   useFlashCommands?: boolean;
   responseTimeout?: number; // Timeout for device responses in milliseconds
   /**


### PR DESCRIPTION
- expose MQTT topic prefix in the HA addon configuration
- log and export `MQTT_TOPIC_PREFIX` in the addon run script
- document `topicPrefix` option in README and translations
- update addon environment tests for the new prefix

Fixes #72