### PR TITLE
Jupiter: Fix / update some existing sensors, add MPPT sensors

### DIFF
--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -851,12 +851,42 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
       }
       // BMS fields
       const bmsFields = [
-        ['soc', { id: 'soc', deviceClass: 'battery', unitOfMeasurement: '%', stateClass: 'measurement' }],
+        [
+          'soc',
+          { id: 'soc', deviceClass: 'battery', unitOfMeasurement: '%', stateClass: 'measurement' },
+        ],
         ['soh', { id: 'soh' }],
-        ['b_cap', { id: 'capacity', deviceClass: 'energy_storage', unitOfMeasurement: 'Wh'}],
-        ['b_vol', { id: 'voltage', deviceClass: 'voltage', unitOfMeasurement: 'V', stateClass: 'measurement', transform: (v: string) => parseInt(v) / 100 }],
-        ['b_cur', { id: 'current', deviceClass: 'current', unitOfMeasurement: 'A', stateClass: 'measurement', transform: (v: string) => parseInt(v) / 10 }],
-        ['b_temp', { id: 'temperature', deviceClass: 'temperature', unitOfMeasurement: '°C', stateClass: 'measurement', transform: (v: string) => parseInt(v) / 10 }],
+        ['b_cap', { id: 'capacity', deviceClass: 'energy_storage', unitOfMeasurement: 'Wh' }],
+        [
+          'b_vol',
+          {
+            id: 'voltage',
+            deviceClass: 'voltage',
+            unitOfMeasurement: 'V',
+            stateClass: 'measurement',
+            transform: (v: string) => parseInt(v) / 100,
+          },
+        ],
+        [
+          'b_cur',
+          {
+            id: 'current',
+            deviceClass: 'current',
+            unitOfMeasurement: 'A',
+            stateClass: 'measurement',
+            transform: (v: string) => parseInt(v) / 10,
+          },
+        ],
+        [
+          'b_temp',
+          {
+            id: 'temperature',
+            deviceClass: 'temperature',
+            unitOfMeasurement: '°C',
+            stateClass: 'measurement',
+            transform: (v: string) => parseInt(v) / 10,
+          },
+        ],
         ['c_vol', { id: 'chargeVoltage', deviceClass: 'voltage', unitOfMeasurement: 'mV' }],
         ['c_cur', { id: 'chargeCurrent', deviceClass: 'current', unitOfMeasurement: 'mA' }],
         ['d_cur', { id: 'dischargeCurrent', deviceClass: 'current', unitOfMeasurement: 'mA' }],
@@ -867,11 +897,31 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
         ['c_flag', { id: 'cellFlag' }],
         ['s_flag', { id: 'statusFlag' }],
         ['b_num', { id: 'bmsNumber' }],
-        ['mos_t', { id: 'mosfetTemp', deviceClass: 'temperature', unitOfMeasurement: '°C', stateClass: 'measurement' }],
-        ['env_t', { id: 'envTemp', deviceClass: 'temperature', unitOfMeasurement: '°C', stateClass: 'measurement' }],
+        [
+          'mos_t',
+          {
+            id: 'mosfetTemp',
+            deviceClass: 'temperature',
+            unitOfMeasurement: '°C',
+            stateClass: 'measurement',
+          },
+        ],
+        [
+          'env_t',
+          {
+            id: 'envTemp',
+            deviceClass: 'temperature',
+            unitOfMeasurement: '°C',
+            stateClass: 'measurement',
+          },
+        ],
       ] as const;
       for (const [key, info] of bmsFields) {
-        field({ key, path: ['bms', info.id], transform: 'transform' in info ? info.transform : undefined });
+        field({
+          key,
+          path: ['bms', info.id],
+          transform: 'transform' in info ? info.transform : undefined,
+        });
         advertise(
           ['bms', info.id],
           sensorComponent<number>({
@@ -886,7 +936,15 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
       }
       // MPPT fields
       const mpptFields = [
-        ['m_temp', { id: 'temperature', deviceClass: 'temperature', unitOfMeasurement: '°C', stateClass: 'measurement' }],
+        [
+          'm_temp',
+          {
+            id: 'temperature',
+            deviceClass: 'temperature',
+            unitOfMeasurement: '°C',
+            stateClass: 'measurement',
+          },
+        ],
         ['m_err', { id: 'error' }],
         ['m_war', { id: 'warning' }],
       ] as const;
@@ -909,10 +967,14 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
         { id: 'voltage', deviceClass: 'voltage', unitOfMeasurement: 'V' },
         { id: 'current', deviceClass: 'current', unitOfMeasurement: 'A' },
         { id: 'power', deviceClass: 'power', unitOfMeasurement: 'W' },
-      ] as const
+      ] as const;
       for (let i = 0; i < 4; ++i) {
         for (const info of mpptPVFields) {
-          field({ key: `pv${i + 1}`, path: ['mppt', 'pv', i, info.id], transform: v => parseMPPTPVInfo(v)[info.id] });
+          field({
+            key: `pv${i + 1}`,
+            path: ['mppt', 'pv', i, info.id],
+            transform: v => parseMPPTPVInfo(v)[info.id],
+          });
           advertise(
             ['mppt', 'pv', i, info.id],
             sensorComponent<number>({
@@ -923,7 +985,7 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
               state_class: 'measurement',
               enabled_by_default: false,
             }),
-          )
+          );
         }
       }
     },
@@ -972,12 +1034,12 @@ function parseMPPTPVInfo(value: string): JupiterMPPTPVInfo {
       voltage: 0,
       current: 0,
       power: 0,
-    }
+    };
   }
 
   return {
     voltage: parseInt(parts[0]) / 10,
     current: parseInt(parts[1]) / 10,
     power: parseInt(parts[2]) / 10,
-  }
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -454,6 +454,12 @@ export interface JupiterDeviceData extends BaseDeviceData {
   alarmCode?: number; // ala_c
 }
 
+export interface JupiterMPPTPVInfo {
+  voltage?: number;
+  current?: number;
+  power?: number;
+}
+
 export interface JupiterBMSInfo extends BaseDeviceData {
   cells?: {
     voltages?: number[]; // vol0-vol15
@@ -478,5 +484,11 @@ export interface JupiterBMSInfo extends BaseDeviceData {
     bmsNumber?: number; // b_num
     mosfetTemp?: number; // mos_t
     envTemp?: number; // env_t
+  };
+  mppt?: {
+    temperature?: number; // m_temp
+    error?: number; // m_err
+    warning?: number; // m_war
+    pv?: JupiterMPPTPVInfo[]; // pv1-pv4
   };
 }


### PR DESCRIPTION
I bought Marstek Jupiter C Plus recently and use your project to integrate it into the Home Assistant. Thanks a lot!

But I noticed that some of the values don't seem right. E.g., BMS voltage of 5231 mV (5.231 V). However, Jupiter C plus has 51.2 V battery (series of 16 x 3.2 V LFP cells), so the voltage should be between 40 V and 54.4 V.

I also added sensors for some MPPT fields (for which I could deduce the meaning).

This pull request:

- Adds sensors for some MPPT fields.

- Adds device and state classes where missing and makes sense.

- Fixes some BMS values by adding divisors.

- Reverses the sign of the WiFi signal strength and adds a unit of measurement (dBm). Based on the description of `wif_s` in the ["Venus MQTT Document"](https://stekker-batterij.nl/wp-content/uploads/2025/01/VenusMQTTInstruction-API.pdf) it really looks like it's reversed dBm.