### PR TITLE
Use total_increasing state_class for period sensors

### DIFF
--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -126,7 +126,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Daily Charging Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
     field({ key: 'ele_m', path: ['monthlyChargingCapacity'], transform: v => parseFloat(v) / 100 });
@@ -137,7 +137,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Monthly Charging Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
     field({ key: 'ele_y', path: ['yearlyChargingCapacity'], transform: v => parseFloat(v) / 100 });
@@ -148,7 +148,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Yearly Charging Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
     field({ key: 'pv1_p', path: ['pv1Power'] });
@@ -203,7 +203,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Daily Discharge Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
     field({
@@ -218,7 +218,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Monthly Discharge Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
     field({ key: 'grd_o', path: ['combinedPower'] });

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -238,7 +238,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Daily Charging Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
 
@@ -254,7 +254,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Monthly Charging Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
 
@@ -270,7 +270,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Daily Discharge Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
 
@@ -286,7 +286,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Monthly Discharge Capacity',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
-        state_class: 'total',
+        state_class: 'total_increasing',
       }),
     );
 


### PR DESCRIPTION
## Summary
- use `total_increasing` state class for Jupiter and Venus period energy sensors
- keep monetary sensors using `total` state class

Fixes #84

## Testing
- `npx jest --runInBand --reporters=default --silent=false`