### PR TITLE
Fix sync-time timezone offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ hm2mqtt/{device_type}/control/{device_mac}/{command}
 - `time-period/[1-5]/output-value`: Sets output power for period (0-800W)
 - `connected-phase`: Sets connected phase for CT meter (`1`, `2`, or `3`)
 - `time-zone`: Sets time zone (UTC offset in hours)
-- `sync-time`: Synchronizes device time with server
+- `sync-time`: Synchronizes device time with server using the server's time zone
 - `surplus-feed-in`: Toggles Surplus Feed-in mode (`on` or `off`). When enabled, surplus PV power is fed into the home grid when the battery is nearly full.
 
 ### Venus Device Commands

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -245,12 +245,12 @@ hame_energy/{type}/App/{uid or mac}/ctrl
 
 **Payload:**
 ```
-cd=08,wy=480,yy=123,mm=1,rr=2,hh=23,mn=56,ss=56
+cd=08,wy=<timezone offset>,yy=123,mm=1,rr=2,hh=23,mn=56,ss=56
 ```
 
 | Parameter | Description |
 |-----------|-------------|
-| wy | Time offset |
+| wy | Time offset (automatically set to server time zone) |
 | yy | Year (actual year minus 1900) |
 | mm | Month (0-11, 0=January) |
 | rr | Date (1-31) |

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -263,9 +263,10 @@ describe('ControlHandler', () => {
       handleControlTopic(testDeviceV2, 'sync-time', 'PRESS');
 
       // Check that the publish callback was called with the correct payload
+      const expectedWy = -mockDate.getTimezoneOffset();
       expect(publishCallback).toHaveBeenCalledWith(
         testDeviceV2,
-        expect.stringContaining('cd=8,wy=480,yy=123,mm=0,rr=1,hh=12,mn=30,ss=45'),
+        expect.stringContaining(`cd=8,wy=${expectedWy},yy=123,mm=0,rr=1,hh=12,mn=30,ss=45`),
       );
 
       // Restore Date

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -636,7 +636,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           if (message === 'PRESS' || message === 'press' || message === 'true' || message === '1') {
             const now = new Date();
             const timeData = {
-              wy: 480, // Default timezone offset
+              wy: -now.getTimezoneOffset(),
               yy: now.getFullYear() - 1900,
               mm: now.getMonth(),
               rr: now.getDate(),


### PR DESCRIPTION
## Summary
- compute timezone offset dynamically when synchronizing time
- document automatic timezone handling
- update unit tests for timezone calculation

## Testing
- `npm test --silent 2>&1 | grep -E "Test Suites|Tests|PASS|FAIL" | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68636ea83b24832ea9a6526e8d1e8142