### PR TITLE
Fix sync-time timezone offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Next]
+
+- Fix time synchronization to use local timezone offset (#98)
+
+
 ## [1.4.3] - 2025-06-22
 
 - Jupiter: Add MPPT sensors for PV voltage, current, and power (#82)

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -250,7 +250,7 @@ cd=08,wy=480,yy=123,mm=1,rr=2,hh=23,mn=56,ss=56
 
 | Parameter | Description |
 |-----------|-------------|
-| wy | Time offset |
+| wy | Time offset (local timezone offset in minutes) |
 | yy | Year (actual year minus 1900) |
 | mm | Month (0-11, 0=January) |
 | rr | Date (1-31) |

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -256,16 +256,17 @@ describe('ControlHandler', () => {
 
     test('should handle sync-time control topic with PRESS', () => {
       // Mock Date.now to return a consistent date for testing
-      const mockDate = new Date(2023, 0, 1, 12, 30, 45);
-      jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+      const mockDate = new Date(Date.UTC(2023, 0, 1, 12, 30, 45));
+      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as any);
 
       // Call the method with a sync time message
       handleControlTopic(testDeviceV2, 'sync-time', 'PRESS');
 
       // Check that the publish callback was called with the correct payload
+      const expectedWy = -mockDate.getTimezoneOffset();
       expect(publishCallback).toHaveBeenCalledWith(
         testDeviceV2,
-        expect.stringContaining('cd=8,wy=480,yy=123,mm=0,rr=1,hh=12,mn=30,ss=45'),
+        expect.stringContaining(`cd=8,wy=${expectedWy},yy=123,mm=0,rr=1,hh=12,mn=30,ss=45`),
       );
 
       // Restore Date

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -636,13 +636,13 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           if (message === 'PRESS' || message === 'press' || message === 'true' || message === '1') {
             const now = new Date();
             const timeData = {
-              wy: 480, // Default timezone offset
-              yy: now.getFullYear() - 1900,
-              mm: now.getMonth(),
-              rr: now.getDate(),
-              hh: now.getHours(),
-              mn: now.getMinutes(),
-              ss: now.getSeconds(),
+              wy: -now.getTimezoneOffset(),
+              yy: now.getUTCFullYear() - 1900,
+              mm: now.getUTCMonth(),
+              rr: now.getUTCDate(),
+              hh: now.getUTCHours(),
+              mn: now.getUTCMinutes(),
+              ss: now.getUTCSeconds(),
             };
             publishCallback(
               processCommand(CommandType.SYNC_TIME, timeData, deviceState.useFlashCommands),


### PR DESCRIPTION
## Summary
- compute timezone offset from local TZ while keeping UTC timestamp
- clarify sync-time docs for B2500 devices
- adjust unit test expectation
- revert README change

## Testing
- `npm test --silent 2>&1 | grep -E "Test Suites|Tests|PASS|FAIL" | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68636ea83b24832ea9a6526e8d1e8142