### PR TITLE
Add CT002 smart meter support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Device Model
       description: |
-        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus
+        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Device Model (optional)
       description: |
-        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus
+        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter
     validations:
       required: false
   - type: input

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Device Model (optional)
       description: |
-        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus
+        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter
     validations:
       required: false
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Next]
 
 - Fix time synchronization to use local timezone offset (#98)
+- Add support for CT002 smart meter device type HME
 
 
 ## [1.4.3] - 2025-06-22

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ hm2mqtt is a bridge application that connects Hame energy storage devices (like 
 - Marstek Jupiter C
 - Marstek Jupiter E
 - Marstek Jupiter Plus
+- Marstek CT002 Smart Meter
 
 ## Prerequisites
 

--- a/src/device/ct002.ts
+++ b/src/device/ct002.ts
@@ -1,0 +1,143 @@
+import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
+import { CT002DeviceData } from '../types';
+import { sensorComponent } from '../homeAssistantDiscovery';
+
+const requiredRuntimeInfoKeys = ['pwr_a', 'pwr_b', 'pwr_c', 'pwr_t'];
+
+function isCt002RuntimeInfoMessage(values: Record<string, string>): boolean {
+  return requiredRuntimeInfoKeys.every(k => k in values);
+}
+
+function extractAdditionalDeviceInfo(state: CT002DeviceData) {
+  return {
+    firmwareVersion: state.firmwareVersion?.toString(),
+  };
+}
+
+registerDeviceDefinition(
+  {
+    deviceTypes: ['HME'],
+  },
+  ({ message }) => {
+    registerRuntimeInfoMessage(message);
+  },
+);
+
+function registerRuntimeInfoMessage(message: BuildMessageFn) {
+  const options = {
+    refreshDataPayload: 'cd=1',
+    isMessage: isCt002RuntimeInfoMessage,
+    publishPath: 'data',
+    defaultState: {},
+    getAdditionalDeviceInfo: extractAdditionalDeviceInfo,
+    pollInterval: globalPollInterval,
+    controlsDeviceAvailability: true,
+  } as const;
+  message<CT002DeviceData>(options, ({ field, advertise }) => {
+    advertise(
+      ['timestamp'],
+      sensorComponent<string>({
+        id: 'timestamp',
+        name: 'Last Update',
+        device_class: 'timestamp',
+        icon: 'mdi:clock',
+      }),
+    );
+
+    field({ key: 'pwr_a', path: ['phase1Power'] });
+    advertise(
+      ['phase1Power'],
+      sensorComponent<number>({
+        id: 'phase1_power',
+        name: 'Phase 1 Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+    );
+
+    field({ key: 'pwr_b', path: ['phase2Power'] });
+    advertise(
+      ['phase2Power'],
+      sensorComponent<number>({
+        id: 'phase2_power',
+        name: 'Phase 2 Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+    );
+
+    field({ key: 'pwr_c', path: ['phase3Power'] });
+    advertise(
+      ['phase3Power'],
+      sensorComponent<number>({
+        id: 'phase3_power',
+        name: 'Phase 3 Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+    );
+
+    field({ key: 'pwr_t', path: ['totalPower'] });
+    advertise(
+      ['totalPower'],
+      sensorComponent<number>({
+        id: 'total_power',
+        name: 'Total Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+    );
+
+    field({ key: 'ble_s', path: ['bluetoothSignal'] });
+    advertise(
+      ['bluetoothSignal'],
+      sensorComponent<number>({
+        id: 'bluetooth_signal',
+        name: 'Bluetooth Signal',
+      }),
+    );
+
+    field({ key: 'wif_r', path: ['wifiRssi'] });
+    advertise(
+      ['wifiRssi'],
+      sensorComponent<number>({
+        id: 'wifi_rssi',
+        name: 'WiFi RSSI',
+        device_class: 'signal_strength',
+        unit_of_measurement: 'dBm',
+        state_class: 'measurement',
+      }),
+    );
+
+    field({ key: 'fc4_v', path: ['fc4Version'], transform: v => v });
+    advertise(
+      ['fc4Version'],
+      sensorComponent<string>({
+        id: 'fc4_version',
+        name: 'FC4 Version',
+      }),
+    );
+
+    field({ key: 'ver_v', path: ['firmwareVersion'] });
+    advertise(
+      ['firmwareVersion'],
+      sensorComponent<number>({
+        id: 'firmware_version',
+        name: 'Firmware Version',
+      }),
+    );
+
+    field({ key: 'wif_s', path: ['wifiStatus'] });
+    advertise(
+      ['wifiStatus'],
+      sensorComponent<number>({
+        id: 'wifi_status',
+        name: 'WiFi Status',
+      }),
+    );
+  });
+}

--- a/src/device/registry.ts
+++ b/src/device/registry.ts
@@ -2,3 +2,4 @@ import './b2500V1';
 import './b2500V2';
 import './venus';
 import './jupiter';
+import './ct002';

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -173,4 +173,22 @@ describe('MQTT Message Parser', () => {
     const { data: unknownScene } = parseMessage(`${requiredKeys},cj=3`, 'HMA-1', '12345');
     expect(unknownScene).toHaveProperty('scene', undefined);
   });
+
+  test('should parse CT002 smart meter message', () => {
+    const message =
+      'pwr_a=119,pwr_b=15,pwr_c=-136,pwr_t=-1,ble_s=5,wif_r=-79,fc4_v=202409090159,ver_v=119,wif_s=2,slv_n=1,cur_d=0';
+    const { data } = parseMessage(message, 'HME-4', 'abcd');
+
+    expect(data).toBeDefined();
+    const result = data as any;
+    expect(result).toHaveProperty('phase1Power', 119);
+    expect(result).toHaveProperty('phase2Power', 15);
+    expect(result).toHaveProperty('phase3Power', -136);
+    expect(result).toHaveProperty('totalPower', -1);
+    expect(result).toHaveProperty('bluetoothSignal', 5);
+    expect(result).toHaveProperty('wifiRssi', -79);
+    expect(result).toHaveProperty('fc4Version', '202409090159');
+    expect(result).toHaveProperty('firmwareVersion', 119);
+    expect(result).toHaveProperty('wifiStatus', 2);
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -492,3 +492,15 @@ export interface JupiterBMSInfo extends BaseDeviceData {
     pv?: JupiterMPPTPVInfo[]; // pv1-pv4
   };
 }
+
+export interface CT002DeviceData extends BaseDeviceData {
+  phase1Power?: number; // pwr_a
+  phase2Power?: number; // pwr_b
+  phase3Power?: number; // pwr_c
+  totalPower?: number; // pwr_t
+  bluetoothSignal?: number; // ble_s
+  wifiRssi?: number; // wif_r
+  fc4Version?: string; // fc4_v
+  firmwareVersion?: number; // ver_v
+  wifiStatus?: number; // wif_s
+}


### PR DESCRIPTION
## Summary
- add CT002 smart meter device definition
- register CT002 device
- document support for CT002 smart meter
- add CT002 parser test
- define CT002DeviceData type
- remove obsolete sensors

## Testing
- `npm run lint:fix`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cb40d28b0832e838c9f0f79cc462d