### PR TITLE
Allow 0W max charging power for Venus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Next]
 
 - Fix time synchronization to use local timezone offset (#98)
+- Venus: Allow setting maximum charging power as low as 0W
 - Add support for CT002 smart meter device type HME
 
 

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -321,7 +321,7 @@ hame_energy/{type}/App/{uid or mac}/ctrl
 
 Payload:
 ```
-cd=16,cp=[300,2500]
+cd=16,cp=[0,2500]
 ```
 
 ### 12.2 Receive

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1123,7 +1123,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:flash',
         unit_of_measurement: 'W',
         command: 'max-charging-power',
-        min: 300,
+        min: 0,
         max: 2500,
         step: 1,
       }),
@@ -1132,7 +1132,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     command('max-charging-power', {
       handler: ({ message, publishCallback, updateDeviceState }) => {
         const power = parseInt(message, 10);
-        if (isNaN(power) || power < 300 || power > 2500) {
+        if (isNaN(power) || power < 0 || power > 2500) {
           logger.error('Invalid maximum charging power value:', message);
           return;
         }


### PR DESCRIPTION
## Summary
- loosen limits for setting the maximum charging power on Venus
- document new minimum range
- add changelog entry

## Testing
- `npm test --silent`

Fixes #111

------
https://chatgpt.com/codex/tasks/task_e_687d624ae0f0832e97959f2600467de0