### PR TITLE
Add conditional advertising for sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Venus: Allow setting maximum charging power as low as 0W (#117)
 - Add support for CT002 smart meter device type HME (#116)
 - Add support for MI800 micro inverter device type HMI (#118)
+- Sensors can now be conditionally disabled using a state-based function (#120)
 
 
 ## [1.4.3] - 2025-06-22

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -100,9 +100,7 @@ export type RegisterCommandDefinitionFn<T extends BaseDeviceData> = (
 ) => void;
 export type AdvertiseComponentFn<T extends BaseDeviceData> = <KP extends KeyPath<T> | []>(
   keyPath: KP,
-  component: HaStatefulAdvertiseBuilder<
-    KP extends KeyPath<T> ? TypeAtPath<T, KP> : void
-  >,
+  component: HaStatefulAdvertiseBuilder<KP extends KeyPath<T> ? TypeAtPath<T, KP> : void>,
   options?: { enabled?: (state: T) => boolean },
 ) => void;
 
@@ -163,11 +161,7 @@ export function registerDeviceDefinition(
       commands.push({ ...command, command: name } as ControlHandlerDefinition<any>);
     };
     const advertisements: HaAdvertisement<any, KeyPath<any> | []>[] = [];
-    const advertise: AdvertiseComponentFn<any> = (
-      keyPath,
-      advertise,
-      options = {},
-    ) => {
+    const advertise: AdvertiseComponentFn<any> = (keyPath, advertise, options = {}) => {
       advertisements.push({
         keyPath,
         advertise,

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -100,7 +100,10 @@ export type RegisterCommandDefinitionFn<T extends BaseDeviceData> = (
 ) => void;
 export type AdvertiseComponentFn<T extends BaseDeviceData> = <KP extends KeyPath<T> | []>(
   keyPath: KP,
-  component: HaStatefulAdvertiseBuilder<KP extends KeyPath<T> ? TypeAtPath<T, KP> : void>,
+  component: HaStatefulAdvertiseBuilder<
+    KP extends KeyPath<T> ? TypeAtPath<T, KP> : void
+  >,
+  options?: { enabled?: (state: T) => boolean },
 ) => void;
 
 export type BuildMessageDefinitionArgs<T extends BaseDeviceData> = {
@@ -160,10 +163,15 @@ export function registerDeviceDefinition(
       commands.push({ ...command, command: name } as ControlHandlerDefinition<any>);
     };
     const advertisements: HaAdvertisement<any, KeyPath<any> | []>[] = [];
-    const advertise: AdvertiseComponentFn<any> = (keyPath, advertise) => {
+    const advertise: AdvertiseComponentFn<any> = (
+      keyPath,
+      advertise,
+      options = {},
+    ) => {
       advertisements.push({
         keyPath,
         advertise,
+        enabled: options.enabled,
       });
     };
 

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -50,9 +50,7 @@ describe('Home Assistant Discovery', () => {
     // Check device info
     expect(firstConfig.config!.device).toHaveProperty('ids');
     expect(firstConfig.config!.device.ids[0]).toBe(`hame_energy_${deviceId}`);
-    expect(firstConfig.config!.device.name).toBe(
-      `HAME Energy ${deviceType} ${deviceId}`,
-    );
+    expect(firstConfig.config!.device.name).toBe(`HAME Energy ${deviceType} ${deviceId}`);
     expect(firstConfig.config!.device.model_id).toBe(deviceType);
     expect(firstConfig.config!.device.manufacturer).toBe('HAME Energy');
 
@@ -69,18 +67,12 @@ describe('Home Assistant Discovery', () => {
     expect(batteryPercentageSensor?.config!.unit_of_measurement).toBe('%');
 
     // Check availability configuration
-    expect(batteryPercentageSensor?.config!.availability?.[1].topic).toBe(
-      availabilityTopic,
-    );
+    expect(batteryPercentageSensor?.config!.availability?.[1].topic).toBe(availabilityTopic);
 
     const chargingModeSelect = configs.find(c => c.topic.includes('charging_mode'));
     expect(chargingModeSelect).toBeDefined();
-    expect(chargingModeSelect?.config!.options).toContain(
-      'Simultaneous Charging/Discharging',
-    );
-    expect(chargingModeSelect?.config!.options).toContain(
-      'Fully Charge Then Discharge',
-    );
+    expect(chargingModeSelect?.config!.options).toContain('Simultaneous Charging/Discharging');
+    expect(chargingModeSelect?.config!.options).toContain('Fully Charge Then Discharge');
 
     // Check time period entities
     const timePeriod1Enabled = configs.find(c => c.topic.includes('time_period_1_enabled'));
@@ -159,6 +151,13 @@ describe('Home Assistant Discovery', () => {
     };
 
     // Call with error client
-    publishDiscoveryConfigs(mockClientWithError, device, deviceTopics, {}, DEFAULT_TOPIC_PREFIX, {});
+    publishDiscoveryConfigs(
+      mockClientWithError,
+      device,
+      deviceTopics,
+      {},
+      DEFAULT_TOPIC_PREFIX,
+      {},
+    );
   });
 });

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -42,17 +42,19 @@ describe('Home Assistant Discovery', () => {
     const firstConfig = configs[0];
     expect(firstConfig).toHaveProperty('topic');
     expect(firstConfig).toHaveProperty('config');
-    expect(firstConfig.config).toHaveProperty('name');
-    expect(firstConfig.config).toHaveProperty('unique_id');
-    expect(firstConfig.config).toHaveProperty('state_topic');
-    expect(firstConfig.config).toHaveProperty('device');
+    expect(firstConfig.config!).toHaveProperty('name');
+    expect(firstConfig.config!).toHaveProperty('unique_id');
+    expect(firstConfig.config!).toHaveProperty('state_topic');
+    expect(firstConfig.config!).toHaveProperty('device');
 
     // Check device info
-    expect(firstConfig.config.device).toHaveProperty('ids');
-    expect(firstConfig.config.device.ids[0]).toBe(`hame_energy_${deviceId}`);
-    expect(firstConfig.config.device.name).toBe(`HAME Energy ${deviceType} ${deviceId}`);
-    expect(firstConfig.config.device.model_id).toBe(deviceType);
-    expect(firstConfig.config.device.manufacturer).toBe('HAME Energy');
+    expect(firstConfig.config!.device).toHaveProperty('ids');
+    expect(firstConfig.config!.device.ids[0]).toBe(`hame_energy_${deviceId}`);
+    expect(firstConfig.config!.device.name).toBe(
+      `HAME Energy ${deviceType} ${deviceId}`,
+    );
+    expect(firstConfig.config!.device.model_id).toBe(deviceType);
+    expect(firstConfig.config!.device.manufacturer).toBe('HAME Energy');
 
     // Check that all topics are unique
     const topics = configs.map(c => c.topic);
@@ -63,22 +65,28 @@ describe('Home Assistant Discovery', () => {
     // Check specific entity types
     const batteryPercentageSensor = configs.find(c => c.topic.includes('battery_percentage'));
     expect(batteryPercentageSensor).toBeDefined();
-    expect(batteryPercentageSensor?.config.device_class).toBe('battery');
-    expect(batteryPercentageSensor?.config.unit_of_measurement).toBe('%');
+    expect(batteryPercentageSensor?.config!.device_class).toBe('battery');
+    expect(batteryPercentageSensor?.config!.unit_of_measurement).toBe('%');
 
     // Check availability configuration
-    expect(batteryPercentageSensor?.config.availability?.[1].topic).toBe(availabilityTopic);
+    expect(batteryPercentageSensor?.config!.availability?.[1].topic).toBe(
+      availabilityTopic,
+    );
 
     const chargingModeSelect = configs.find(c => c.topic.includes('charging_mode'));
     expect(chargingModeSelect).toBeDefined();
-    expect(chargingModeSelect?.config.options).toContain('Simultaneous Charging/Discharging');
-    expect(chargingModeSelect?.config.options).toContain('Fully Charge Then Discharge');
+    expect(chargingModeSelect?.config!.options).toContain(
+      'Simultaneous Charging/Discharging',
+    );
+    expect(chargingModeSelect?.config!.options).toContain(
+      'Fully Charge Then Discharge',
+    );
 
     // Check time period entities
     const timePeriod1Enabled = configs.find(c => c.topic.includes('time_period_1_enabled'));
     expect(timePeriod1Enabled).toBeDefined();
-    expect(timePeriod1Enabled?.config.payload_on).toBe('true');
-    expect(timePeriod1Enabled?.config.payload_off).toBe('false');
+    expect(timePeriod1Enabled?.config!.payload_on).toBe('true');
+    expect(timePeriod1Enabled?.config!.payload_off).toBe('false');
 
     // Check that we have all 5 time periods
     for (let i = 1; i <= 5; i++) {
@@ -96,13 +104,13 @@ describe('Home Assistant Discovery', () => {
     // Check flash commands switch
     const flashCommandsSwitch = configs.find(c => c.topic.includes('use_flash_commands'));
     expect(flashCommandsSwitch).toBeDefined();
-    expect(flashCommandsSwitch?.config.payload_on).toBe('true');
-    expect(flashCommandsSwitch?.config.payload_off).toBe('false');
+    expect(flashCommandsSwitch?.config!.payload_on).toBe('true');
+    expect(flashCommandsSwitch?.config!.payload_off).toBe('false');
 
     // Check factory reset button
     const factoryResetButton = configs.find(c => c.topic.includes('factory_reset'));
     expect(factoryResetButton).toBeDefined();
-    expect(factoryResetButton?.config.payload_press).toBe('PRESS');
+    expect(factoryResetButton?.config!.payload_press).toBe('PRESS');
   });
 
   test('should mock publishDiscoveryConfigs', () => {
@@ -138,7 +146,7 @@ describe('Home Assistant Discovery', () => {
     const { publishDiscoveryConfigs } = require('./generateDiscoveryConfigs');
 
     // Call the function with the mock client
-    publishDiscoveryConfigs(mockClient, device, deviceTopics, {}, DEFAULT_TOPIC_PREFIX);
+    publishDiscoveryConfigs(mockClient, device, deviceTopics, {}, DEFAULT_TOPIC_PREFIX, {});
 
     // Check that publish was called
     expect(mockClient.publish).toHaveBeenCalled();
@@ -151,6 +159,6 @@ describe('Home Assistant Discovery', () => {
     };
 
     // Call with error client
-    publishDiscoveryConfigs(mockClientWithError, device, deviceTopics, {}, DEFAULT_TOPIC_PREFIX);
+    publishDiscoveryConfigs(mockClientWithError, device, deviceTopics, {}, DEFAULT_TOPIC_PREFIX, {});
   });
 });

--- a/src/generateDiscoveryConfigs.ts
+++ b/src/generateDiscoveryConfigs.ts
@@ -12,9 +12,7 @@ import {
 import { Device } from './types';
 export interface HaAdvertisement<T, KP extends KeyPath<T> | []> {
   keyPath: KP;
-  advertise: HaStatefulAdvertiseBuilder<
-    KP extends KeyPath<T> ? TypeAtPath<T, KeyPath<T>> : void
-  >;
+  advertise: HaStatefulAdvertiseBuilder<KP extends KeyPath<T> ? TypeAtPath<T, KeyPath<T>> : void>;
   enabled?: (state: T) => boolean;
 }
 

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -198,12 +198,14 @@ export class MqttClient {
 
     if (topics) {
       let additionalDeviceInfo = this.getAdditionalDeviceInfo(device);
+      const deviceState = this.deviceManager.getDeviceState(device);
       publishDiscoveryConfigs(
         this.client,
         device,
         topics,
         additionalDeviceInfo,
         this.config.topicPrefix,
+        deviceState,
       );
     }
   }


### PR DESCRIPTION
## Summary
- allow sensor advertisements to be conditionally enabled by providing a callback
- un-advertise sensors when disabled
- include current device state when publishing discovery information
- document feature in CHANGELOG

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884b7377c5c832e8a240df533498791