### PR TITLE
feat: auto-disable sensors when optional messages are disabled

### DIFF
--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -685,6 +685,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
     publishPath: 'cells',
     pollInterval: 60000,
     controlsDeviceAvailability: false,
+    enabled: process.env.POLL_CELL_DATA === 'true',
   } as const;
   message<B2500CellData>(options, ({ field, advertise }) => {
     advertise(
@@ -805,6 +806,7 @@ export function registerCalibrationDataMessage(message: BuildMessageFn) {
     publishPath: 'calibration',
     pollInterval: 60000,
     controlsDeviceAvailability: false,
+    enabled: process.env.POLL_CALIBRATION_DATA === 'true',
   } as const;
   message<B2500CalibrationData>(options, ({ field, advertise }) => {
     advertise(

--- a/src/device/b2500V1.ts
+++ b/src/device/b2500V1.ts
@@ -24,15 +24,9 @@ registerDeviceDefinition(
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);
-    if (process.env.POLL_EXTRA_BATTERY_DATA === 'true') {
-      registerExtraBatteryData(message);
-    }
-    if (process.env.POLL_CELL_DATA === 'true') {
-      registerCellDataMessage(message);
-    }
-    if (process.env.POLL_CALIBRATION_DATA === 'true') {
-      registerCalibrationDataMessage(message);
-    }
+    registerExtraBatteryData(message);
+    registerCellDataMessage(message);
+    registerCalibrationDataMessage(message);
   },
 );
 
@@ -216,6 +210,7 @@ function registerExtraBatteryData(message: BuildMessageFn) {
     getAdditionalDeviceInfo: () => ({}),
     pollInterval: globalPollInterval,
     controlsDeviceAvailability: false,
+    enabled: process.env.POLL_EXTRA_BATTERY_DATA === 'true',
   } as const;
   message<B2500V1CD16Data>(options, ({ field, advertise }) => {
     advertise(

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -136,15 +136,9 @@ registerDeviceDefinition(
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);
-    if (process.env.POLL_EXTRA_BATTERY_DATA === 'true') {
-      registerExtraBatteryData(message);
-    }
-    if (process.env.POLL_CELL_DATA === 'true') {
-      registerCellDataMessage(message);
-    }
-    if (process.env.POLL_CALIBRATION_DATA === 'true') {
-      registerCalibrationDataMessage(message);
-    }
+    registerExtraBatteryData(message);
+    registerCellDataMessage(message);
+    registerCalibrationDataMessage(message);
   },
 );
 
@@ -738,6 +732,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
     pollInterval: 60000,
     controlsDeviceAvailability: false,
     getAdditionalDeviceInfo: () => ({}),
+    enabled: process.env.POLL_EXTRA_BATTERY_DATA === 'true',
   } as const;
   message<B2500V2CD16Data>(options, ({ field, advertise }) => {
     advertise(

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -91,9 +91,7 @@ registerDeviceDefinition(
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);
-    if (process.env.POLL_CELL_DATA === 'true') {
-      registerJupiterBMSInfoMessage(message);
-    }
+    registerJupiterBMSInfoMessage(message);
   },
 );
 
@@ -817,6 +815,7 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
       getAdditionalDeviceInfo: () => ({}),
       pollInterval: 60000,
       controlsDeviceAvailability: false,
+      enabled: process.env.POLL_CELL_DATA === 'true',
     },
     ({ field, advertise }) => {
       // Cell voltages (vol0-vol15)

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -137,9 +137,7 @@ registerDeviceDefinition(
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);
-    if (process.env.POLL_CELL_DATA === 'true') {
-      registerBMSInfoMessage(message);
-    }
+    registerBMSInfoMessage(message);
   },
 );
 
@@ -1162,6 +1160,7 @@ function registerBMSInfoMessage(message: BuildMessageFn) {
       getAdditionalDeviceInfo: () => ({}),
       pollInterval: 60000,
       controlsDeviceAvailability: false,
+      enabled: process.env.POLL_CELL_DATA === 'true',
     },
     ({ field, advertise }) => {
       for (let i = 1; i <= 16; i++) {

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -79,6 +79,7 @@ export interface MessageDefinition<T extends BaseDeviceData> {
   publishPath: string;
   pollInterval: number;
   controlsDeviceAvailability: boolean;
+  enabled?: boolean;
 }
 
 export type BaseDeviceData = {
@@ -128,6 +129,7 @@ export type BuildMessageFn = <T extends BaseDeviceData>(
     getAdditionalDeviceInfo: (state: T) => AdditionalDeviceInfo;
     pollInterval: number;
     controlsDeviceAvailability: boolean;
+    enabled?: boolean;
   },
   args: BuildMessageDefinitionFn<T>,
 ) => void;
@@ -162,10 +164,13 @@ export function registerDeviceDefinition(
     };
     const advertisements: HaAdvertisement<any, KeyPath<any> | []>[] = [];
     const advertise: AdvertiseComponentFn<any> = (keyPath, advertise, options = {}) => {
+      // If the message is disabled, override enabled to always return false
+      const enabled = messageOptions.enabled === false ? () => false : options.enabled;
+
       advertisements.push({
         keyPath,
         advertise,
-        enabled: options.enabled,
+        enabled,
       });
     };
 
@@ -175,6 +180,7 @@ export function registerDeviceDefinition(
       advertisements,
       commands,
       ...messageOptions,
+      enabled: messageOptions.enabled !== false,
     } satisfies MessageDefinition<any>;
     messages.push(messageDefinition);
   };


### PR DESCRIPTION
Fixes dangling sensors by automatically disabling them when their parent message is disabled via environment variables. Previously, disabling POLL_CELL_DATA etc. would stop polling but leave sensors visible in Home Assistant with stale data.

- Add enabled flag to BuildMessageFn to control message and sensor state
- Replace conditional registration with always-register + enabled flag
- Sensors now automatically become unavailable when message is disabled
- Maintain backward compatibility with existing environment variables