### PR TITLE
feat(venus): add local api control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Next]
+
+- Venus: Add local API enable and port controls for firmware 153 and above (#??)
+
+
 ## [1.5.0] - 2025-08-09
 
 - Fix time synchronization to use local timezone offset (#102)

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -38,6 +38,7 @@ enum CommandType {
   SET_METER_TYPE = 18,
   GET_CT_POWER = 19,
   UPGRADE_FC4_MODULE = 20,
+  SET_LOCAL_API = 30,
 }
 
 /**
@@ -608,6 +609,83 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:wifi',
       }),
     );
+
+    field({
+      key: 'api',
+      path: ['localApiEnabled'],
+      transform: v => v === '1',
+    });
+    advertise(
+      ['localApiEnabled'],
+      switchComponent({
+        id: 'local_api_enabled',
+        name: 'Local API Enabled',
+        icon: 'mdi:lan',
+        command: 'local-api-enabled',
+      }),
+      { enabled: state => (state.deviceVersion ?? 0) >= 153 },
+    );
+
+    field({
+      key: 'port',
+      path: ['localApiPort'],
+      transform: v => parseInt(v, 10),
+    });
+    advertise(
+      ['localApiPort'],
+      numberComponent({
+        id: 'local_api_port',
+        name: 'Local API Port',
+        icon: 'mdi:numeric',
+        command: 'local-api-port',
+        min: 0,
+        max: 65535,
+        step: 1,
+      }),
+      { enabled: state => (state.deviceVersion ?? 0) >= 153 },
+    );
+
+    command('local-api-enabled', {
+      handler: ({ message, publishCallback, updateDeviceState, deviceState }) => {
+        if ((deviceState.deviceVersion ?? 0) < 153) {
+          logger.warn(
+            'Local API control not supported for firmware version',
+            deviceState.deviceVersion,
+          );
+          return;
+        }
+        const enabled = message.toLowerCase() === 'true' || message === '1' || message === 'ON';
+        updateDeviceState(() => ({ localApiEnabled: enabled }));
+        const params: CommandParams = { api: enabled ? 1 : 0 };
+        if (deviceState.localApiPort != null) {
+          params.port = deviceState.localApiPort;
+        }
+        publishCallback(processCommand(CommandType.SET_LOCAL_API, params));
+      },
+    });
+
+    command('local-api-port', {
+      handler: ({ message, publishCallback, updateDeviceState, deviceState }) => {
+        if ((deviceState.deviceVersion ?? 0) < 153) {
+          logger.warn(
+            'Local API control not supported for firmware version',
+            deviceState.deviceVersion,
+          );
+          return;
+        }
+        const port = parseInt(message, 10);
+        if (isNaN(port) || port < 0 || port > 65535) {
+          logger.warn('Invalid local API port value:', message);
+          return;
+        }
+        updateDeviceState(() => ({ localApiPort: port }));
+        const params: CommandParams = { port };
+        if (deviceState.localApiEnabled != null) {
+          params.api = deviceState.localApiEnabled ? 1 : 0;
+        }
+        publishCallback(processCommand(CommandType.SET_LOCAL_API, params));
+      },
+    });
 
     // Time periods
     for (let i = 0; i < 10; i++) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -380,6 +380,8 @@ export interface VenusDeviceData extends BaseDeviceData {
   bmsVersion?: number;
   communicationModuleVersion?: string;
   wifiName?: string;
+  localApiEnabled?: boolean;
+  localApiPort?: number;
 }
 
 export interface VenusBMSInfo extends BaseDeviceData {


### PR DESCRIPTION
## Summary
- add sensors and commands to manage Venus local API
- expose local API enablement and port only for firmware >=153

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e39b85150832e9e56565f3ba3c143