### PR TITLE
chore: downgrade client ID conflict log to info

### DIFF
--- a/src/mqttProxy.ts
+++ b/src/mqttProxy.ts
@@ -68,8 +68,8 @@ export class MqttProxy {
           }
 
           packet.clientId = uniqueId;
-          logger.warn(
-            `MQTT Proxy: Modified client ID from '${originalClientId}' to '${uniqueId}' (conflict resolution)`,
+          logger.info(
+            `MQTT Proxy: Modified client ID from '${originalClientId}' to '${uniqueId}' (conflict resolution). Use distinct usernames for each storage to avoid conflicts`,
           );
         }
 


### PR DESCRIPTION
## Summary
- downgrade client ID conflict message from warning to info and add note about using distinct usernames per storage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9cf317600832e92a87879c6165f7d