### PR TITLE
Add Venus E 3.0 device type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+- Venus: Add support for Venus E 3.0 device type (VNSE3-0) (#??)
 - Venus: Add local API enable and port controls for firmware 153 and above (#??)
 - Home Assistant add-on: make application log level configurable via `log_level` option (#161)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
-- Venus: Add support for Venus E 3.0 device type (VNSE3-0) (#??)
+- Venus: Add support for Venus E 3.0 device type (VNSE3-0) (#182)
 - Venus: Add local API enable and port controls for firmware 153 and above (#??)
 - Home Assistant add-on: make application log level configurable via `log_level` option (#161)
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ The device type can be one of the following:
 - **HMA-X**: (e.g. HMA-1, HMA-2, ...) B2500 storage v2  
 - **HMK-X**: (e.g. HMK-1, HMK-2, ...) Greensolar storage v3
 - **HMG-X**: (e.g. HMG-50) Marstek Venus
+- **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -78,7 +78,7 @@ hame_energy/{type}/device/{uid or mac}/ctrl
 ```
 
 The parameters that need to be filled in the command include your device type, device ID or MAC.
-Venus currently has the following type: HMG-x, like HMG-1.
+Venus currently has the following types: HMG-x (e.g. HMG-1) and VNSE3-x (e.g. VNSE3-0).
 
 ## 3 Read device information
 

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -28,6 +28,6 @@ configuration:
     description: "Detailgrad der Protokollierung (Standard: info)"
   devices:
     name: "Geräte"
-    description: "Liste der Energiespeichergeräte, mit denen eine Verbindung hergestellt werden soll. Für jedes Gerät angeben: deviceType (z.B. HMA-1 für B2500 v2, HMB-1 für B2500 v1, HMG-50 für Venus), deviceId (12-stellige MAC-Adresse aus der App, nicht WLAN-MAC)"
+    description: "Liste der Energiespeichergeräte, mit denen eine Verbindung hergestellt werden soll. Für jedes Gerät angeben: deviceType (z.B. HMA-1 für B2500 v2, HMB-1 für B2500 v1, HMG-50 oder VNSE3-0 für Venus), deviceId (12-stellige MAC-Adresse aus der App, nicht WLAN-MAC)"
 network:
   "1890/tcp": "Port für den MQTT Proxy-Server (Standard: 1890)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -28,6 +28,6 @@ configuration:
     description: "Verbosity of application logs (default: info)"
   devices:
     name: Devices
-    description: "List of energy storage devices to connect to. For each device, specify: deviceType (e.g. HMA-1 for B2500 v2, HMB-1 for B2500 v1, HMG-50 for Venus), deviceId (12-character MAC address from app, not WiFi MAC)"
+    description: "List of energy storage devices to connect to. For each device, specify: deviceType (e.g. HMA-1 for B2500 v2, HMB-1 for B2500 v1, HMG-50 or VNSE3-0 for Venus), deviceId (12-character MAC address from app, not WiFi MAC)"
 network:
   1890/tcp: "Port for the MQTT proxy server (default: 1890)"

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -134,7 +134,7 @@ function isVenusRuntimeInfoMessage(values: Record<string, string>): boolean {
 
 registerDeviceDefinition(
   {
-    deviceTypes: ['HMG'],
+    deviceTypes: ['HMG', 'VNSE3'],
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);


### PR DESCRIPTION
## Summary
- register the VNSE3 Venus E 3.0 base type so it reuses the Venus device definition
- document the new device type in the README, Venus docs, and Home Assistant add-on translations
- record the new device support in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d25137c340832eb823b915f611914e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Venus E 3.0 devices (VNSE3-x, e.g., VNSE3-0) alongside existing Venus types.
* **Documentation**
  * Updated README and Venus device guide to document VNSE3-x in addition to HMG-x.
  * Added CHANGELOG entry noting VNSE3-0 support.
* **Chores**
  * Updated English and German translations to include VNSE3-0 as an example Venus device type in configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->