### PR TITLE
fix: defer sensor enablement until device data is received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
+
 ## [Next]
 
+### Fixed
 
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Venus: Fix race condition where local API components were incorrectly disabled on startup. Components with conditional enablement now defer their decision until required device data is available (#189)
 
 ## [1.5.1] - 2025-10-03
 

--- a/src/dataHandler.ts
+++ b/src/dataHandler.ts
@@ -20,18 +20,23 @@ export class DataHandler {
    *
    * @param device - The device configuration
    * @param message - The raw message
+   * @returns Array of message paths that were updated
    */
-  handleDeviceData(device: Device, message: string): void {
+  handleDeviceData(device: Device, message: string): string[] {
     logger.debug(`Received new device data for device ${device.deviceType}:${device.deviceId}`);
     logger.trace(`Raw message: ${message}`);
 
     try {
       const parsedData = parseMessage(message, device.deviceType, device.deviceId);
+      const updatedPaths: string[] = [];
       for (const [path, data] of Object.entries(parsedData)) {
         this.deviceManager.updateDeviceState(device, path, () => data);
+        updatedPaths.push(path);
       }
+      return updatedPaths;
     } catch (error) {
       logger.error(`Error handling device data for ${device.deviceId}:`, error);
+      return [];
     }
   }
 }

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -623,7 +623,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:lan',
         command: 'local-api-enabled',
       }),
-      { enabled: state => (state.deviceVersion ?? 0) >= 153 },
+      { enabled: state => (state.deviceVersion == null ? undefined : state.deviceVersion >= 153) },
     );
 
     field({
@@ -642,7 +642,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         max: 65535,
         step: 1,
       }),
-      { enabled: state => (state.deviceVersion ?? 0) >= 153 },
+      { enabled: state => (state.deviceVersion == null ? undefined : state.deviceVersion >= 153) },
     );
 
     command('local-api-enabled', {

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -102,7 +102,7 @@ export type RegisterCommandDefinitionFn<T extends BaseDeviceData> = (
 export type AdvertiseComponentFn<T extends BaseDeviceData> = <KP extends KeyPath<T> | []>(
   keyPath: KP,
   component: HaStatefulAdvertiseBuilder<KP extends KeyPath<T> ? TypeAtPath<T, KP> : void>,
-  options?: { enabled?: (state: T) => boolean },
+  options?: { enabled?: (state: T) => boolean | undefined },
 ) => void;
 
 export type BuildMessageDefinitionArgs<T extends BaseDeviceData> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,7 +224,9 @@ async function main() {
             }
 
             deviceManager.clearResponseTimeout(device);
-            dataHandler.handleDeviceData(device, message.toString());
+            const updatedPaths = dataHandler.handleDeviceData(device, message.toString());
+            // Re-publish discovery configs for each message path that received data for the first time
+            updatedPaths.forEach(path => mqttClient.onDeviceDataReceived(device, path));
             break;
 
           case 'control':


### PR DESCRIPTION
This fixes a race-condition where we disabled sensors before we received the first device data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed an issue where local API controls could start disabled; availability now updates once required device data is received.
  - Improved behavior when device version is unknown to avoid premature disablement.
  - Discovery configurations are re-published upon first data receipt for a device path to reflect accurate enablement.

- Documentation
  - Updated the changelog with a “Fixed” entry and removed a duplicate header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->