### PR TITLE
Adds required firmware version for Venus 3.0 to readme.md #202

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ The device type can be one of the following:
 - **HMA-X**: (e.g. HMA-1, HMA-2, ...) B2500 storage v2  
 - **HMK-X**: (e.g. HMK-1, HMK-2, ...) Greensolar storage v3
 - **HMG-X**: (e.g. HMG-50) Marstek Venus
-- **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
+- **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0 (requires firmware 139 or later)
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus


### PR DESCRIPTION
Add the minimum required firmware version to the README.md

#202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated firmware requirements for Venus E 3.0 devices (VNSE3-X), now specifying that firmware 139 or later is required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->