### PR TITLE
Add support for Venus A and Venus D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [Next]
 
+- Venus: Add support for Venus device types VNSA and VNSD
 - Fix loop when all configured devices have invalid/unknown device types.
 
 ## [1.5.2] - 2025-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [Next]
 
-- Venus: Add support for Venus device types VNSA and VNSD
+- Venus: Add support for Venus A (VNSA) and Venus D (VNSD) device types
 - Fix loop when all configured devices have invalid/unknown device types.
 
 ## [1.5.2] - 2025-10-03

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ The device type can be one of the following:
 - **HMK-X**: (e.g. HMK-1, HMK-2, ...) Greensolar storage v3
 - **HMG-X**: (e.g. HMG-50) Marstek Venus
 - **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
+- **VNSA-X**: (e.g. VNSA-1) Venus
+- **VNSD-X**: (e.g. VNSD-1) Venus
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus

--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ The device type can be one of the following:
 - **HMK-X**: (e.g. HMK-1, HMK-2, ...) Greensolar storage v3
 - **HMG-X**: (e.g. HMG-50) Marstek Venus
 - **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
-- **VNSA-X**: (e.g. VNSA-1) Venus
-- **VNSD-X**: (e.g. VNSD-1) Venus
+- **VNSA-X**: (e.g. VNSA-1) Venus A
+- **VNSD-X**: (e.g. VNSD-1) Venus D
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -78,7 +78,7 @@ hame_energy/{type}/device/{uid or mac}/ctrl
 ```
 
 The parameters that need to be filled in the command include your device type, device ID or MAC.
-Venus currently has the following types: HMG-x (e.g. HMG-1) and VNSE3-x (e.g. VNSE3-0).
+Venus currently has the following types: HMG-x (e.g. HMG-1), VNSE3-x (e.g. VNSE3-0), VNSA-x (e.g. VNSA-1), and VNSD-x (e.g. VNSD-1).
 
 ## 3 Read device information
 

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -28,6 +28,6 @@ configuration:
     description: "Detailgrad der Protokollierung (Standard: info)"
   devices:
     name: "Geräte"
-    description: "Liste der Energiespeichergeräte, mit denen eine Verbindung hergestellt werden soll. Für jedes Gerät angeben: deviceType (z.B. HMA-1 für B2500 v2, HMB-1 für B2500 v1, HMG-50 oder VNSE3-0 für Venus), deviceId (12-stellige MAC-Adresse aus der App, nicht WLAN-MAC)"
+    description: "Liste der Energiespeichergeräte, mit denen eine Verbindung hergestellt werden soll. Für jedes Gerät angeben: deviceType (z.B. HMA-1 für B2500 v2, HMB-1 für B2500 v1, HMG-50, VNSE3-0, VNSA-1, oder VNSD-1 für Venus), deviceId (12-stellige MAC-Adresse aus der App, nicht WLAN-MAC)"
 network:
   "1890/tcp": "Port für den MQTT Proxy-Server (Standard: 1890)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -28,6 +28,6 @@ configuration:
     description: "Verbosity of application logs (default: info)"
   devices:
     name: Devices
-    description: "List of energy storage devices to connect to. For each device, specify: deviceType (e.g. HMA-1 for B2500 v2, HMB-1 for B2500 v1, HMG-50 or VNSE3-0 for Venus), deviceId (12-character MAC address from app, not WiFi MAC)"
+    description: "List of energy storage devices to connect to. For each device, specify: deviceType (e.g. HMA-1 for B2500 v2, HMB-1 for B2500 v1, HMG-50, VNSE3-0, VNSA-1, or VNSD-1 for Venus), deviceId (12-character MAC address from app, not WiFi MAC)"
 network:
   1890/tcp: "Port for the MQTT proxy server (default: 1890)"

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -134,7 +134,7 @@ function isVenusRuntimeInfoMessage(values: Record<string, string>): boolean {
 
 registerDeviceDefinition(
   {
-    deviceTypes: ['HMG', 'VNSE3'],
+    deviceTypes: ['HMG', 'VNSE3', 'VNSA', 'VNSD'],
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Venus A (VNSA) and Venus D (VNSD) device types, enabling users to configure and manage two additional Venus-based energy storage device models.

* **Documentation**
  * Updated all relevant documentation, README, and user translations (English and German) to include the new Venus device types in device configuration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->