### PR TITLE
Gate surplus feed-in to supported firmware versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## [Next]
 
+- Fix Home Assistant warning when surplus feed-in is unavailable on older HM firmware versions
+
 
 ## [1.5.3] - 2026-01-01
 

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -705,6 +705,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Surplus Feed-in',
         icon: 'mdi:transfer',
         command: 'surplus-feed-in',
+        defaultValue: 'false',
       }),
       { enabled: isSurplusFeedInSupported },
     );

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -152,6 +152,18 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     pollInterval: globalPollInterval,
     controlsDeviceAvailability: true,
   } as const;
+  const isSurplusFeedInSupported = (
+    state: Pick<B2500V2DeviceData, 'deviceType'> & { deviceInfo?: B2500V2DeviceData['deviceInfo'] },
+  ) => {
+    const requiredVersion = state.deviceType === 'HMJ' ? 108 : 226;
+    const deviceVersion = state.deviceInfo?.deviceVersion;
+    if (deviceVersion == null) {
+      return undefined;
+    }
+
+    return deviceVersion >= requiredVersion;
+  };
+
   message<B2500V2DeviceData>(options, ({ field, command, advertise }) => {
     registerBaseMessage({ command, advertise, field });
 
@@ -694,10 +706,18 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:transfer',
         command: 'surplus-feed-in',
       }),
+      { enabled: isSurplusFeedInSupported },
     );
     // Surplus Feed-in command
     command('surplus-feed-in', {
       handler: ({ message, publishCallback, deviceState }) => {
+        const surplusFeedInSupported = isSurplusFeedInSupported(deviceState);
+        if (surplusFeedInSupported === false) {
+          logger.warn(
+            `Surplus feed-in is not supported on ${deviceState.deviceType} version ${deviceState.deviceInfo?.deviceVersion}`,
+          );
+          return;
+        }
         // Accepts 'true'/'1'/'ON' to enable, 'false'/'0'/'OFF' to disable
         const enable = message.toLowerCase() === 'true' || message === '1' || message === 'on';
         const value = enable ? 0 : 1;


### PR DESCRIPTION
## Summary
- add firmware-version checks before advertising surplus feed-in controls on HM devices
- block surplus feed-in commands when firmware versions are below supported thresholds

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c3a0db828832eb2f9968bafa9d64f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device version compatibility checks for surplus feed-in functionality so UI and controls reflect availability.

* **Bug Fixes**
  * Prevented attempts to toggle surplus feed-in on unsupported devices, showing a warning and aborting the action.
  * Ensured the surplus feed-in control has a sensible default state when unavailable.

* **Documentation**
  * Changelog updated with a note about handling surplus feed-in on older firmware.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->