### PR TITLE
Jupiter: Fix incorrect parsing of negative temperatures

### DIFF
--- a/src/device/helpers.test.ts
+++ b/src/device/helpers.test.ts
@@ -1,0 +1,36 @@
+import { transformTemperature } from './helpers';
+
+describe('transformTemperature()', () => {
+  it('should convert positive temperatures correctly', () => {
+    expect(transformTemperature('42')).toBe(42);
+    expect(transformTemperature('0')).toBe(0);
+    expect(transformTemperature('127')).toBe(127);
+  });
+
+  it('should convert negative temperatures correctly', () => {
+    expect(transformTemperature('214')).toBe(-42);
+    expect(transformTemperature('128')).toBe(-128);
+    expect(transformTemperature('255')).toBe(-1);
+  });
+
+  it('should return 0 for invalid number strings', () => {
+    expect(transformTemperature('invalid')).toBe(0);
+    expect(transformTemperature('')).toBe(0);
+    expect(transformTemperature('NaN')).toBe(0);
+  });
+
+  it('should return values outside `uint8` bounds without conversion', () => {
+    expect(transformTemperature('-100')).toBe(-100);
+    expect(transformTemperature('1000')).toBe(1000);
+    expect(transformTemperature('-1')).toBe(-1);
+    expect(transformTemperature('256')).toBe(256);
+  });
+
+  // Although returned temperatures seem to always be integers, the function can
+  // still convert decimals
+  it('should handle decimal values correctly', () => {
+    expect(transformTemperature('25.5')).toBe(25.5);
+    expect(transformTemperature('0.5')).toBe(0.5);
+    expect(transformTemperature('200.75')).toBe(-55.25);
+  });
+});

--- a/src/device/helpers.ts
+++ b/src/device/helpers.ts
@@ -17,3 +17,26 @@ export const transformNumber = (value: string) => {
   const number = parseFloat(value);
   return isNaN(number) ? 0 : number;
 };
+
+/**
+ * Converts the value exposed through MQTT to a temperature. It looks like the
+ * device sends a signed temperature as an unsigned 8-bit integer (`uint8`).
+ * This function converts that value back.
+ *
+ * @param value - The temperature coming from MQTT
+ * @returns The temperature in degrees Celsius
+ */
+export const transformTemperature = (value: string) => {
+  const number = transformNumber(value);
+
+  // Out of `uint8` bounds - return as is
+  if (number < 0 || number > 255) {
+    return number;
+  }
+
+  // Convert uint8 to int8
+  if (number > 127) {
+    return number - 256;
+  }
+  return number;
+};

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -18,6 +18,7 @@ import {
   textComponent,
   numberComponent,
 } from '../homeAssistantDiscovery';
+import { transformTemperature } from './helpers';
 
 /**
  * Command types supported by the Jupiter device (subset of Venus)
@@ -836,7 +837,11 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
       // Cell temperatures (b_temp0-b_temp3)
       for (let i = 0; i < 4; i++) {
         const key = `b_temp${i}`;
-        field({ key, path: ['cells', 'temperatures', i] });
+        field({
+          key,
+          path: ['cells', 'temperatures', i],
+          transform: transformTemperature,
+        });
         advertise(
           ['cells', 'temperatures', i],
           sensorComponent<number>({
@@ -884,6 +889,7 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
             deviceClass: 'temperature',
             unitOfMeasurement: '°C',
             stateClass: 'measurement',
+            // This value seems to never go below 250 (25.0°C)
             transform: (v: string) => parseInt(v) / 10,
           },
         ],
@@ -904,6 +910,7 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
             deviceClass: 'temperature',
             unitOfMeasurement: '°C',
             stateClass: 'measurement',
+            transform: transformTemperature,
           },
         ],
         [
@@ -913,6 +920,7 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
             deviceClass: 'temperature',
             unitOfMeasurement: '°C',
             stateClass: 'measurement',
+            transform: transformTemperature,
           },
         ],
       ] as const;
@@ -943,13 +951,18 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
             deviceClass: 'temperature',
             unitOfMeasurement: '°C',
             stateClass: 'measurement',
+            transform: transformTemperature,
           },
         ],
         ['m_err', { id: 'error' }],
         ['m_war', { id: 'warning' }],
       ] as const;
       for (const [key, info] of mpptFields) {
-        field({ key, path: ['mppt', info.id] });
+        field({
+          key,
+          path: ['mppt', info.id],
+          transform: 'transform' in info ? info.transform : undefined,
+        });
         advertise(
           ['mppt', info.id],
           sensorComponent<number>({


### PR DESCRIPTION
The Jupter devices seem to send a signed temperature as an unsigned 8-bit integer, which causes negative temperatures to be interpreted as large numbers. E.g., `-2` is sent as `254`.

This may also apply to other Marstek devices, however I only have Jupiter C Plus, so I didn't touch the code for the other ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed temperature readings for BMS cell, environmental, and MOSFET temperatures to correctly convert unsigned byte values to signed Celsius.
  * MPPT device temperature readings now display correct signed values.

* **Tests**
  * Added comprehensive test coverage for temperature conversion, including edge cases, invalid inputs, and decimal values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->