### PR TITLE
Limit encrypted Marstek device IDs to HM series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Next]
 
 - Fix Home Assistant warning when surplus feed-in is unavailable on older HM firmware versions
+- Only encrypt Marstek topic device IDs for HMA, HMF, HMK, and HMJ devices (#231)
 - Jupiter: Add Depth of Discharge control (needs firmware 140+). It is a reverse of the battery charge, so setting it to 75% means that the battery will only feed-in power when charged above 25%.
 - Jupiter: Add BMS, MPPT, and inverter version sensors. Change friendly name of _Device Version_ sensor to _EMS Version_, as reported by the Marstek app during firmware upgrade.
 - Jupiter: The firmware reported to Home Assistant is now composed of four values: `<EMS version>.<BMS version>.<MPPT version>.<INV version>`.

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -103,4 +103,24 @@ describe('DeviceManager', () => {
     // getPollingInterval should work since there's at least one valid device
     expect(() => dm.getPollingInterval()).not.toThrow();
   });
+
+  it('should not encrypt new topics for non-HMA/HMF/HMK/HMJ devices', () => {
+    const nonEncryptedConfig: MqttConfig = {
+      brokerUrl: 'mqtt://localhost',
+      clientId: 'test-client',
+      topicPrefix: DEFAULT_TOPIC_PREFIX,
+      devices: [
+        {
+          deviceType: 'HMB-1',
+          deviceId: 'test123',
+        },
+      ],
+    };
+
+    const dm = new DeviceManager(nonEncryptedConfig, mockOnUpdateState);
+    const device = nonEncryptedConfig.devices[0];
+    const topics = dm.getDeviceTopics(device);
+    expect(topics?.deviceTopicNew).toBe('marstek_energy/HMB-1/device/test123/ctrl');
+    expect(topics?.deviceControlTopicNew).toBe('marstek_energy/HMB-1/App/test123/ctrl');
+  });
 });


### PR DESCRIPTION
### Motivation
- The code always used the encrypted variant of the device id for `deviceTopicNew`, but only HMA/HMF/HMK/HMJ devices should use encrypted topic IDs per device firmware differences and issue #231.
- Add a changelog entry documenting the change.

### Description
- Add `encryptedDeviceTypes` set containing `HMA`, `HMF`, `HMK`, and `HMJ` and a helper `shouldEncryptDeviceId(deviceType)` that extracts the base type and checks the set.
- Use `shouldEncryptDeviceId` to conditionally call `calculateNewVersionTopicId(deviceId)` and otherwise reuse the plain `deviceId` when building `deviceTopicNew` and `deviceControlTopicNew` in `DeviceManager`.
- Add a unit test in `src/deviceManager.test.ts` that asserts non-HM devices (example `HMB-1`) keep unencrypted Marstek topics using plain device IDs.
- Update `CHANGELOG.md` with the entry: "Only encrypt Marstek topic device IDs for HMA, HMF, HMK, and HMJ devices (#231)".

### Testing
- Added a unit test in `src/deviceManager.test.ts` to verify that non-HMA/HMF/HMK/HMJ devices do not get encrypted Marstek topics; the test was added but the test suite was not executed in this rollout.
- No automated tests were run as part of this change (no CI/test run executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f8916fc10832e88aa7606a6407b2f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device ID encryption now applies only to HMA, HMF, HMK, and HMJ device types. Other device types use unencrypted topic identifiers.

* **Tests**
  * Added test coverage for topic handling on non-encrypted device types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->