### PR TITLE
ci: build arm64 images on native runners (drop arm/v7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Build natively on each architecture. GitHub now provides arm64 runners,
-          # so we can drop QEMU-based builds (which frequently hang) and also drop
-          # 32-bit ARM (arm/v7).
+          # Build natively on each architecture. GitHub now provides arm64 runners.
           - platform: linux/amd64
             runner: ubuntu-latest
           - platform: linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -234,7 +234,7 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Build natively on each architecture. GitHub now provides arm64 runners.
           - platform: linux/amd64
             runner: ubuntu-latest
           - platform: linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,14 +80,18 @@ jobs:
 
   build:
     needs: [validate, test-addon]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
+          # Build natively on each architecture. GitHub now provides arm64 runners,
+          # so we can drop QEMU-based builds (which frequently hang) and also drop
+          # 32-bit ARM (arm/v7).
           - platform: linux/amd64
+            runner: ubuntu-latest
           - platform: linux/arm64
-          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm64
     permissions:
       contents: read
       packages: write
@@ -95,9 +99,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -225,14 +226,15 @@ jobs:
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   build-addon:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
+            runner: ubuntu-latest
           - platform: linux/arm64
-          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm64
     permissions:
       contents: read
       packages: write
@@ -240,9 +242,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Next]
 
+### Breaking Changes
+
+- Drop 32-bit ARM (linux/arm/v7) image builds. Home Assistant no longer supports 32-bit ARM, and the CI now builds ARM images natively (arm64).
 
 ## [1.6.0] - 2026-01-25
 


### PR DESCRIPTION
GitHub now provides native arm64 runners, so we can stop using QEMU for ARM builds (which often hang) and build amd64 + arm64 images natively. This also drops 32-bit ARM (arm/v7), which aligns with Home Assistant dropping 32-bit ARM support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD infrastructure to use native platform runners for improved build performance on AMD64 and ARM64 architectures.
  * Removed support for ARM v7 architecture builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->