### PR TITLE
fix: time period 5 commands + normalize timer time format (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Drop 32-bit ARM (linux/arm/v7) image builds. Home Assistant no longer supports 32-bit ARM, and the CI now builds ARM images natively (arm64).
 
+### Fixed
+
+- B2500: Fix time period 5 control topics not being processed and normalize time format in timer commands (fixes #244)
+
 ## [1.6.0] - 2026-01-25
 
 - Fix Home Assistant warning when surplus feed-in is unavailable on older HM firmware versions

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -101,8 +101,10 @@ export const timePeriodSettingHandler = (
  * Build time period parameters for all periods
  */
 function formatTimeForB2500V2(time: string): string {
-  // Device seems to prefer H:MM (no leading zero for hours).
-  // Example: "00:30" should be sent as "0:30".
+  // Device seems to prefer H:M (no leading zeros).
+  // Examples:
+  // - "00:30" should be sent as "0:30"
+  // - "08:01" should be sent as "8:1"
   const [hStr, mStr] = time.split(':');
   if (hStr == null || mStr == null) return time;
 

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -110,7 +110,8 @@ function formatTimeForB2500V2(time: string): string {
   const m = parseInt(mStr, 10);
   if (Number.isNaN(h) || Number.isNaN(m)) return time;
 
-  return `${h}:${String(m).padStart(2, '0')}`;
+  // Minutes are also sent without zero-padding (e.g. 08:01 -> 8:1), matching device/app behavior.
+  return `${h}:${m}`;
 }
 
 function buildTimePeriodParams(

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -100,6 +100,19 @@ export const timePeriodSettingHandler = (
 /**
  * Build time period parameters for all periods
  */
+function formatTimeForB2500V2(time: string): string {
+  // Device seems to prefer H:MM (no leading zero for hours).
+  // Example: "00:30" should be sent as "0:30".
+  const [hStr, mStr] = time.split(':');
+  if (hStr == null || mStr == null) return time;
+
+  const h = parseInt(hStr, 10);
+  const m = parseInt(mStr, 10);
+  if (Number.isNaN(h) || Number.isNaN(m)) return time;
+
+  return `${h}:${String(m).padStart(2, '0')}`;
+}
+
 function buildTimePeriodParams(
   timePeriods: NonNullable<B2500V2DeviceData['timePeriods']>,
 ): CommandParams {
@@ -116,8 +129,8 @@ function buildTimePeriodParams(
 
     // Use new settings if available, otherwise use stored settings
     const enabled = period.enabled;
-    const startTime = period.startTime;
-    const endTime = period.endTime;
+    const startTime = formatTimeForB2500V2(period.startTime);
+    const endTime = formatTimeForB2500V2(period.endTime);
     const outputValue = period.outputValue;
 
     // Set parameters dynamically using the period index
@@ -315,10 +328,10 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       );
 
       const timerPeriodCommands = [
-        timePeriodSettingHandler(i, 'enabled'),
-        timePeriodSettingHandler(i, 'start-time'),
-        timePeriodSettingHandler(i, 'end-time'),
-        timePeriodSettingHandler(i, 'output-value'),
+        timePeriodSettingHandler(i + 1, 'enabled'),
+        timePeriodSettingHandler(i + 1, 'start-time'),
+        timePeriodSettingHandler(i + 1, 'end-time'),
+        timePeriodSettingHandler(i + 1, 'output-value'),
       ];
       for (const { command: name, ...commandHandler } of timerPeriodCommands) {
         command(name, commandHandler);

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -545,7 +545,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/enabled',
     input: 'true',
-    expectedOutput: 'cd=7,md=0,a1=1,b1=8:00,e1=20:00,v1=500',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=8:0,e1=20:0,v1=500',
   },
   {
     description: 'B2500V2 time-period/1/enabled false',
@@ -555,7 +555,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/enabled',
     input: 'false',
-    expectedOutput: 'cd=7,md=0,a1=0,b1=8:00,e1=20:00,v1=500',
+    expectedOutput: 'cd=7,md=0,a1=0,b1=8:0,e1=20:0,v1=500',
   },
   {
     description: 'B2500V2 time-period/1/start-time valid',
@@ -565,7 +565,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/start-time',
     input: '06:30',
-    expectedOutput: 'cd=7,md=0,a1=1,b1=6:30,e1=20:00,v1=500',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=6:30,e1=20:0,v1=500',
   },
   {
     description: 'B2500V2 time-period/1/start-time invalid format (letters)',
@@ -595,7 +595,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/end-time',
     input: '22:45',
-    expectedOutput: 'cd=7,md=0,a1=1,b1=8:00,e1=22:45,v1=500',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=8:0,e1=22:45,v1=500',
   },
   {
     description: 'B2500V2 time-period/1/output-value valid',
@@ -605,7 +605,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/output-value',
     input: '750',
-    expectedOutput: 'cd=7,md=0,a1=1,b1=8:00,e1=20:00,v1=750',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=8:0,e1=20:0,v1=750',
   },
   {
     description: 'B2500V2 time-period/1/output-value above max (invalid)',

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -548,6 +548,16 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: 'cd=7,md=0,a1=1,b1=8:0,e1=20:0,v1=500',
   },
   {
+    description: 'B2500V2 time-period/1/end-time should send minutes without zero padding',
+    deviceType: 'HMA-1',
+    initialState: {
+      timePeriods: [{ enabled: true, startTime: '08:00', endTime: '20:00', outputValue: 500 }],
+    },
+    command: 'time-period/1/end-time',
+    input: '08:01',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=8:0,e1=8:1,v1=500',
+  },
+  {
     description: 'B2500V2 time-period/1/enabled false',
     deviceType: 'HMA-1',
     initialState: {

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -545,7 +545,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/enabled',
     input: 'true',
-    expectedOutput: 'cd=7,md=0,a1=1,b1=08:00,e1=20:00,v1=500',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=8:00,e1=20:00,v1=500',
   },
   {
     description: 'B2500V2 time-period/1/enabled false',
@@ -555,7 +555,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/enabled',
     input: 'false',
-    expectedOutput: 'cd=7,md=0,a1=0,b1=08:00,e1=20:00,v1=500',
+    expectedOutput: 'cd=7,md=0,a1=0,b1=8:00,e1=20:00,v1=500',
   },
   {
     description: 'B2500V2 time-period/1/start-time valid',
@@ -565,7 +565,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/start-time',
     input: '06:30',
-    expectedOutput: 'cd=7,md=0,a1=1,b1=06:30,e1=20:00,v1=500',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=6:30,e1=20:00,v1=500',
   },
   {
     description: 'B2500V2 time-period/1/start-time invalid format (letters)',
@@ -595,7 +595,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/end-time',
     input: '22:45',
-    expectedOutput: 'cd=7,md=0,a1=1,b1=08:00,e1=22:45,v1=500',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=8:00,e1=22:45,v1=500',
   },
   {
     description: 'B2500V2 time-period/1/output-value valid',
@@ -605,7 +605,7 @@ const commandTestCases: CommandTestCase[] = [
     },
     command: 'time-period/1/output-value',
     input: '750',
-    expectedOutput: 'cd=7,md=0,a1=1,b1=08:00,e1=20:00,v1=750',
+    expectedOutput: 'cd=7,md=0,a1=1,b1=8:00,e1=20:00,v1=750',
   },
   {
     description: 'B2500V2 time-period/1/output-value above max (invalid)',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -239,7 +239,7 @@ describe('MQTT Client', () => {
     const publishCall = mockClient.publish.mock.calls[0];
     expect(publishCall[0]).toContain('hame_energy/HMA-1/App/testdevice/ctrl');
     expect(publishCall[1]).toContain(
-      'cd=20,md=0,a1=1,b1=0:00,e1=23:59,v1=300,a2=0,b2=0:00,e2=23:59,v2=300,a3=0,b3=0:00,e3=23:59,v3=300,a4=0,b4=0:00,e4=23:59,v4=300,a5=0,b5=0:00,e5=23:59,v5=300',
+      'cd=20,md=0,a1=1,b1=0:0,e1=23:59,v1=300,a2=0,b2=0:0,e2=23:59,v2=300,a3=0,b3=0:0,e3=23:59,v3=300,a4=0,b4=0:0,e4=23:59,v4=300,a5=0,b5=0:0,e5=23:59,v5=300',
     );
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -239,7 +239,7 @@ describe('MQTT Client', () => {
     const publishCall = mockClient.publish.mock.calls[0];
     expect(publishCall[0]).toContain('hame_energy/HMA-1/App/testdevice/ctrl');
     expect(publishCall[1]).toContain(
-      'cd=20,md=0,a1=1,b1=00:00,e1=23:59,v1=300,a2=0,b2=00:00,e2=23:59,v2=300,a3=0,b3=00:00,e3=23:59,v3=300,a4=0,b4=00:00,e4=23:59,v4=300,a5=0,b5=00:00,e5=23:59,v5=300',
+      'cd=20,md=0,a1=1,b1=0:00,e1=23:59,v1=300,a2=0,b2=0:00,e2=23:59,v2=300,a3=0,b3=0:00,e3=23:59,v3=300,a4=0,b4=0:00,e4=23:59,v4=300,a5=0,b5=0:00,e5=23:59,v5=300',
     );
   });
 


### PR DESCRIPTION
Fixes #244.

### What was happening
- HA entities for time periods are advertised as `time-period/1..5/...`
- But the command handlers were registered off-by-one (`timePeriodSettingHandler(i, ...)` with `i` starting at 0)
  - so `time-period/5/...` had **no handler** and nothing was sent to the device

Additionally, logs from #244 show the device expects times like `0:30` (not `00:30`). Sending `00:30` could result in the device applying `00:00`.

### Fix
- Register handlers using `i + 1` so period 5 is handled
- Normalize times when building the cd=7/cd=20 timer payloads to `H:MM` (no leading zero for hours)

### Tests
- Updated existing command payload expectations in tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed time formatting for B2500V2 devices to display hours without leading zeros (e.g., 8:00 instead of 08:00).
  * Corrected timer period command indexing so time-period settings align with device expectations.
* **Tests**
  * Updated tests to expect the new single-segment time format in time-period fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->