### PR TITLE
feat: configurable autodiscovery topic prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Drop 32-bit ARM (linux/arm/v7) image builds. Home Assistant no longer supports 32-bit ARM, and the CI now builds ARM images natively (arm64).
 
+### Added
+
+- Add configurable Home Assistant MQTT discovery topic prefix via `AUTODISCOVERY_TOPIC_PREFIX` (add-on option: `autodiscoveryTopicPrefix`, default: `homeassistant`) (#248)
+
 ### Fixed
 
 - Venus: Treat out-of-range/sentinel `mcp_w` values (e.g. -1) as unknown for the *Maximum Charging Power* entity to avoid Home Assistant log spam (#240)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ services:
 | `MQTT_BROKER_URL` | MQTT broker URL | `mqtt://localhost:1883` |
 | `MQTT_CLIENT_ID` | MQTT client ID | `hm2mqtt-{random}`      |
 | `MQTT_TOPIC_PREFIX` | Base MQTT topic prefix for published data | `hm2mqtt` |
+| `AUTODISCOVERY_TOPIC_PREFIX` | Base MQTT topic prefix for Home Assistant auto discovery topics | `homeassistant` |
 | `MQTT_USERNAME` | MQTT username | -                       |
 | `MQTT_PASSWORD` | MQTT password | -                       |
 | `MQTT_POLLING_INTERVAL` | Interval between device polls in seconds | `60`                 |
@@ -194,6 +195,7 @@ pollingInterval: 60  # Interval between device polls in seconds
 responseTimeout: 30  # Timeout for device responses in seconds
 allowedConsecutiveTimeouts: 3  # Number of consecutive timeouts before a device is marked offline
 topicPrefix: hm2mqtt  # Base MQTT topic prefix for published data
+autodiscoveryTopicPrefix: homeassistant  # Base MQTT topic prefix for HA auto discovery
 devices:
   - deviceType: "HMA-1"
     deviceId: "your-device-mac"
@@ -274,6 +276,7 @@ DEVICE_2=HMB-1:device3mac
 ```yaml
 mqttProxyEnabled: true
 topicPrefix: hm2mqtt
+autodiscoveryTopicPrefix: homeassistant
 devices:
   - deviceType: "HMA-1"
     deviceId: "device1-mac"
@@ -405,6 +408,14 @@ You can control your device by publishing messages to specific MQTT topics. The 
 
 ```
 hm2mqtt/{device_type}/control/{device_mac}/{command}
+```
+
+### Home Assistant Discovery Topics
+
+Home Assistant discovery config is published under this prefix (configurable via `AUTODISCOVERY_TOPIC_PREFIX`):
+
+```
+homeassistant/{component}/{node_id}/{object_id}/config
 ```
 
 ### Common Commands (All Devices)

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -25,6 +25,7 @@ options:
   enableExtraBatteryData: false
   allowedConsecutiveTimeouts: 3
   topicPrefix: hm2mqtt
+  autodiscoveryTopicPrefix: homeassistant
   mqttProxyEnabled: false
   log_level: info
   devices:
@@ -39,6 +40,7 @@ schema:
   enableExtraBatteryData: bool
   allowedConsecutiveTimeouts: int?
   topicPrefix: str?
+  autodiscoveryTopicPrefix: str?
   debug: bool?
   mqttProxyEnabled: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -25,7 +25,6 @@ options:
   enableExtraBatteryData: false
   allowedConsecutiveTimeouts: 3
   topicPrefix: hm2mqtt
-  autodiscoveryTopicPrefix: homeassistant
   mqttProxyEnabled: false
   log_level: info
   devices:

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -13,7 +13,7 @@ start_application() {
 output_env_for_testing() {
     bashio::log.info "Running in test mode, outputting environment variables"
     # Output all environment variables that start with MQTT_ or DEVICE_
-    env | grep -E "^(MQTT_|DEVICE_|POLL_|DEBUG=|LOG_LEVEL=)" | sort
+    env | grep -E "^(MQTT_|AUTODISCOVERY_|DEVICE_|POLL_|DEBUG=|LOG_LEVEL=)" | sort
 }
 
 # Function to manually parse options.json
@@ -114,12 +114,14 @@ export POLL_EXTRA_BATTERY_DATA=$(bashio::config 'enableExtraBatteryData' "false"
 export DEBUG=$(bashio::config 'debug' "false")
 export MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS=$(bashio::config 'allowedConsecutiveTimeouts' "3")
 export MQTT_TOPIC_PREFIX=$(bashio::config 'topicPrefix' "hm2mqtt")
+export AUTODISCOVERY_TOPIC_PREFIX=$(bashio::config 'autodiscoveryTopicPrefix' "homeassistant")
 export MQTT_PROXY_ENABLED=$(bashio::config 'mqttProxyEnabled' "false")
 bashio::log.info "MQTT allowed consecutive timeouts: ${MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS}"
 bashio::log.info "MQTT proxy enabled: ${MQTT_PROXY_ENABLED}"
 bashio::log.info "MQTT polling interval: ${MQTT_POLLING_INTERVAL} seconds"
 bashio::log.info "MQTT response timeout: ${MQTT_RESPONSE_TIMEOUT} seconds"
 bashio::log.info "MQTT topic prefix: ${MQTT_TOPIC_PREFIX}"
+bashio::log.info "MQTT autodiscovery topic prefix: ${AUTODISCOVERY_TOPIC_PREFIX}"
 
 # Process devices using Bashio functions properly
 bashio::log.info "Configuring devices..."

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -20,6 +20,9 @@ configuration:
   topicPrefix:
     name: MQTT-Topic-Präfix
     description: "Basis-MQTT-Präfix für veröffentlichte Daten (Standard: hm2mqtt)"
+  autodiscoveryTopicPrefix:
+    name: MQTT-Auto-Discovery-Topic-Präfix
+    description: "Basis-MQTT-Präfix für Home-Assistant-Auto-Discovery-Topics (Standard: homeassistant)"
   mqttProxyEnabled:
     name: MQTT Proxy aktivieren
     description: "MQTT Proxy-Server aktivieren um B2500 Client-ID-Konflikte zu lösen (Standard: false)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -20,6 +20,9 @@ configuration:
   topicPrefix:
     name: MQTT Topic Prefix
     description: "Base MQTT topic prefix for published data (default: hm2mqtt)"
+  autodiscoveryTopicPrefix:
+    name: MQTT Auto Discovery Topic Prefix
+    description: "Base MQTT topic prefix for Home Assistant auto discovery topics (default: homeassistant)"
   mqttProxyEnabled:
     name: Enable MQTT Proxy
     description: "Enable MQTT proxy server to resolve B2500 client ID conflicts (default: false)"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,3 +3,10 @@
  * messages. This value is used when `MQTT_TOPIC_PREFIX` is not provided.
  */
 export const DEFAULT_TOPIC_PREFIX = 'hm2mqtt';
+
+/**
+ * Default Home Assistant MQTT discovery topic prefix used for publishing
+ * auto-discovery config payloads. This value is used when
+ * `AUTODISCOVERY_TOPIC_PREFIX` is not provided.
+ */
+export const DEFAULT_AUTODISCOVERY_TOPIC_PREFIX = 'homeassistant';

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -36,6 +36,7 @@ describe('ControlHandler', () => {
       brokerUrl: 'mqtt://test.mosquitto.org',
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
+      autodiscoveryTopicPrefix: 'homeassistant',
       devices: [testDeviceV1, testDeviceV2],
       responseTimeout: 15000,
     };

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1155,6 +1155,7 @@ describe('Device Commands', () => {
       brokerUrl: 'mqtt://test.mosquitto.org',
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
+      autodiscoveryTopicPrefix: 'homeassistant',
       devices: [device],
       responseTimeout: 15000,
     };

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -8,6 +8,7 @@ describe('DeviceManager', () => {
     brokerUrl: 'mqtt://localhost',
     clientId: 'test-client',
     topicPrefix: DEFAULT_TOPIC_PREFIX,
+    autodiscoveryTopicPrefix: 'homeassistant',
     devices: [
       {
         deviceType: 'HMA-1',
@@ -59,6 +60,7 @@ describe('DeviceManager', () => {
       brokerUrl: 'mqtt://localhost',
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
+      autodiscoveryTopicPrefix: 'homeassistant',
       devices: [
         {
           deviceType: 'INVALID-TYPE',
@@ -78,6 +80,7 @@ describe('DeviceManager', () => {
       brokerUrl: 'mqtt://localhost',
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
+      autodiscoveryTopicPrefix: 'homeassistant',
       devices: [
         {
           deviceType: 'INVALID-TYPE',
@@ -109,6 +112,7 @@ describe('DeviceManager', () => {
       brokerUrl: 'mqtt://localhost',
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
+      autodiscoveryTopicPrefix: 'homeassistant',
       devices: [
         {
           deviceType: 'HMB-1',

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -33,6 +33,7 @@ describe('Home Assistant Discovery', () => {
       deviceTopics,
       additionalDeviceInfo,
       DEFAULT_TOPIC_PREFIX,
+      'homeassistant',
     );
 
     // Check that we have configs
@@ -127,6 +128,7 @@ describe('Home Assistant Discovery', () => {
       deviceTopics,
       {},
       DEFAULT_TOPIC_PREFIX,
+      'homeassistant',
       supportedState,
     );
 
@@ -141,12 +143,37 @@ describe('Home Assistant Discovery', () => {
       deviceTopics,
       {},
       DEFAULT_TOPIC_PREFIX,
+      'homeassistant',
       unsupportedState,
     );
 
     const surplusSwitchDisabled = unsupportedConfigs.find(c => c.topic.includes('surplus_feed_in'));
     expect(surplusSwitchDisabled).toBeDefined();
     expect(surplusSwitchDisabled?.config).toBeNull();
+  });
+
+  test('should support custom autodiscovery topic prefix', () => {
+    const device: Device = { deviceType: 'HMA-1', deviceId: 'test123' };
+    const deviceTopics: DeviceTopics = {
+      deviceTopicOld: 'hame_energy/HMA-1/device/test123/ctrl',
+      deviceTopicNew: 'marstek_energy/HMA-1/device/test123/ctrl',
+      deviceControlTopicOld: 'hame_energy/HMA-1/App/test123/ctrl',
+      deviceControlTopicNew: 'marstek_energy/HMA-1/App/test123/ctrl',
+      availabilityTopic: 'hame_energy/HMA-1/availability/test123',
+      controlSubscriptionTopic: 'hame_energy/HMA-1/control/test123/control',
+      publishTopic: 'hame_energy/HMA-1/device/test123/data',
+    };
+
+    const configs = generateDiscoveryConfigs(
+      device,
+      deviceTopics,
+      {},
+      DEFAULT_TOPIC_PREFIX,
+      'domoticz',
+    );
+
+    expect(configs.length).toBeGreaterThan(0);
+    expect(configs[0].topic.startsWith('domoticz/')).toBe(true);
   });
 
   test('should mock publishDiscoveryConfigs', () => {
@@ -182,7 +209,15 @@ describe('Home Assistant Discovery', () => {
     const { publishDiscoveryConfigs } = require('./generateDiscoveryConfigs');
 
     // Call the function with the mock client
-    publishDiscoveryConfigs(mockClient, device, deviceTopics, {}, DEFAULT_TOPIC_PREFIX, {});
+    publishDiscoveryConfigs(
+      mockClient,
+      device,
+      deviceTopics,
+      {},
+      DEFAULT_TOPIC_PREFIX,
+      'homeassistant',
+      {},
+    );
 
     // Check that publish was called
     expect(mockClient.publish).toHaveBeenCalled();
@@ -201,6 +236,7 @@ describe('Home Assistant Discovery', () => {
       deviceTopics,
       {},
       DEFAULT_TOPIC_PREFIX,
+      'homeassistant',
       {},
     );
   });

--- a/src/generateDiscoveryConfigs.ts
+++ b/src/generateDiscoveryConfigs.ts
@@ -21,6 +21,7 @@ export function generateDiscoveryConfigs(
   topics: DeviceTopics,
   additionalDeviceInfo: AdditionalDeviceInfo,
   topicPrefix: string,
+  autodiscoveryTopicPrefix: string,
   deviceState: any = {},
 ): Array<{ topic: string; config: HaDiscoveryConfig | null }> {
   const deviceDefinition = getDeviceDefinition(device.deviceType);
@@ -73,7 +74,7 @@ export function generateDiscoveryConfigs(
       });
       const { type: platform, id: _objectId, ...config } = advertisement;
       const objectId = _objectId.replace(/[^a-zA-Z0-9_-]/g, '_');
-      const topic = `homeassistant/${platform}/${nodeId}/${objectId}/config`;
+      const topic = `${autodiscoveryTopicPrefix}/${platform}/${nodeId}/${objectId}/config`;
 
       if (field.enabled) {
         const enabledResult = field.enabled(deviceState);
@@ -110,6 +111,7 @@ export function publishDiscoveryConfigs(
   deviceTopics: DeviceTopics,
   additionalDeviceInfo: AdditionalDeviceInfo,
   topicPrefix: string,
+  autodiscoveryTopicPrefix: string,
   deviceState: any = {},
 ): void {
   const configs = generateDiscoveryConfigs(
@@ -117,6 +119,7 @@ export function publishDiscoveryConfigs(
     deviceTopics,
     additionalDeviceInfo,
     topicPrefix,
+    autodiscoveryTopicPrefix,
     deviceState,
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 import { Device, MqttConfig } from './types';
-import { DEFAULT_TOPIC_PREFIX } from './constants';
+import { DEFAULT_AUTODISCOVERY_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX } from './constants';
 import { DeviceManager, DeviceStateData } from './deviceManager';
 import { MqttClient } from './mqttClient';
 import { ControlHandler } from './controlHandler';
@@ -111,6 +111,8 @@ function createMqttConfig(devices: Device[]): MqttConfig {
     username: process.env.MQTT_USERNAME || undefined,
     password: process.env.MQTT_PASSWORD || undefined,
     topicPrefix: process.env.MQTT_TOPIC_PREFIX || DEFAULT_TOPIC_PREFIX,
+    autodiscoveryTopicPrefix:
+      process.env.AUTODISCOVERY_TOPIC_PREFIX || DEFAULT_AUTODISCOVERY_TOPIC_PREFIX,
     devices,
     responseTimeout: parseInt(process.env.MQTT_RESPONSE_TIMEOUT || '15', 10) * 1000,
     allowedConsecutiveTimeouts: parseInt(process.env.MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS || '3', 10),

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -56,6 +56,7 @@ describe('MqttClient discovery re-publish', () => {
       brokerUrl: 'mqtt://localhost:1883',
       clientId: 'test-client',
       topicPrefix: 'homeassistant',
+      autodiscoveryTopicPrefix: 'homeassistant',
     };
 
     const mqttClient = new MqttClient(config, deviceManager, jest.fn());
@@ -77,6 +78,7 @@ describe('MqttClient discovery re-publish', () => {
       device,
       topics,
       expect.objectContaining({ firmwareVersion: '116.6' }),
+      'homeassistant',
       'homeassistant',
       expect.objectContaining({ fw: '116.6' }),
     );

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -229,6 +229,7 @@ export class MqttClient {
         topics,
         additionalDeviceInfo,
         this.config.topicPrefix,
+        this.config.autodiscoveryTopicPrefix,
         deviceState,
       );
       this.lastDiscoveryInfoSignatureByDevice.set(

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,6 +228,11 @@ export interface MqttConfig {
    * specific topics (default: 'hm2mqtt')
    */
   topicPrefix: string;
+  /**
+   * Base MQTT topic prefix used for Home Assistant auto discovery
+   * (default: 'homeassistant')
+   */
+  autodiscoveryTopicPrefix: string;
   useFlashCommands?: boolean;
   responseTimeout?: number; // Timeout for device responses in milliseconds
   /**


### PR DESCRIPTION
## Summary
- add configurable autodiscovery topic prefix via `AUTODISCOVERY_TOPIC_PREFIX` (default: `homeassistant`)
- use the configured prefix when generating MQTT discovery config topics
- extend Home Assistant add-on config with `autodiscoveryTopicPrefix`
- document the new setting in README and add test coverage

Closes #248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Home Assistant autodiscovery topic prefix (option + env var; default "homeassistant") and automatic re-publishing of discovery when device info changes.

* **Documentation**
  * Updated README, examples and changelog to document the new autodiscoveryTopicPrefix; added English and German translations.

* **Tests**
  * Added and updated tests to cover custom autodiscovery prefixes and discovery re-publish behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->