### PR TITLE
docs: add AGENTS.md with contributor-agent guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,13 +45,13 @@ When adding/changing configuration options (env vars or add-on options), update 
 6. Translations (`ha_addon/translations/en.yaml`, `ha_addon/translations/de.yaml`)
 7. `CHANGELOG.md` under `[Next]`
 
-## Lessons Learned (from recent misses)
+## Configuration Change Quality Gate
 
-Do **not** forget these when introducing new config options:
+For every new or changed config option, treat the following as mandatory completion criteria:
 
-- Add-on translations (`en.yaml` + `de.yaml`)
-- Changelog entry under `[Next]`
-- All TypeScript test fixtures that construct `MqttConfig`
+- Add-on translations (`ha_addon/translations/en.yaml` and `ha_addon/translations/de.yaml`)
+- Changelog entry under `[Next]` in `CHANGELOG.md`
+- Updates to all TypeScript test fixtures that construct `MqttConfig`
 
 ## Coding & Change Style
 


### PR DESCRIPTION
## Summary
Add a root `AGENTS.md` with practical instructions for coding agents working on this repo.

## Included guidance
- PRs must target `develop`
- validation checks to run before opening a PR (`npm test -- --runInBand`, `npm run build`)
- config-change consistency checklist (runtime, add-on config/run script, tests, docs, translations, changelog)
- explicit reminders for recent misses (translations + changelog + `MqttConfig` fixtures)
- PR quality expectations and basic safety rules

## Context
Created in response to request for a canonical agent instruction file with repo-specific guardrails.
