### PR TITLE
fix: republish discovery when firmware becomes known after startup timeout

### DIFF
--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -69,5 +69,16 @@ describe('MqttClient discovery re-publish', () => {
 
     // We expect discovery to be re-published again so newly enabled entities appear
     expect(publishDiscoveryConfigs).toHaveBeenCalledTimes(2);
+
+    // Verify the second publish carries firmware info
+    expect(publishDiscoveryConfigs).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      device,
+      topics,
+      expect.objectContaining({ firmwareVersion: '116.6' }),
+      'homeassistant',
+      expect.objectContaining({ fw: '116.6' }),
+    );
   });
 });

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -1,0 +1,73 @@
+import { MqttClient } from './mqttClient';
+import { Device } from './types';
+
+jest.mock('mqtt', () => {
+  const mockClient = {
+    on: jest.fn(),
+    publish: jest.fn(),
+    subscribe: jest.fn(),
+    end: jest.fn(),
+  };
+
+  return {
+    connect: jest.fn(() => mockClient),
+  };
+});
+
+jest.mock('./generateDiscoveryConfigs', () => ({
+  publishDiscoveryConfigs: jest.fn(),
+}));
+
+jest.mock('./deviceDefinition', () => ({
+  getDeviceDefinition: jest.fn(() => ({
+    messages: [
+      {
+        getAdditionalDeviceInfo: (state: any) => ({
+          firmwareVersion: state?.fw,
+        }),
+      },
+    ],
+  })),
+}));
+
+describe('MqttClient discovery re-publish', () => {
+  test('re-publishes discovery when additional device info changes after first data on same path (regression #235)', () => {
+    const { publishDiscoveryConfigs } = require('./generateDiscoveryConfigs');
+
+    const device: Device = { deviceType: 'HMJ-2', deviceId: 'abc123' };
+    const topics = {
+      deviceTopicOld: 'hame_energy/HMJ-2/device/abc123/ctrl',
+      deviceTopicNew: 'marstek_energy/HMJ-2/device/abc123/ctrl',
+      publishTopic: 'homeassistant/HMJ-2/device/abc123/data',
+      deviceControlTopicOld: 'hame_energy/HMJ-2/App/abc123/ctrl',
+      deviceControlTopicNew: 'marstek_energy/HMJ-2/App/abc123/ctrl',
+      controlSubscriptionTopic: 'homeassistant/HMJ-2/control/abc123/control',
+      availabilityTopic: 'homeassistant/HMJ-2/availability/abc123',
+    };
+
+    let currentState: any = { fw: undefined };
+    const deviceManager: any = {
+      getDeviceTopics: jest.fn(() => topics),
+      getDeviceState: jest.fn(() => currentState),
+      getDevices: jest.fn(() => []),
+    };
+
+    const config: any = {
+      brokerUrl: 'mqtt://localhost:1883',
+      clientId: 'test-client',
+      topicPrefix: 'homeassistant',
+    };
+
+    const mqttClient = new MqttClient(config, deviceManager, jest.fn());
+
+    // First successful data for this path, but firmware is still unknown
+    mqttClient.onDeviceDataReceived(device, 'data');
+
+    // Later on the same path, firmware info becomes available
+    currentState = { fw: '116.6' };
+    mqttClient.onDeviceDataReceived(device, 'data');
+
+    // We expect discovery to be re-published again so newly enabled entities appear
+    expect(publishDiscoveryConfigs).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -12,6 +12,7 @@ export class MqttClient {
   private timeoutCounters: Map<string, number> = new Map();
   private allowedConsecutiveTimeouts: number;
   private devicePathsWithData: Set<string> = new Set();
+  private lastDiscoveryInfoSignatureByDevice: Map<string, string> = new Map();
 
   constructor(
     private config: MqttConfig,
@@ -93,6 +94,10 @@ export class MqttClient {
     this.setupPeriodicPolling();
   }
 
+  private getDeviceKey(device: Device): string {
+    return `${device.deviceType}:${device.deviceId}`;
+  }
+
   private getAdditionalDeviceInfo(device: Device) {
     const deviceDefinitions = getDeviceDefinition(device.deviceType);
     const deviceState = this.deviceManager.getDeviceState(device);
@@ -106,6 +111,10 @@ export class MqttClient {
       }
     }
     return additionalDeviceInfo;
+  }
+
+  private getDiscoveryInfoSignature(device: Device): string {
+    return JSON.stringify(this.getAdditionalDeviceInfo(device));
   }
 
   /**
@@ -218,6 +227,10 @@ export class MqttClient {
         this.config.topicPrefix,
         deviceState,
       );
+      this.lastDiscoveryInfoSignatureByDevice.set(
+        this.getDeviceKey(device),
+        JSON.stringify(additionalDeviceInfo),
+      );
     }
   }
 
@@ -230,6 +243,9 @@ export class MqttClient {
    */
   onDeviceDataReceived(device: Device, publishPath: string): void {
     const devicePathKey = `${device.deviceType}:${device.deviceId}:${publishPath}`;
+    const deviceKey = this.getDeviceKey(device);
+    const previousSignature = this.lastDiscoveryInfoSignatureByDevice.get(deviceKey);
+    const currentSignature = this.getDiscoveryInfoSignature(device);
 
     // If this is the first time we're receiving data for this device+path,
     // re-publish discovery configs now that we have device state
@@ -238,6 +254,16 @@ export class MqttClient {
         `First data received for ${device.deviceType}:${device.deviceId} on path ${publishPath}, re-publishing discovery configs`,
       );
       this.devicePathsWithData.add(devicePathKey);
+      this.publishDiscoveryConfigs(device);
+      return;
+    }
+
+    // Re-publish discovery when additional device info changed (e.g. firmware version
+    // becomes known after an initial timeout), so gated entities get (re-)announced.
+    if (previousSignature !== currentSignature) {
+      logger.debug(
+        `Discovery-relevant info changed for ${device.deviceType}:${device.deviceId}, re-publishing discovery configs`,
+      );
       this.publishDiscoveryConfigs(device);
     }
   }

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -113,8 +113,12 @@ export class MqttClient {
     return additionalDeviceInfo;
   }
 
+  private getDiscoveryInfoSignatureFromInfo(additionalDeviceInfo: AdditionalDeviceInfo): string {
+    return JSON.stringify(additionalDeviceInfo);
+  }
+
   private getDiscoveryInfoSignature(device: Device): string {
-    return JSON.stringify(this.getAdditionalDeviceInfo(device));
+    return this.getDiscoveryInfoSignatureFromInfo(this.getAdditionalDeviceInfo(device));
   }
 
   /**
@@ -229,7 +233,7 @@ export class MqttClient {
       );
       this.lastDiscoveryInfoSignatureByDevice.set(
         this.getDeviceKey(device),
-        JSON.stringify(additionalDeviceInfo),
+        this.getDiscoveryInfoSignatureFromInfo(additionalDeviceInfo),
       );
     }
   }


### PR DESCRIPTION
## Summary
- Add a regression test for #235 that reproduces this sequence:
  1. first successful data on a path arrives **without** firmware info,
  2. later data on the **same path** includes firmware info.
- Update `MqttClient.onDeviceDataReceived` to re-publish Home Assistant discovery not only on first data per path, but also when discovery-relevant device info changes.
- Track the last published discovery-info signature per device to avoid unnecessary re-publishes.

## Why
At startup, devices may time out on the first poll. Discovery can be published before firmware is known, so firmware-gated entities (like `surplus_feed_in`) are omitted. If firmware becomes known on a later message for the same path, discovery must be published again so Home Assistant can discover those entities.

## Testing
- `npm test -- --runTestsByPath src/mqttClient.test.ts`
- `npm test -- --runTestsByPath src/generateDiscoveryConfigs.test.ts src/mqttClient.test.ts`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MQTT discovery configurations now automatically re-publish when additional device information becomes available after the initial discovery announcement, ensuring downstream systems receive complete and up-to-date device metadata for proper configuration, integration, and initialization.

* **Tests**
  * Added comprehensive test coverage for the discovery re-publishing functionality, verifying correct behavior when device information updates occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->