### PR TITLE
docs: add step-by-step setup guide for local MQTT and relay mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ hm2mqtt is a bridge application that connects Hame energy storage devices (like 
 
 ## Step-by-step setup
 
-Choose one of the following variants.
+Choose one of the following variants. Install hm2mqtt using your preferred method from the [Installation](#installation) section, then apply the matching setup flow below.
 
 ### Variant A: B2500 configured for local MQTT
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 **When to use:** Choose this if you want direct local MQTT communication from B2500 to your broker (for local-first integrations), and you accept that direct cloud connectivity is disabled unless you add hame-relay Mode 1.
 
 ```mermaid
-flowchart LR
+flowchart TB
     B2500[B2500 device] <-->|MQTT telemetry + commands| Broker[Local MQTT broker]
+
     Broker -->|device telemetry / responses| HM2MQTT[hm2mqtt]
     HM2MQTT -->|parsed state + HA discovery + command topics| Broker
     HA[Home Assistant] <-->|MQTT integration| Broker
+
     Broker -->|local telemetry from device| Relay[hame relay Mode 1 optional]
     Relay -->|commands forwarded from cloud/app| Broker
     Cloud[Marstek Cloud] -->|app/cloud commands + control| Relay
@@ -78,12 +80,15 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
 **When to use:** Choose this if your device remains cloud-configured, or if you want to keep the standard cloud setup and bridge data into your local broker via hame-relay.
 
 ```mermaid
-flowchart LR
+flowchart TB
     Device[Marstek device in cloud mode] <-->|device MQTT| CloudMQTT[Marstek Cloud MQTT]
+
     CloudMQTT -->|cloud telemetry + command state| Relay[hame relay]
     Relay -->|mirrored local status/telemetry| CloudMQTT
+
     Broker[Local MQTT broker] -->|local commands + local state topics| Relay
     Relay -->|commands forwarded from cloud/app| Broker
+
     Broker -->|device telemetry / responses| HM2MQTT[hm2mqtt]
     HM2MQTT -->|parsed state + HA discovery + command topics| Broker
     HA[Home Assistant] <-->|MQTT integration| Broker

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Use this when your B2500 should send data directly to your local MQTT broker.
 
 Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/CT002), or for B2500 when you do not switch it to local MQTT.
 
-For B2500 in this variant, configure hame-relay with inverse forwarding for the specific device ID (see hame-relay docs, `inverse_forwarding_device_ids`).
+For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
 
 1. **Install and configure hame-relay**
    - Follow the hame-relay README: https://github.com/tomquist/hame-relay

--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
 
 **When to use:** Choose this if your device remains cloud-configured, or if you want to keep the standard cloud setup and bridge data into your local broker via hame-relay.
 
-For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
-
 1. **Install and configure hame-relay**
    - Follow the hame-relay README: https://github.com/tomquist/hame-relay
    - Enter your account credentials in hame-relay config.
+
+For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
+
 2. **Use a separate Marstek account (recommended)**
    - Share your devices to that account.
    - Use that account in hame-relay.

--- a/README.md
+++ b/README.md
@@ -21,18 +21,55 @@ hm2mqtt is a bridge application that connects Hame energy storage devices (like 
 
 ## Prerequisites
 
-- Before you start, you need a local MQTT broker. You can install one as a Home Assistant App in Home Assistant's Apps (formerly known as add-ons): https://www.home-assistant.io/integrations/mqtt/#setting-up-a-broker
-- After setting up an MQTT broker, configure your energy storage device to send MQTT data to your MQTT broker:
-  1. For the **B2500**, you have two options:
-  
-     > **⚠️ Important for Multiple B2500 Devices**: If you plan to use multiple B2500 devices with firmware 226.5 or 108.7, configure them to connect to the MQTT proxy port (default: 1890) instead of your main MQTT broker. See the [MQTT Proxy Configuration](#mqtt-proxy-for-b2500-client-id-conflicts) section for details.
-     1. Contact the support and ask them to enable MQTT for your device, then configure the MQTT broker in the device settings through the PowerZero or Marstek app.
-     2. With an Android smartphone or a Bluetooth‑enabled PC, use [this tool](https://tomquist.github.io/hame-relay/b2500.html) to configure the MQTT broker directly via Bluetooth. **Make sure you write down the MAC address that is displayed in this tool or in the Marstek app! You will need it later on and the WIFI MAC address of the battery is the wrong one.**
-   
-     **Warning:** Enabling MQTT on the device will disable the cloud connection. You will not be able to use the PowerZero or Marstek app to monitor or control your device anymore. You can re-enable the cloud connection by installing [Hame Relay](https://github.com/tomquist/hame-relay#mode-1-storage-configured-with-local-broker-inverse_forwarding-false) in Mode 1.
-  2. The **Marstek Venus**, **Marstek Jupiter** and **Jupiter Plus** don't officially support MQTT. However, you can install the [Hame Relay](https://github.com/tomquist/hame-relay) in [Mode 2](https://github.com/tomquist/hame-relay#mode-2-storage-configured-with-hame-broker-inverse_forwarding-true) to forward the Cloud MQTT data to your local MQTT broker.
-  3. The **Marstek MI800 Micro Inverter** requires the same setup as Venus/Jupiter devices. Use [Hame Relay](https://github.com/tomquist/hame-relay) in [Mode 2](https://github.com/tomquist/hame-relay#mode-2-storage-configured-with-hame-broker-inverse_forwarding-true) to forward the Cloud MQTT data to your local MQTT broker.
-  
+- A local MQTT broker (for example the Home Assistant Mosquitto broker): https://www.home-assistant.io/integrations/mqtt/#setting-up-a-broker
+- Access to your device details (device type + Bluetooth MAC address)
+
+## Step-by-step setup
+
+Choose one of the following variants.
+
+### Variant A: B2500 configured for local MQTT
+
+Use this when your B2500 should send data directly to your local MQTT broker.
+
+> **⚠️ Important for multiple B2500 devices:** If you use multiple B2500 units (especially firmware 226.5/108.7), configure them to use the hm2mqtt MQTT proxy port (default `1890`) instead of your main broker port. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts).
+
+1. **Enable and configure MQTT on the B2500**
+   - Option 1: Contact support and ask them to enable MQTT in the app.
+   - Option 2: Use the Bluetooth configuration tool in Chrome: https://tomquist.github.io/hame-relay/b2500.html
+2. **Point the B2500 to your local broker**
+   - Configure host/port (or proxy port `1890` if needed for multiple devices).
+3. **Note the correct device ID**
+   - Use the MAC shown in the Bluetooth tool (or app device list).
+   - This is the value used by hm2mqtt (`deviceId` / `DEVICE_n`).
+   - Do **not** use the Wi-Fi MAC.
+4. **Configure hm2mqtt**
+   - Add your MQTT broker settings.
+   - Add the device in format `{deviceType}:{bluetoothMac}` (for example `HMA-1:001a2b3c4d5e`).
+5. **Start hm2mqtt**
+   - After startup, Home Assistant should discover the new device via MQTT Discovery.
+
+### Variant B: Other Marstek devices (and B2500 without local MQTT)
+
+Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/CT002), or for B2500 when you do not switch it to local MQTT.
+
+1. **Install and configure hame-relay**
+   - Follow the hame-relay README: https://github.com/tomquist/hame-relay
+   - Enter your account credentials in hame-relay config.
+2. **Use a separate Marstek account (recommended)**
+   - Share your devices to that account.
+   - Use that account in hame-relay.
+   - This avoids logging your primary app account out of the mobile app session.
+3. **Start hame-relay and check startup output**
+   - hame-relay loads your account device list on startup.
+   - From the startup logs/output, note:
+     - `deviceType`
+     - Bluetooth MAC address (used as hm2mqtt `deviceId`)
+4. **Configure hm2mqtt**
+   - Add device entries using `{deviceType}:{bluetoothMac}` from hame-relay output.
+5. **Start hm2mqtt**
+   - Home Assistant should discover the devices once data is available on your local broker.
+
 ## Installation
 
 ### As a Home Assistant App (Recommended)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use this when your B2500 should send data directly to your local MQTT broker.
 
 1. **Enable and configure MQTT on the B2500**
    - Option 1: Contact support and ask them to enable MQTT in the app.
-   - Option 2: Use the Bluetooth configuration tool in Chrome: https://tomquist.github.io/hame-relay/b2500.html
+   - Option 2: Use the Bluetooth configuration tool in Chrome: https://tomquist.github.io/hmjs/
 2. **Point the B2500 to your local broker**
    - Configure host/port (or proxy port `1890` if needed for multiple devices).
 3. **Note the correct device ID**
@@ -372,7 +372,7 @@ This message is almost always a **symptom**, not the root cause. It usually mean
 
 #### Troubleshooting: B2500
 1. **Verify the B2500 is actually configured for local MQTT**
-   - Use the configuration tool: <https://tomquist.github.io/hame-relay/b2500.html>
+   - Use the configuration tool: <https://tomquist.github.io/hmjs/>
    - Double-check host/port and the SSL toggle.
 2. If you have **multiple B2500s**, ensure you handled client-ID conflicts
    - Either configure **unique MQTT usernames** per storage, or
@@ -389,7 +389,7 @@ This message is almost always a **symptom**, not the root cause. It usually mean
 In hm2mqtt, `deviceId` must be the **Bluetooth MAC** of the device (12 hex chars, lowercase, no `:`).
 
 **Where to find it:**
-- **B2500:** via <https://tomquist.github.io/hame-relay/b2500.html>
+- **B2500:** via <https://tomquist.github.io/hmjs/>
 - **All devices via hame-relay:** check the **hame-relay logs** (they include the mapping).
 
 **Troubleshooting (quick):**

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Choose one of the following variants.
 
 ### Variant A: B2500 configured for local MQTT
 
-Use this when your B2500 should send data directly to your local MQTT broker.
+Use this **only** for B2500 devices when your B2500 should send data directly to your local MQTT broker. If you have any other Marstek device type, follow **Variant B** instead.
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup).
 >

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 
 ```mermaid
 flowchart LR
-    A[B2500] -->|MQTT| B[Local MQTT Broker]
+    A[B2500] -->|MQTT telemetry/commands| B[Local MQTT Broker]
     B --> C[hm2mqtt]
     C --> D[Home Assistant]
-    A -. cloud disabled by local MQTT .-> E[Marstek Cloud/App]
-    F[hame relay Mode 1 optional] -. restores app and cloud access .-> E
+    F[hame relay Mode 1 optional] --> B
+    F -. restore cloud/app access .-> E[Marstek Cloud/App]
 ```
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
@@ -79,7 +79,7 @@ flowchart LR
     A[Marstek Device
 (Venus/Jupiter/etc.
 or B2500 in cloud mode)] --> B[Marstek Cloud MQTT]
-    B --> C[hame-relay]
+    B <--> C[hame relay]
     C --> D[Local MQTT Broker]
     D --> E[hm2mqtt]
     E --> F[Home Assistant]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ flowchart LR
     B --> C[hm2mqtt]
     C --> D[Home Assistant]
     A -. cloud disabled by local MQTT .-> E[Marstek Cloud/App]
-    F[hame-relay Mode 1 (optional)] -. restores app/cloud access .-> E
+    F[hame relay Mode 1 optional] -. restores app and cloud access .-> E
 ```
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 
 **When to use:** Choose this if you want direct local MQTT communication from B2500 to your broker (for local-first integrations), and you accept that direct cloud connectivity is disabled unless you add hame-relay Mode 1.
 
+```mermaid
+flowchart LR
+    A[B2500] -->|MQTT| B[Local MQTT Broker]
+    B --> C[hm2mqtt]
+    C --> D[Home Assistant]
+    A -. cloud disabled by local MQTT .-> E[Marstek Cloud/App]
+    F[hame-relay Mode 1 (optional)] -. restores app/cloud access .-> E
+```
+
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
 >
 > **⚠️ Important for multiple B2500 devices:** For firmware `226.5` / `108.7`, use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts) for details.
@@ -64,6 +73,17 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/CT002), or for B2500 when you do not switch it to local MQTT.
 
 **When to use:** Choose this if your device remains cloud-configured, or if you want to keep the standard cloud setup and bridge data into your local broker via hame-relay.
+
+```mermaid
+flowchart LR
+    A[Marstek Device
+(Venus/Jupiter/etc.
+or B2500 in cloud mode)] --> B[Marstek Cloud MQTT]
+    B --> C[hame-relay]
+    C --> D[Local MQTT Broker]
+    D --> E[hm2mqtt]
+    E --> F[Home Assistant]
+```
 
 1. **Install and configure hame-relay**
    - Follow the hame-relay README: https://github.com/tomquist/hame-relay

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
    - Follow the hame-relay README: https://github.com/tomquist/hame-relay
    - Enter your account credentials in hame-relay config.
 
-For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
+- For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
 
 2. **Use a separate Marstek account (recommended)**
    - Share your devices to that account.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 ```mermaid
 flowchart LR
     B2500[B2500 device] <-->|MQTT telemetry + commands| Broker[Local MQTT broker]
-    HM2MQTT[hm2mqtt] <-->|subscribe/publish| Broker
+    Broker -->|device telemetry / responses| HM2MQTT[hm2mqtt]
+    HM2MQTT -->|parsed state + HA discovery + command topics| Broker
     HA[Home Assistant] <-->|MQTT integration| Broker
     Relay[hame relay Mode 1 optional] <-->|bridge local topics| Broker
     Relay <-->|bridge to cloud| Cloud[Marstek Cloud]
@@ -79,7 +80,8 @@ flowchart LR
     Device[Marstek device in cloud mode] <-->|device MQTT| CloudMQTT[Marstek Cloud MQTT]
     Relay[hame relay] <-->|cloud-side bridge| CloudMQTT
     Relay <-->|local-side bridge| Broker[Local MQTT broker]
-    HM2MQTT[hm2mqtt] <-->|subscribe/publish| Broker
+    Broker -->|device telemetry / responses| HM2MQTT[hm2mqtt]
+    HM2MQTT -->|parsed state + HA discovery + command topics| Broker
     HA[Home Assistant] <-->|MQTT integration| Broker
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ flowchart LR
     Broker -->|device telemetry / responses| HM2MQTT[hm2mqtt]
     HM2MQTT -->|parsed state + HA discovery + command topics| Broker
     HA[Home Assistant] <-->|MQTT integration| Broker
-    Broker -->|local MQTT traffic| Relay[hame relay Mode 1 optional]
-    Relay -->|local MQTT traffic| Broker
-    Cloud[Marstek Cloud] -->|cloud MQTT traffic| Relay
-    Relay -->|cloud MQTT traffic| Cloud
+    Broker -->|local telemetry from device| Relay[hame relay Mode 1 optional]
+    Relay -->|commands forwarded from cloud/app| Broker
+    Cloud[Marstek Cloud] -->|app/cloud commands + control| Relay
+    Relay -->|mirrored local status/telemetry| Cloud
 ```
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
@@ -80,10 +80,10 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
 ```mermaid
 flowchart LR
     Device[Marstek device in cloud mode] <-->|device MQTT| CloudMQTT[Marstek Cloud MQTT]
-    CloudMQTT -->|cloud MQTT traffic| Relay[hame relay]
-    Relay -->|cloud MQTT traffic| CloudMQTT
-    Broker[Local MQTT broker] -->|local MQTT traffic| Relay
-    Relay -->|local MQTT traffic| Broker
+    CloudMQTT -->|cloud telemetry + command state| Relay[hame relay]
+    Relay -->|mirrored local status/telemetry| CloudMQTT
+    Broker[Local MQTT broker] -->|local commands + local state topics| Relay
+    Relay -->|commands forwarded from cloud/app| Broker
     Broker -->|device telemetry / responses| HM2MQTT[hm2mqtt]
     HM2MQTT -->|parsed state + HA discovery + command topics| Broker
     HA[Home Assistant] <-->|MQTT integration| Broker

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 
 ```mermaid
 flowchart LR
-    A[B2500] -->|MQTT telemetry/commands| B[Local MQTT Broker]
-    B --> C[hm2mqtt]
-    C --> D[Home Assistant]
-    F[hame relay Mode 1 optional] --> B
-    F -. restore cloud/app access .-> E[Marstek Cloud/App]
+    B2500[B2500 device] <--> Broker[Local MQTT broker]
+    HM2MQTT[hm2mqtt] <--> Broker
+    HA[Home Assistant] <--> Broker
+    Relay[hame relay Mode 1 optional] <--> Broker
+    Relay <--> Cloud[Marstek Cloud]
 ```
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
@@ -76,13 +76,11 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
 
 ```mermaid
 flowchart LR
-    A[Marstek Device
-(Venus/Jupiter/etc.
-or B2500 in cloud mode)] --> B[Marstek Cloud MQTT]
-    B <--> C[hame relay]
-    C --> D[Local MQTT Broker]
-    D --> E[hm2mqtt]
-    E --> F[Home Assistant]
+    Device[Marstek device in cloud mode] <--> CloudMQTT[Marstek Cloud MQTT]
+    Relay[hame relay] <--> CloudMQTT
+    Relay <--> Broker[Local MQTT broker]
+    HM2MQTT[hm2mqtt] <--> Broker
+    HA[Home Assistant] <--> Broker
 ```
 
 1. **Install and configure hame-relay**

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 
 ```mermaid
 flowchart LR
-    B2500[B2500 device] <--> Broker[Local MQTT broker]
-    HM2MQTT[hm2mqtt] <--> Broker
-    HA[Home Assistant] <--> Broker
-    Relay[hame relay Mode 1 optional] <--> Broker
-    Relay <--> Cloud[Marstek Cloud]
+    B2500[B2500 device] <-->|MQTT telemetry + commands| Broker[Local MQTT broker]
+    HM2MQTT[hm2mqtt] <-->|subscribe/publish| Broker
+    HA[Home Assistant] <-->|MQTT integration| Broker
+    Relay[hame relay Mode 1 optional] <-->|bridge local topics| Broker
+    Relay <-->|bridge to cloud| Cloud[Marstek Cloud]
 ```
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
@@ -76,11 +76,11 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
 
 ```mermaid
 flowchart LR
-    Device[Marstek device in cloud mode] <--> CloudMQTT[Marstek Cloud MQTT]
-    Relay[hame relay] <--> CloudMQTT
-    Relay <--> Broker[Local MQTT broker]
-    HM2MQTT[hm2mqtt] <--> Broker
-    HA[Home Assistant] <--> Broker
+    Device[Marstek device in cloud mode] <-->|device MQTT| CloudMQTT[Marstek Cloud MQTT]
+    Relay[hame relay] <-->|cloud-side bridge| CloudMQTT
+    Relay <-->|local-side bridge| Broker[Local MQTT broker]
+    HM2MQTT[hm2mqtt] <-->|subscribe/publish| Broker
+    HA[Home Assistant] <-->|MQTT integration| Broker
 ```
 
 1. **Install and configure hame-relay**

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flowchart TB
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
 >
-> **⚠️ Important for multiple B2500 devices:** For firmware `226.5` / `108.7`, use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts) for details.
+> **⚠️ Important for multiple B2500 devices:** For firmware `226.5` / `108.7`, you **must** use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Firmware 226.5/108.7 Client ID Conflict](#mqtt-proxy-for-b2500-firmware-22651087-client-id-conflict) for details.
 
 1. **Enable and configure MQTT on the B2500**
    - Option 1: Contact support and ask them to enable MQTT in the app.
@@ -292,11 +292,11 @@ The device id is the MAC address of the device in lowercase, without colons.
 - Use the MAC address shown in the Marstek/PowerZero app's device list or in the Bluetooth configuration tool
 - **Important:** Do not use the WiFi interface MAC address - it must be the one shown in the app or Bluetooth tool
 
-### MQTT Proxy for B2500 Client ID Conflicts
+### MQTT Proxy for B2500 Firmware 226.5/108.7 Client ID Conflict
 
 **🔧 Recommended for Multiple B2500 Devices**
 
-If you have multiple B2500 devices (especially with firmware 226.5/108.7 or later), you **must** use the MQTT proxy to avoid client ID conflicts. The proxy resolves the firmware bug where all B2500 devices try to connect with the same client ID (`mst_`).
+If you run multiple B2500 devices on firmware 226.5/108.7, you **must** use the MQTT proxy to avoid client ID conflicts. In that firmware version, all B2500 devices try to connect with the same client ID (`mst_`). For newer firmware versions, use different MQTT usernames per battery (proxy remains optional).
 
 #### How It Works
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Choose one of the following variants.
 
 Use this **only** for B2500 devices when your B2500 should send data directly to your local MQTT broker. If you have any other Marstek device type, follow **Variant B** instead.
 
+**When to use:** Choose this if you want direct local MQTT communication from B2500 to your broker (for local-first integrations), and you accept that direct cloud connectivity is disabled unless you add hame-relay Mode 1.
+
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup).
 >
 > **⚠️ Important for multiple B2500 devices:** For firmware `226.5` / `108.7`, use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts) for details.
@@ -60,6 +62,8 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 ### Variant B: Other Marstek devices (and B2500 without local MQTT)
 
 Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/CT002), or for B2500 when you do not switch it to local MQTT.
+
+**When to use:** Choose this if your device remains cloud-configured, or if you want to keep the standard cloud setup and bridge data into your local broker via hame-relay.
 
 For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use this **only** for B2500 devices when your B2500 should send data directly to
 
 **When to use:** Choose this if you want direct local MQTT communication from B2500 to your broker (for local-first integrations), and you accept that direct cloud connectivity is disabled unless you add hame-relay Mode 1.
 
-> **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup).
+> **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
 >
 > **⚠️ Important for multiple B2500 devices:** For firmware `226.5` / `108.7`, use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts) for details.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Choose one of the following variants.
 
 Use this when your B2500 should send data directly to your local MQTT broker.
 
-> **⚠️ Important for multiple B2500 devices:** If you use multiple B2500 units (especially firmware 226.5/108.7), configure them to use the hm2mqtt MQTT proxy port (default `1890`) instead of your main broker port. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts).
+> **⚠️ Important for multiple B2500 devices:** Recommended/default approach: configure all B2500 units (especially firmware 226.5/108.7) to use the hm2mqtt MQTT proxy port (default `1890`) instead of your main broker port. Valid alternative: assign unique MQTT usernames/client IDs per B2500. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts) for both approaches.
 
 1. **Enable and configure MQTT on the B2500**
    - Option 1: Contact support and ask them to enable MQTT in the app.
@@ -46,12 +46,17 @@ Use this when your B2500 should send data directly to your local MQTT broker.
 4. **Configure hm2mqtt**
    - Add your MQTT broker settings.
    - Add the device in format `{deviceType}:{bluetoothMac}` (for example `HMA-1:001a2b3c4d5e`).
-5. **Start hm2mqtt**
+5. **Understand cloud/app impact (important)**
+   - Enabling local MQTT on the B2500 disables direct cloud connectivity for that device.
+   - You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup).
+6. **Start hm2mqtt**
    - After startup, Home Assistant should discover the new device via MQTT Discovery.
 
 ### Variant B: Other Marstek devices (and B2500 without local MQTT)
 
 Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/CT002), or for B2500 when you do not switch it to local MQTT.
+
+For B2500 in this variant, configure hame-relay with inverse forwarding for the specific device ID (see hame-relay docs, `inverse_forwarding_device_ids`).
 
 1. **Install and configure hame-relay**
    - Follow the hame-relay README: https://github.com/tomquist/hame-relay
@@ -367,7 +372,7 @@ This message is almost always a **symptom**, not the root cause. It usually mean
 
 #### Troubleshooting: B2500
 1. **Verify the B2500 is actually configured for local MQTT**
-   - Use the configuration tool: <https://tomquist.github.io/hmjs/>
+   - Use the configuration tool: <https://tomquist.github.io/hame-relay/b2500.html>
    - Double-check host/port and the SSL toggle.
 2. If you have **multiple B2500s**, ensure you handled client-ID conflicts
    - Either configure **unique MQTT usernames** per storage, or
@@ -384,7 +389,7 @@ This message is almost always a **symptom**, not the root cause. It usually mean
 In hm2mqtt, `deviceId` must be the **Bluetooth MAC** of the device (12 hex chars, lowercase, no `:`).
 
 **Where to find it:**
-- **B2500:** via <https://tomquist.github.io/hmjs/>
+- **B2500:** via <https://tomquist.github.io/hame-relay/b2500.html>
 - **All devices via hame-relay:** check the **hame-relay logs** (they include the mapping).
 
 **Troubleshooting (quick):**

--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ Use this when your B2500 should send data directly to your local MQTT broker.
    - Do **not** use the Wi-Fi MAC.
 4. **Configure hm2mqtt**
    - Add your MQTT broker settings.
-   - Add the device in format `{deviceType}:{bluetoothMac}` (for example `HMA-1:001a2b3c4d5e`).
+   - **Home Assistant App:** add a device entry under `devices`:
+     ```yaml
+     devices:
+       - deviceType: "HMA-1"
+         deviceId: "001a2b3c4d5e"
+     ```
+   - **Docker / .env:** add `DEVICE_n` in format `{deviceType}:{bluetoothMac}` (for example `DEVICE_0=HMA-1:001a2b3c4d5e`).
 5. **Start hm2mqtt**
    - After startup, Home Assistant should discover the new device via MQTT Discovery.
 
@@ -70,7 +76,14 @@ For B2500 in this variant, configure hame-relay with inverse forwarding for the 
      - `deviceType`
      - Bluetooth MAC address (used as hm2mqtt `deviceId`)
 4. **Configure hm2mqtt**
-   - Add device entries using `{deviceType}:{bluetoothMac}` from hame-relay output.
+   - Use `deviceType` + Bluetooth MAC from hame-relay output.
+   - **Home Assistant App:** add entries under `devices`:
+     ```yaml
+     devices:
+       - deviceType: "HMG-50"
+         deviceId: "001a2b3c4d5e"
+     ```
+   - **Docker / .env:** add `DEVICE_n={deviceType}:{bluetoothMac}`.
 5. **Start hm2mqtt**
    - Home Assistant should discover the devices once data is available on your local broker.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ flowchart TB
      - Share your devices to that account.
      - Use that account in hame-relay.
      - This avoids logging your primary app account out of the mobile app session.
-   - For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
+   - For B2500 in this variant, configure hame-relay inverse forwarding with the 24-character **cloud device ID** in `inverse_forwarding_device_ids` (from hame-relay startup/device output). In hm2mqtt, continue using the **Bluetooth MAC** as `deviceId` (see step 3 above). See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
 
 2. **Start hame-relay and check startup output**
    - hame-relay loads your account device list on startup.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flowchart TB
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
 >
-> **⚠️ Important for multiple B2500 devices:** For firmware `226.5` / `108.7`, you **must** use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Firmware 226.5/108.7 Client ID Conflict](#mqtt-proxy-for-b2500-firmware-22651087-client-id-conflict) for details.
+> **⚠️ Important if you want to use multiple B2500 simultaneously:** For firmware `226.5` / `108.7`, you **must** use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Firmware 226.5/108.7 Client ID Conflict](#mqtt-proxy-for-b2500-firmware-22651087-client-id-conflict) for details.
 
 1. **Enable and configure MQTT on the B2500**
    - Option 1: Contact support and ask them to enable MQTT in the app.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Choose one of the following variants.
 
 Use this when your B2500 should send data directly to your local MQTT broker.
 
+> **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup).
+>
 > **⚠️ Important for multiple B2500 devices:** For firmware `226.5` / `108.7`, use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts) for details.
 
 1. **Enable and configure MQTT on the B2500**
@@ -46,10 +48,7 @@ Use this when your B2500 should send data directly to your local MQTT broker.
 4. **Configure hm2mqtt**
    - Add your MQTT broker settings.
    - Add the device in format `{deviceType}:{bluetoothMac}` (for example `HMA-1:001a2b3c4d5e`).
-5. **Understand cloud/app impact (important)**
-   - Enabling local MQTT on the B2500 disables direct cloud connectivity for that device.
-   - You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup).
-6. **Start hm2mqtt**
+5. **Start hm2mqtt**
    - After startup, Home Assistant should discover the new device via MQTT Discovery.
 
 ### Variant B: Other Marstek devices (and B2500 without local MQTT)

--- a/README.md
+++ b/README.md
@@ -68,19 +68,18 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
 1. **Install and configure hame-relay**
    - Follow the hame-relay README: https://github.com/tomquist/hame-relay
    - Enter your account credentials in hame-relay config.
+   - Use a separate Marstek account (recommended):
+     - Share your devices to that account.
+     - Use that account in hame-relay.
+     - This avoids logging your primary app account out of the mobile app session.
+   - For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
 
-- For B2500 in this variant, configure hame-relay inverse forwarding for the B2500 **cloud device ID** (the 24-character device ID from hame-relay startup/device output, not the Bluetooth MAC). Use `inverse_forwarding_device_ids` in hame-relay config. See hame-relay docs: https://github.com/tomquist/hame-relay#optional-settings
-
-2. **Use a separate Marstek account (recommended)**
-   - Share your devices to that account.
-   - Use that account in hame-relay.
-   - This avoids logging your primary app account out of the mobile app session.
-3. **Start hame-relay and check startup output**
+2. **Start hame-relay and check startup output**
    - hame-relay loads your account device list on startup.
    - From the startup logs/output, note:
      - `deviceType`
      - Bluetooth MAC address (used as hm2mqtt `deviceId`)
-4. **Configure hm2mqtt**
+3. **Configure hm2mqtt**
    - Use `deviceType` + Bluetooth MAC from hame-relay output.
    - **Home Assistant App:** add entries under `devices`:
      ```yaml
@@ -89,7 +88,7 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
          deviceId: "001a2b3c4d5e"
      ```
    - **Docker / .env:** add `DEVICE_n={deviceType}:{bluetoothMac}`.
-5. **Start hm2mqtt**
+4. **Start hm2mqtt**
    - Home Assistant should discover the devices once data is available on your local broker.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ flowchart LR
     Broker -->|device telemetry / responses| HM2MQTT[hm2mqtt]
     HM2MQTT -->|parsed state + HA discovery + command topics| Broker
     HA[Home Assistant] <-->|MQTT integration| Broker
-    Relay[hame relay Mode 1 optional] <-->|bridge local topics| Broker
-    Relay <-->|bridge to cloud| Cloud[Marstek Cloud]
+    Broker -->|local MQTT traffic| Relay[hame relay Mode 1 optional]
+    Relay -->|local MQTT traffic| Broker
+    Cloud[Marstek Cloud] -->|cloud MQTT traffic| Relay
+    Relay -->|cloud MQTT traffic| Cloud
 ```
 
 > **⚠️ Cloud/app impact (read first):** Enabling local MQTT on the B2500 disables direct cloud connectivity for that device. You can restore app/cloud functionality by running hame-relay in Mode 1 (local broker setup). For more background, see [FAQ: When do I need hm2mqtt, hame-relay, or both?](#1-when-do-i-need-hm2mqtt-hame-relay-or-both).
@@ -78,8 +80,10 @@ Use this for devices that stay on cloud MQTT (Venus/Jupiter/Jupiter Plus/MI800/C
 ```mermaid
 flowchart LR
     Device[Marstek device in cloud mode] <-->|device MQTT| CloudMQTT[Marstek Cloud MQTT]
-    Relay[hame relay] <-->|cloud-side bridge| CloudMQTT
-    Relay <-->|local-side bridge| Broker[Local MQTT broker]
+    CloudMQTT -->|cloud MQTT traffic| Relay[hame relay]
+    Relay -->|cloud MQTT traffic| CloudMQTT
+    Broker[Local MQTT broker] -->|local MQTT traffic| Relay
+    Relay -->|local MQTT traffic| Broker
     Broker -->|device telemetry / responses| HM2MQTT[hm2mqtt]
     HM2MQTT -->|parsed state + HA discovery + command topics| Broker
     HA[Home Assistant] <-->|MQTT integration| Broker

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ hm2mqtt is a bridge application that connects Hame energy storage devices (like 
 ## Prerequisites
 
 - A local MQTT broker (for example the Home Assistant Mosquitto broker): https://www.home-assistant.io/integrations/mqtt/#setting-up-a-broker
-- Access to your device details (device type + Bluetooth MAC address)
+- Access to your device details (device type + Bluetooth MAC address) — how to find these is explained in the setup steps below.
 
 ## Step-by-step setup
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Choose one of the following variants.
 
 Use this when your B2500 should send data directly to your local MQTT broker.
 
-> **⚠️ Important for multiple B2500 devices:** Recommended/default approach: configure all B2500 units (especially firmware 226.5/108.7) to use the hm2mqtt MQTT proxy port (default `1890`) instead of your main broker port. Valid alternative: assign unique MQTT usernames/client IDs per B2500. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts) for both approaches.
+> **⚠️ Important for multiple B2500 devices:** For firmware `226.5` / `108.7`, use the hm2mqtt MQTT proxy port (default `1890`) to avoid client-ID conflicts. For newer firmware versions, the recommended approach is to configure different MQTT usernames per B2500. See [MQTT Proxy for B2500 Client ID Conflicts](#mqtt-proxy-for-b2500-client-id-conflicts) for details.
 
 1. **Enable and configure MQTT on the B2500**
    - Option 1: Contact support and ask them to enable MQTT in the app.


### PR DESCRIPTION
## Summary
- replace the old mixed prerequisite text with a clearer step-by-step setup section
- add two explicit setup variants:
  1. B2500 configured for local MQTT
  2. Other Marstek devices (and B2500 without local MQTT) via hame-relay
- document where to get `deviceType` and Bluetooth MAC and how to apply them in hm2mqtt config
- include recommendation for using a separate Marstek account with hame-relay

## Why
This makes onboarding easier by guiding users through the exact sequence for both supported integration paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized setup into two clear step-by-step paths (Variant A: local MQTT; Variant B: cloud-to-local bridge)
  * Added a mermaid setup diagram and sequenced steps for each variant
  * Replaced generic cloud warnings with variant-specific guidance
  * Added explicit MQTT enable/configuration steps, device-ID guidance (use Bluetooth MAC), discovery notes, and proxy port defaults
  * Included concrete configuration examples for Home Assistant, Docker, and Docker Compose; reordered installation content
<!-- end of auto-generated comment: release notes by coderabbit.ai -->