### PR TITLE
chore: log build commit at startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NODE_ENV=production
+            BUILD_COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,9 @@ jobs:
           file: ha_addon/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.lower-repo.outputs.ADDON_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-          build-args: BUILD_FROM=ghcr.io/hassio-addons/base:14.2.2
+          build-args: |
+            BUILD_FROM=ghcr.io/hassio-addons/base:14.2.2
+            BUILD_COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Added
 
+- Log the build commit hash at application startup to make it easier to verify which exact source revision a running container/add-on was built from
 - Add configurable Home Assistant MQTT discovery topic prefix via `AUTODISCOVERY_TOPIC_PREFIX` (add-on option: `autodiscoveryTopicPrefix`, default: `homeassistant`) (#248)
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine
 
+ARG BUILD_COMMIT=unknown
+
 # Create app directory
 WORKDIR /app
 
@@ -19,6 +21,7 @@ RUN npm ci --only=production
 
 # Set environment variables
 ENV NODE_ENV=production
+ENV BUILD_COMMIT=${BUILD_COMMIT}
 
 # Expose MQTT port if needed
 # EXPOSE 1883

--- a/ha_addon/Dockerfile
+++ b/ha_addon/Dockerfile
@@ -21,8 +21,8 @@ RUN npm ci --only=production
 
 # Final stage
 ARG BUILD_FROM
-ARG BUILD_COMMIT=unknown
 FROM ${BUILD_FROM:-ghcr.io/hassio-addons/base:14.2.2}
+ARG BUILD_COMMIT=unknown
 
 # Install Node.js
 RUN apk add --no-cache nodejs

--- a/ha_addon/Dockerfile
+++ b/ha_addon/Dockerfile
@@ -21,6 +21,7 @@ RUN npm ci --only=production
 
 # Final stage
 ARG BUILD_FROM
+ARG BUILD_COMMIT=unknown
 FROM ${BUILD_FROM:-ghcr.io/hassio-addons/base:14.2.2}
 
 # Install Node.js
@@ -28,6 +29,7 @@ RUN apk add --no-cache nodejs
 
 # Set work directory
 WORKDIR /app
+ENV BUILD_COMMIT=${BUILD_COMMIT}
 
 # Copy package file (for reference only)
 COPY package.json ./

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ function createMqttConfig(devices: Device[]): MqttConfig {
 async function main() {
   try {
     logger.info('Starting hm2mqtt application...');
+    logger.info(`Build commit: ${process.env.BUILD_COMMIT || 'unknown'}`);
     logger.info(`Environment: ${process.env.NODE_ENV || 'production'}`);
     logger.info(
       `MQTT Proxy: ${MQTT_PROXY_ENABLED ? `enabled on port ${MQTT_PROXY_PORT}` : 'disabled'}`,


### PR DESCRIPTION
## Summary
- log the build commit hash at app startup
- pass `BUILD_COMMIT` through both Docker build paths
- wire GitHub Actions addon builds to inject `${{ github.sha }}`

## Why
This makes it obvious which exact build/commit a running add-on was built from when inspecting logs.

## Validation
- `npm test -- --runInBand src/mqttClient.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build metadata now includes the build commit and is captured for both primary and addon builds.
  * The application logs the build commit at startup so the exact build version can be identified at runtime.

* **Documentation**
  * Changelog updated to record the startup logging of the build commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->