### PR TITLE
Jupiter: Updates and fixes to several sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Drop 32-bit ARM (linux/arm/v7) image builds. Home Assistant no longer supports 32-bit ARM, and the CI now builds ARM images natively (arm64).
 
+- Jupiter: The "Cell Voltage X" sensors were removed as they were misleading. The `vol0`..`vol15` fields do not represent the actual cell voltages, but rather the numbers and voltages of the cell with the highest and lowest voltage. New sensors were added to represent these values properly.
+
+- Jupiter: `chargeCurrent` and `dischargeCurrent` sensors were renamed to `chargeCurrentLimit` and `dischargeCurrentLimit` to reflect that they represent the current limits set by BMS.
+
 ### Added
 
 - Log the build commit hash at application startup to make it easier to verify which exact source revision a running container/add-on was built from
@@ -15,6 +19,11 @@
 - Venus: Treat out-of-range/sentinel `mcp_w` values (e.g. -1) as unknown for the *Maximum Charging Power* entity to avoid Home Assistant log spam (#240)
 - B2500: Fix `Surplus Feed-in` entity missing for `HMJ-*` devices (firmware 108+) (fixes #235, #242)
 - B2500: Fix time period 5 control topics not being processed and normalize time format in timer commands (fixes #244)
+- Jupiter: Change parsing of cell voltages (`vol0`..`vol15`). They were not what they seemed, as they represent the numbers and the voltages of the cell with the highest and lowest voltage, not the actual cell voltages. See discussion in #253 for more details. The values are now parsed into new sensors and the old sensors ("Cell Voltage X") were removed.
+- Jupiter: Fix incorrect parsing of the "Surplus Feed-In" control state. The fix that was included in the previous release (#223) was incorrect and the control would still show as disabled when the device was actively feeding in surplus power.
+- Jupiter: Fix "Inverter Temperature" (`i_temp`) parsing by applying the correct divisor.
+- Jupiter: Update "Depth of Discharge" control range to 30% - 90% to keep up-to-date with the Marstek app (fixes #260).
+- Jupiter: Fix parsing and naming of "BMS ChargeCurrent" (`c_cur`) and "BMS DischargeCurrent" (`d_cur`) fields. They represent current limits set by the BMS, not the actual currents, so they were renamed to `BMS ChargeCurrentLimit` and `BMS DischargeCurrentLimit` and their values are now in Amperes.
 
 ## [1.6.0] - 2026-01-25
 

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -1,4 +1,9 @@
-import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
+import {
+  BuildMessageFn,
+  globalPollInterval,
+  KeyPath,
+  registerDeviceDefinition,
+} from '../deviceDefinition';
 import {
   CommandParams,
   JupiterBatteryWorkingStatus,
@@ -18,7 +23,16 @@ import {
   textComponent,
   numberComponent,
 } from '../homeAssistantDiscovery';
-import { divide, map, negate, identity, equalsBoolean, number, temperature } from '../transforms';
+import {
+  divide,
+  map,
+  negate,
+  identity,
+  number,
+  temperature,
+  highByte,
+  lowByte,
+} from '../transforms';
 
 /**
  * Command types supported by the Jupiter device (subset of Venus)
@@ -34,6 +48,11 @@ enum CommandType {
   GET_BMS_INFO = 14, // -> inv:g_state=1,w_state1=1,w_state2=1,i_err=0,i_war=0,g_vol=2399,g_cur=0,g_pf=0,g_fre=5000,b_vol=526,g_power=119,i_temp=31,mppt:m_state=244,m_err=0,m_temp=30,m_war=0,pv1=350|37|1304,pv2=349|39|1372,pv3=378|18|712,pv4=365|32|1180,b_vol=525,b_cur=85,base_v=221,pe_v=165,fail_t=0,bms:c_vol=571,c_cur=500,d_cur=500,soc=33,soh=100,b_cap=5120,b_vol=5252,b_cur=63,b_temp=250,b_err=0,b_war=0,b_err2=0,b_war2=0,c_flag=192,s_flag=0,b_num=1,vol0=3280,vol1=3281,vol2=3283,vol3=3283,vol4=3283,vol5=3283,vol6=3280,vol7=3284,vol8=3283,vol9=3284,vol10=3282,vol11=3286,vol12=3277,vol13=3286,vol14=3283,vol15=3284,b_temp0=14,b_temp1=15,b_temp2=15,b_temp3=16,env_t=27,mos_t=20,lck=0
   DEPTH_OF_DISCHARGE = 56,
 }
+
+// Minimum and maximum Depth of Discharge values based on Marstek app limits (30-90%).
+// NOTE: Experience has shown that these limits may change over time!
+const DOD_MIN = 30;
+const DOD_MAX = 90;
 
 function processCommand(command: CommandType, params: CommandParams = {}): string {
   const entries = Object.entries(params);
@@ -436,7 +455,11 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     );
 
     // Surplus Feed-in (ful_d)
-    field({ key: 'ful_d', path: ['surplusFeedInEnabled'], transform: equalsBoolean('1') });
+    field({
+      key: 'ful_d',
+      path: ['surplusFeedInEnabled'],
+      transform: map({ '1': true, '3': true }, false),
+    });
     advertise(
       ['surplusFeedInEnabled'],
       switchComponent({
@@ -449,11 +472,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     command('surplus-feed-in', {
       handler: ({ message, publishCallback, updateDeviceState }) => {
         const enable =
-          message.toLowerCase() === 'true' ||
-          message === '1' ||
-          // `3` is reported when surplus is being fed-in
-          message === '3' ||
-          message === 'on';
+          message.toLowerCase() === 'true' || message.toLowerCase() === 'on' || message === '1';
         updateDeviceState(() => ({ surplusFeedInEnabled: enable }));
         // Yes, it's `full_d` in the command params
         publishCallback(processCommand(CommandType.SURPLUS_FEED_IN, { full_d: enable ? 1 : 0 }));
@@ -470,8 +489,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         unit_of_measurement: '%',
         device_class: 'battery',
         command: 'discharge-depth',
-        min: 30,
-        max: 88,
+        min: DOD_MIN,
+        max: DOD_MAX,
         step: 1,
       }),
       { enabled: state => state.deviceVersion !== undefined && state.deviceVersion >= 140 },
@@ -479,9 +498,11 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     command('discharge-depth', {
       handler: ({ message, publishCallback, updateDeviceState }) => {
         const dod = parseInt(message, 10);
-        // Marstek app limits DoD to 30-88%
-        if (isNaN(dod) || dod < 30 || dod > 88) {
-          logger.warn('Invalid depth of discharge value (should be 30-88):', message);
+        if (Number.isNaN(dod) || dod < DOD_MIN || dod > DOD_MAX) {
+          logger.warn(
+            `Invalid depth of discharge value (should be ${DOD_MIN}-${DOD_MAX}):`,
+            message,
+          );
           return;
         }
         updateDeviceState(() => ({ depthOfDischarge: dod }));
@@ -884,21 +905,107 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
       enabled: process.env.POLL_CELL_DATA === 'true',
     },
     ({ field, advertise }) => {
-      // Cell voltages (vol0-vol15)
-      for (let i = 0; i < 16; i++) {
-        const key = `vol${i}`;
-        field({ key, path: ['cells', 'voltages', i] });
+      // `volX` fields are actually not what they look like. `vol0` encodes two
+      // cell numbers from the internal battery - high byte for the cell with
+      // the maximum voltage, and low byte for the cell with the minimum
+      // voltage. `vol1` and `vol2` provide maximum and minimum voltage,
+      // respectively. This was verified by Marstek support. However, we don't
+      // know which one of those cell numbers corresponds to the maximum voltage
+      // and which one corresponds to the minimum voltage. Marstek's reply to
+      // this question is still pending. For now, based on the observations, we
+      // assume that high byte encodes the cell with the minimum voltage and low
+      // byte encodes the cell with the maximum voltage.
+      //
+      // In addition to that, Marstek Jupiter C Plus can have up to 3 extra
+      // batteries attached, and the remaining `volX` fields should provide
+      // voltages for those batteries in the same way. However, we don't know
+      // where the block of values for the next battery starts. When no external
+      // batteries are attached, `vol3` to `vol15` are all `0`.
+      //
+      // For now, we will assume that four `volX` fields correspond to each
+      // battery, as it nicely aligns with 16 being divisible by 4 (1 internal
+      // battery + up to 3 external batteries). I don't have external batteries,
+      // so I can't verify this assumption.
+      //
+      // See: https://github.com/tomquist/hm2mqtt/discussions/253
+
+      // Batteries: 1 internal (battery 0) + up to 3 external (batteries 1-3)
+      for (let batteryIndex = 0; batteryIndex < 4; batteryIndex++) {
+        const baseIndex = batteryIndex * 4;
+        const batteryLabel =
+          batteryIndex === 0 ? 'Internal Battery' : `External Battery ${batteryIndex}`;
+        const volNumberKey = `vol${baseIndex}`;
+        const pathPrefix: KeyPath<JupiterBMSInfo> = ['batteries', batteryIndex, 'cellVoltages'];
+
+        // Cell with the highest voltage (low byte of volX)
+        field({
+          key: volNumberKey,
+          path: [...pathPrefix, 'maxVoltageCell'],
+          transform: lowByte(),
+        });
         advertise(
-          ['cells', 'voltages', i],
+          [...pathPrefix, 'maxVoltageCell'],
           sensorComponent<number>({
-            id: `cell_voltage_${i + 1}`,
-            name: `Cell Voltage ${i + 1}`,
+            id: `battery_${batteryIndex}_cell_number_voltage_max`,
+            name: `${batteryLabel} Cell With Highest Voltage`,
+            enabled_by_default: false,
+          }),
+        );
+
+        // Cell with the lowest voltage (high byte of volX)
+        field({
+          key: volNumberKey,
+          path: [...pathPrefix, 'minVoltageCell'],
+          transform: highByte(),
+        });
+        advertise(
+          [...pathPrefix, 'minVoltageCell'],
+          sensorComponent<number>({
+            id: `battery_${batteryIndex}_cell_number_voltage_min`,
+            name: `${batteryLabel} Cell With Lowest Voltage`,
+            enabled_by_default: false,
+          }),
+        );
+
+        // Highest voltage
+        const maxVoltageKey = `vol${baseIndex + 1}`;
+        field({
+          key: maxVoltageKey,
+          path: [...pathPrefix, 'maxVoltage'],
+          transform: number(),
+        });
+        advertise(
+          [...pathPrefix, 'maxVoltage'],
+          sensorComponent<number>({
+            id: `battery_${batteryIndex}_cell_voltage_max`,
+            name: `${batteryLabel} Highest Cell Voltage`,
             unit_of_measurement: 'mV',
             device_class: 'voltage',
+            state_class: 'measurement',
+            enabled_by_default: false,
+          }),
+        );
+
+        // Lowest voltage
+        const minVoltageKey = `vol${baseIndex + 2}`;
+        field({
+          key: minVoltageKey,
+          path: [...pathPrefix, 'minVoltage'],
+          transform: number(),
+        });
+        advertise(
+          [...pathPrefix, 'minVoltage'],
+          sensorComponent<number>({
+            id: `battery_${batteryIndex}_cell_voltage_min`,
+            name: `${batteryLabel} Lowest Cell Voltage`,
+            unit_of_measurement: 'mV',
+            device_class: 'voltage',
+            state_class: 'measurement',
             enabled_by_default: false,
           }),
         );
       }
+
       // Cell temperatures (b_temp0-b_temp3)
       for (let i = 0; i < 4; i++) {
         const key = `b_temp${i}`;
@@ -974,13 +1081,28 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
             transform: divide(10),
           },
         ],
-        // My unit always reports 75 for `c_cur` and 300 for `d_cur`. 75 mA is
-        // too low, 75 A is too high. Dividing by 10 gives 7.5 A which looks
-        // more reasonable. However, 30 A for `d_cur` seems way too high. These
-        // values definitely need scaling, but I'm not sure what the correct
-        // factors are.
-        ['c_cur', { id: 'chargeCurrent', deviceClass: 'current', unitOfMeasurement: 'mA' }],
-        ['d_cur', { id: 'dischargeCurrent', deviceClass: 'current', unitOfMeasurement: 'mA' }],
+        // By observing the values, these two fields seem to represent the limits, not the actual
+        // charge and discharge currents.
+        [
+          'c_cur',
+          {
+            id: 'chargeCurrentLimit',
+            deviceClass: 'current',
+            unitOfMeasurement: 'A',
+            stateClass: 'measurement',
+            transform: divide(10),
+          },
+        ],
+        [
+          'd_cur',
+          {
+            id: 'dischargeCurrentLimit',
+            deviceClass: 'current',
+            unitOfMeasurement: 'A',
+            stateClass: 'measurement',
+            transform: divide(10),
+          },
+        ],
         ['b_err', { id: 'error' }],
         ['b_war', { id: 'warning' }],
         ['b_err2', { id: 'error2' }],
@@ -1095,7 +1217,7 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
             deviceClass: 'temperature',
             unitOfMeasurement: '°C',
             stateClass: 'measurement',
-            transform: divide(10),
+            transform: temperature(),
           },
         ],
         ['i_err', { id: 'error' }],

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -923,15 +923,8 @@ const commandTestCases: CommandTestCase[] = [
     input: 'false',
     expectedOutput: 'cd=13,full_d=0',
   },
-  {
-    description: 'Jupiter surplus-feed-in with 3 (feed-in active)',
-    deviceType: 'HMN-1',
-    command: 'surplus-feed-in',
-    input: '3',
-    expectedOutput: 'cd=13,full_d=1',
-  },
 
-  // discharge-depth command (Jupiter: 30-88%)
+  // discharge-depth command (Jupiter: 30-90%)
   {
     description: 'Jupiter discharge-depth valid',
     deviceType: 'HMN-1',
@@ -947,11 +940,11 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: 'cd=56,dod=30',
   },
   {
-    description: 'Jupiter discharge-depth maximum (88%)',
+    description: 'Jupiter discharge-depth maximum (90%)',
     deviceType: 'HMN-1',
     command: 'discharge-depth',
-    input: '88',
-    expectedOutput: 'cd=56,dod=88',
+    input: '90',
+    expectedOutput: 'cd=56,dod=90',
   },
   {
     description: 'Jupiter discharge-depth below minimum (invalid)',
@@ -964,7 +957,7 @@ const commandTestCases: CommandTestCase[] = [
     description: 'Jupiter discharge-depth above maximum (invalid)',
     deviceType: 'HMN-1',
     command: 'discharge-depth',
-    input: '89',
+    input: '91',
     expectedOutput: null,
   },
 

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -392,7 +392,7 @@ describe('MQTT Message Parser', () => {
 
   test('should parse Jupiter BMS message correctly', () => {
     const message =
-      'inv:g_state=1,w_state1=1,w_state2=1,i_err=0,i_war=0,g_vol=2399,g_cur=0,g_pf=0,g_fre=5002,b_vol=526,g_power=119,i_temp=143,mppt:m_state=244,m_err=0,m_temp=30,m_war=0,pv1=350|37|1304,pv2=349|39|1372,pv3=378|18|712,pv4=365|32|1180,b_vol=525,b_cur=85,base_v=221,pe_v=165,fail_t=0,bms:c_vol=571,c_cur=500,d_cur=500,soc=33,soh=100,b_cap=5120,b_vol=5252,b_cur=63,b_temp=213,b_err=0,b_war=0,b_err2=0,b_war2=0,c_flag=192,s_flag=0,b_num=1,vol0=3280,vol1=3281,vol2=3283,vol3=3283,vol4=3283,vol5=3283,vol6=3280,vol7=3284,vol8=3283,vol9=3284,vol10=3282,vol11=3286,vol12=3277,vol13=3286,vol14=3283,vol15=3284,b_temp0=14,b_temp1=15,b_temp2=15,b_temp3=16,env_t=27,mos_t=20,lck=0';
+      'inv:g_state=1,w_state1=1,w_state2=1,i_err=0,i_war=0,g_vol=2399,g_cur=0,g_pf=0,g_fre=5002,b_vol=526,g_power=119,i_temp=42,mppt:m_state=244,m_err=0,m_temp=30,m_war=0,pv1=350|37|1304,pv2=349|39|1372,pv3=378|18|712,pv4=365|32|1180,b_vol=525,b_cur=85,base_v=221,pe_v=165,fail_t=0,bms:c_vol=571,c_cur=500,d_cur=500,soc=33,soh=100,b_cap=5120,b_vol=5252,b_cur=63,b_temp=213,b_err=0,b_war=0,b_err2=0,b_war2=0,c_flag=192,s_flag=0,b_num=1,vol0=3280,vol1=3281,vol2=3283,vol3=3283,vol4=3283,vol5=3283,vol6=3280,vol7=3284,vol8=3283,vol9=3284,vol10=3282,vol11=3286,vol12=3277,vol13=3286,vol14=3283,vol15=3284,b_temp0=14,b_temp1=15,b_temp2=15,b_temp3=16,env_t=27,mos_t=20,lck=0';
     const deviceType = 'JPLS-1';
     const deviceId = 'jupiter123';
 
@@ -409,13 +409,51 @@ describe('MQTT Message Parser', () => {
 
     // Cell voltages (vol0-vol15)
     expect(result).toHaveProperty('cells');
-    expect(result.cells).toHaveProperty('voltages');
-    expect(Array.isArray(result.cells?.voltages)).toBe(true);
-    expect(result.cells?.voltages).toHaveLength(16);
-    expect(result.cells?.voltages).toEqual([
-      3280, 3281, 3283, 3283, 3283, 3283, 3280, 3284, 3283, 3284, 3282, 3286, 3277, 3286, 3283,
-      3284,
-    ]);
+
+    // Battery cell voltages: 4 batteries, each using 4 volX values
+    // Battery 0 (internal): vol0, vol1, vol2, vol3
+    // Battery 1 (external 1): vol4, vol5, vol6, vol7
+    // Battery 2 (external 2): vol8, vol9, vol10, vol11
+    // Battery 3 (external 3): vol12, vol13, vol14, vol15
+    expect(result).toHaveProperty('batteries');
+    expect(Array.isArray(result.batteries)).toBe(true);
+    expect(result.batteries).toHaveLength(4);
+
+    // Battery 0 (internal): vol0=3280 (0x0CD0), vol1=3281, vol2=3283, vol3=3283
+    expect(result.batteries?.[0]).toHaveProperty('cellVoltages');
+    expect(result.batteries?.[0]?.cellVoltages?.maxVoltage).toBe(3281);
+    expect(result.batteries?.[0]?.cellVoltages?.minVoltage).toBe(3283);
+    // Low byte: 0xD0 = 208
+    expect(result.batteries?.[0]?.cellVoltages?.maxVoltageCell).toBe(208);
+    // High byte: 0x0C = 12
+    expect(result.batteries?.[0]?.cellVoltages?.minVoltageCell).toBe(12);
+
+    // Battery 1 (external 1): vol4=3283 (0x0CD3), vol5=3283, vol6=3280, vol7=3284
+    expect(result.batteries?.[1]).toHaveProperty('cellVoltages');
+    expect(result.batteries?.[1]?.cellVoltages?.maxVoltage).toBe(3283);
+    expect(result.batteries?.[1]?.cellVoltages?.minVoltage).toBe(3280);
+    // Low byte: 0xD3 = 211
+    expect(result.batteries?.[1]?.cellVoltages?.maxVoltageCell).toBe(211);
+    // High byte: 0x0C = 12
+    expect(result.batteries?.[1]?.cellVoltages?.minVoltageCell).toBe(12);
+
+    // Battery 2 (external 2): vol8=3283 (0x0CD3), vol9=3284, vol10=3282, vol11=3286
+    expect(result.batteries?.[2]).toHaveProperty('cellVoltages');
+    expect(result.batteries?.[2]?.cellVoltages?.maxVoltage).toBe(3284);
+    expect(result.batteries?.[2]?.cellVoltages?.minVoltage).toBe(3282);
+    // Low byte: 0xD3 = 211
+    expect(result.batteries?.[2]?.cellVoltages?.maxVoltageCell).toBe(211);
+    // High byte: 0x0C = 12
+    expect(result.batteries?.[2]?.cellVoltages?.minVoltageCell).toBe(12);
+
+    // Battery 3 (external 3): vol12=3277 (0x0CCD), vol13=3286, vol14=3283, vol15=3284
+    expect(result.batteries?.[3]).toHaveProperty('cellVoltages');
+    expect(result.batteries?.[3]?.cellVoltages?.maxVoltage).toBe(3286);
+    expect(result.batteries?.[3]?.cellVoltages?.minVoltage).toBe(3283);
+    // Low byte: 0xCD = 205
+    expect(result.batteries?.[3]?.cellVoltages?.maxVoltageCell).toBe(205);
+    // High byte: 0x0C = 12
+    expect(result.batteries?.[3]?.cellVoltages?.minVoltageCell).toBe(12);
 
     // Cell temperatures (b_temp0-b_temp3)
     expect(result.cells).toHaveProperty('temperatures');
@@ -474,7 +512,7 @@ describe('MQTT Message Parser', () => {
 
     // Inverter fields
     expect(result).toHaveProperty('inverter');
-    expect(result.inverter).toHaveProperty('temperature', 14.3);
+    expect(result.inverter).toHaveProperty('temperature', 42);
     expect(result.inverter).toHaveProperty('error', 0);
     expect(result.inverter).toHaveProperty('warning', 0);
     expect(result.inverter).toHaveProperty('gridVoltage', 239.9);
@@ -507,6 +545,38 @@ describe('MQTT Message Parser', () => {
     expect(result['mppt']).toHaveProperty('temperature', 5);
 
     expect(result).toHaveProperty('inverter');
-    expect(result.inverter).toHaveProperty('temperature', -3.1);
+    expect(result.inverter).toHaveProperty('temperature', -31);
+  });
+
+  test('should parse surplus feed-in correctly', () => {
+    // Surplus Feed-In disabled
+    const messageDisabled =
+      'ele_d=349,ele_m=2193,ele_y=0,pv1_p=94,pv1_s=1,pv2_p=77,pv2_s=1,pv3_p=41,pv3_s=1,pv4_p=60,pv4_s=1,grd_o=250,grd_t=1,gct_s=1,cel_s=0,cel_p=424,cel_c=83,err_t=0,wor_m=1,tim_0=12|0|23|59|127|800|1,tim_1=0|0|12|0|127|150|1,tim_2=0|0|0|0|255|0|0,tim_3=0|0|0|0|255|0|0,tim_4=0|0|0|0|255|0|0,cts_m=0,grd_d=285,grd_m=2018,dev_n=134,dev_i=106,dev_m=206,dev_b=209,dev_t=110,wif_s=75,ala_c=0,ful_d=0,ssid=xxxx,stop_s=10,htt_p=0,ct_t=4,phase_t=1,dchrg=1,seq_s=3,ctrl_r=0,shelly_p=1010,c_ratio=100,b_lck=0,dod=88,total_b=1,online_b=1';
+    // Surplus Feed-In enabled
+    const messageEnabled =
+      'ele_d=349,ele_m=2193,ele_y=0,pv1_p=94,pv1_s=1,pv2_p=77,pv2_s=1,pv3_p=41,pv3_s=1,pv4_p=60,pv4_s=1,grd_o=250,grd_t=1,gct_s=1,cel_s=0,cel_p=424,cel_c=83,err_t=0,wor_m=1,tim_0=12|0|23|59|127|800|1,tim_1=0|0|12|0|127|150|1,tim_2=0|0|0|0|255|0|0,tim_3=0|0|0|0|255|0|0,tim_4=0|0|0|0|255|0|0,cts_m=0,grd_d=285,grd_m=2018,dev_n=134,dev_i=106,dev_m=206,dev_b=209,dev_t=110,wif_s=75,ala_c=0,ful_d=1,ssid=xxxx,stop_s=10,htt_p=0,ct_t=4,phase_t=1,dchrg=1,seq_s=3,ctrl_r=0,shelly_p=1010,c_ratio=100,b_lck=0,dod=88,total_b=1,online_b=1';
+    // Surplus Feed-In actively feeding-in surplus
+    const messageActive =
+      'ele_d=349,ele_m=2193,ele_y=0,pv1_p=94,pv1_s=1,pv2_p=77,pv2_s=1,pv3_p=41,pv3_s=1,pv4_p=60,pv4_s=1,grd_o=250,grd_t=1,gct_s=1,cel_s=0,cel_p=424,cel_c=83,err_t=0,wor_m=1,tim_0=12|0|23|59|127|800|1,tim_1=0|0|12|0|127|150|1,tim_2=0|0|0|0|255|0|0,tim_3=0|0|0|0|255|0|0,tim_4=0|0|0|0|255|0|0,cts_m=0,grd_d=285,grd_m=2018,dev_n=134,dev_i=106,dev_m=206,dev_b=209,dev_t=110,wif_s=75,ala_c=0,ful_d=3,ssid=xxxx,stop_s=10,htt_p=0,ct_t=4,phase_t=1,dchrg=1,seq_s=3,ctrl_r=0,shelly_p=1010,c_ratio=100,b_lck=0,dod=88,total_b=1,online_b=1';
+    const deviceType = 'JPLS-1';
+    const deviceId = '12345';
+
+    let parsed = parseMessage(messageDisabled, deviceType, deviceId);
+    expect(parsed).toHaveProperty('data');
+
+    let result = parsed['data'] as B2500V2DeviceData;
+    expect(result).toHaveProperty('surplusFeedInEnabled', false);
+
+    parsed = parseMessage(messageEnabled, deviceType, deviceId);
+    expect(parsed).toHaveProperty('data');
+
+    result = parsed['data'] as B2500V2DeviceData;
+    expect(result).toHaveProperty('surplusFeedInEnabled', true);
+
+    parsed = parseMessage(messageActive, deviceType, deviceId);
+    expect(parsed).toHaveProperty('data');
+
+    result = parsed['data'] as B2500V2DeviceData;
+    expect(result).toHaveProperty('surplusFeedInEnabled', true);
   });
 });

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -14,6 +14,8 @@ import {
   identity,
   map,
   round,
+  highByte,
+  lowByte,
   chain,
   timePeriodField,
   mpptPvField,
@@ -246,6 +248,55 @@ describe('transforms', () => {
     it('should round to specified decimal places', () => {
       expect(executeTransform(round(2), '3.14159')).toBe(3.14);
       expect(executeTransform(round(1), '3.14159')).toBe(3.1);
+    });
+  });
+
+  describe('highByte transform', () => {
+    it('should extract high byte (bits 8-15) from integer', () => {
+      expect(executeTransform(highByte(), '0x1234')).toBe(0); // NaN for hex
+      expect(executeTransform(highByte(), '256')).toBe(1); // 0x0100
+      expect(executeTransform(highByte(), '512')).toBe(2); // 0x0200
+      expect(executeTransform(highByte(), '65280')).toBe(255); // 0xFF00
+      expect(executeTransform(highByte(), '4660')).toBe(18); // 0x1234
+    });
+
+    it('should return 0 for non-numeric values', () => {
+      expect(executeTransform(highByte(), 'invalid')).toBe(0);
+      expect(executeTransform(highByte(), '')).toBe(0);
+    });
+
+    it('should handle zero', () => {
+      expect(executeTransform(highByte(), '0')).toBe(0);
+    });
+
+    it('should generate correct Jinja2 template', () => {
+      expect(transformToJinja2(highByte(), 'value')).toBe(
+        '{{ ((value | int(0)) // 0x100) | bitwise_and(0xff) }}',
+      );
+    });
+  });
+
+  describe('lowByte transform', () => {
+    it('should extract low byte (bits 0-7) from integer', () => {
+      expect(executeTransform(lowByte(), '256')).toBe(0); // 0x0100
+      expect(executeTransform(lowByte(), '257')).toBe(1); // 0x0101
+      expect(executeTransform(lowByte(), '511')).toBe(255); // 0x01FF
+      expect(executeTransform(lowByte(), '4660')).toBe(52); // 0x1234
+    });
+
+    it('should return 0 for non-numeric values', () => {
+      expect(executeTransform(lowByte(), 'invalid')).toBe(0);
+      expect(executeTransform(lowByte(), '')).toBe(0);
+    });
+
+    it('should handle zero', () => {
+      expect(executeTransform(lowByte(), '0')).toBe(0);
+    });
+
+    it('should generate correct Jinja2 template', () => {
+      expect(transformToJinja2(lowByte(), 'value')).toBe(
+        '{{ (value | int(0)) | bitwise_and(0xff) }}',
+      );
     });
   });
 

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -41,6 +41,8 @@ export type Transform =
   | AverageTransform
   | RoundTransform
   | InRangeTransform
+  | HighByteTransform
+  | LowByteTransform
   | TimePeriodFieldTransform
   | MPPTPVFieldTransform
   | BitMaskToWeekdayTransform
@@ -136,6 +138,16 @@ export interface MapTransform {
 export interface RoundTransform {
   type: 'round';
   decimals?: number;
+}
+
+/** Extract high byte (bits 8-15) from an integer value */
+export interface HighByteTransform {
+  type: 'highByte';
+}
+
+/** Extract low byte (bits 0-7) from an integer value */
+export interface LowByteTransform {
+  type: 'lowByte';
 }
 
 /** Chain multiple transforms together */
@@ -260,6 +272,12 @@ export const map = (
 
 /** Create a round transform */
 export const round = (decimals?: number): RoundTransform => ({ type: 'round', decimals });
+
+/** Create a high byte transform */
+export const highByte = (): HighByteTransform => ({ type: 'highByte' });
+
+/** Create a low byte transform */
+export const lowByte = (): LowByteTransform => ({ type: 'lowByte' });
 
 /** Return the numeric value if it is within range, otherwise undefined */
 export interface InRangeTransform {
@@ -396,6 +414,16 @@ export function executeTransform(
       if (transform.decimals === undefined) return Math.round(num);
       const factor = Math.pow(10, transform.decimals);
       return Math.round(num * factor) / factor;
+    }
+
+    case 'highByte': {
+      const num = parseInt(value, 10);
+      return isNaN(num) ? 0 : (num >> 8) & 0xff;
+    }
+
+    case 'lowByte': {
+      const num = parseInt(value, 10);
+      return isNaN(num) ? 0 : num & 0xff;
     }
 
     case 'inRange': {
@@ -614,6 +642,12 @@ export function transformToJinja2(
         return `{{ (${valueExpr} | float(0)) | round }}`;
       }
       return `{{ (${valueExpr} | float(0)) | round(${transform.decimals}) }}`;
+
+    case 'highByte':
+      return `{{ ((${valueExpr} | int(0)) // 0x100) | bitwise_and(0xff) }}`;
+
+    case 'lowByte':
+      return `{{ (${valueExpr} | int(0)) | bitwise_and(0xff) }}`;
 
     case 'inRange':
       // If outside range, return undefined (rendered as "unknown" by HA)

--- a/src/types.ts
+++ b/src/types.ts
@@ -519,7 +519,6 @@ export interface JupiterMPPTPVInfo {
 
 export interface JupiterBMSInfo extends BaseDeviceData {
   cells?: {
-    voltages?: number[]; // vol0-vol15
     temperatures?: number[]; // b_temp0-b_temp3
   };
   bms?: {
@@ -530,8 +529,8 @@ export interface JupiterBMSInfo extends BaseDeviceData {
     current?: number; // b_cur
     temperature?: number; // b_temp
     chargeVoltage?: number; // c_vol
-    chargeCurrent?: number; // c_cur
-    dischargeCurrent?: number; // d_cur
+    chargeCurrentLimit?: number; // c_cur
+    dischargeCurrentLimit?: number; // d_cur
     error?: number; // b_err
     warning?: number; // b_war
     error2?: number; // b_err2
@@ -542,6 +541,14 @@ export interface JupiterBMSInfo extends BaseDeviceData {
     mosfetTemp?: number; // mos_t
     envTemp?: number; // env_t
   };
+  batteries?: {
+    cellVoltages?: {
+      minVoltage?: number; // vol_[x*i+2]
+      minVoltageCell?: number; // vol_[x*i], high byte
+      maxVoltage?: number; // vol_[x*i+1]
+      maxVoltageCell?: number; // vol_[x*i], low byte
+    };
+  }[];
   mppt?: {
     temperature?: number; // m_temp
     error?: number; // m_err


### PR DESCRIPTION
This includes:

1. Change the cell voltage (`volX`) parsing logic to the way it was discussed in #253. Minimum and maximum cell voltages, as well as their corresponding cell numbers, are now in the `cellVoltages` property of `batteries[0..3]` array, which contains 4 values: `minVoltage`, `minVoltageCell`, `maxVoltage`, and `maxVoltageCell`.

    **Breaking change:** The old `cell_voltage_X` sensors were removed.

3. Now definitely fix the surplus feed-in state when device is actively feeding in surplus. The fix introduced in PR #223 was accidentally applied to sending the command instead of reading the state. The command can only have `0` (disable) or `1` (enable), while the state reported by the device can be `0` (disabled), `1` (enabled and inactive), or `3` (enabled and active). It could even be treated bitwise: first bit is `enabled` flag, while the second one is `active` flag. That might actually be the reason why the state doesn't have `2`.

4. Inverter temperature (`i_temp`) shouldn't be divided by 10. Mostly based on observations and sanity: e.g., inverter temperature going from 22° to 45° after activating feed-in at full power (800 W) when outside temperature is above 10° looks much more sane than the same temperature going from 2.2° to 4.5°.

5. Update depth of discharge range to 30% - 90%. Looks like the app was updated with the new range at some point. I moved the bounds to constants at the top of `jupiter.ts` so they can be updated faster if the range changes again. Fixes #260.

6. Again, based on the observations, the `chargeCurrent` (`c_cur`) and `dischargeCurrent` (`d_cur`) sensors are actually charge and discharge current limits. This is supported by the fact that when my battery went over 95%¹ SoC on a sunny day, `c_cur` changed to 75 (7.5 A) and the current (`b_cur`) became clamped at around 7.5~8 A. `c_cur` will even go to zero when battery reaches 100% SoC, which will cause the device to stop taking any PV power until SoC goes to 99% or lower.

    **Breaking change:** The sensors were renamed to `chargeCurrentLimit` and `dischargeCurrentLimit`.

¹ - I don't remember exactly, but it was either 95% or 90%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected inverter temperature scaling for accurate readings.
  * Expanded Depth-of-Discharge validation and warning to 30–90%.
  * Improved surplus feed‑in detection to recognize additional true-like values.
  * Renamed BMS current fields to reflect current limits and clarified units (now in amps).

* **New Features**
  * Introduced derived battery sensors reporting highest/lowest cell voltages across multiple batteries (disabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->