### PR TITLE
Add monotonic counter guard to suppress transient corrupt readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- Filter transient corrupt readings in cumulative energy counters: a single backward jump (e.g. a dropped digit from the battery) is now suppressed until a following reading confirms it, so genuine period resets still pass through but glitches no longer poison Home Assistant statistics (fixes #296)
 - Venus: Treat out-of-range/sentinel `mcp_w` values (e.g. -1) as unknown for the *Maximum Charging Power* entity to avoid Home Assistant log spam (#240)
 - B2500: Fix `Surplus Feed-in` entity missing for `HMJ-*` devices (firmware 108+) (fixes #235, #242)
 - B2500: Fix time period 5 control topics not being processed and normalize time format in timer commands (fixes #244)

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -352,6 +352,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'bc',
       path: ['dailyStats', 'batteryChargingPower'],
       transform: number(),
+      monotonic: true,
     });
     advertise(
       ['dailyStats', 'batteryChargingPower'],
@@ -367,6 +368,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'bs',
       path: ['dailyStats', 'batteryDischargePower'],
       transform: number(),
+      monotonic: true,
     });
     advertise(
       ['dailyStats', 'batteryDischargePower'],
@@ -382,6 +384,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'pt',
       path: ['dailyStats', 'photovoltaicChargingPower'],
       transform: number(),
+      monotonic: true,
     });
     advertise(
       ['dailyStats', 'photovoltaicChargingPower'],
@@ -397,6 +400,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'it',
       path: ['dailyStats', 'microReverseOutputPower'],
       transform: number(),
+      monotonic: true,
     });
     advertise(
       ['dailyStats', 'microReverseOutputPower'],

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -151,7 +151,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    field({ key: 'ele_d', path: ['dailyChargingCapacity'], transform: divide(100) });
+    field({
+      key: 'ele_d',
+      path: ['dailyChargingCapacity'],
+      transform: divide(100),
+      monotonic: true,
+    });
     advertise(
       ['dailyChargingCapacity'],
       sensorComponent<number>({
@@ -162,7 +167,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         state_class: 'total_increasing',
       }),
     );
-    field({ key: 'ele_m', path: ['monthlyChargingCapacity'], transform: divide(100) });
+    field({
+      key: 'ele_m',
+      path: ['monthlyChargingCapacity'],
+      transform: divide(100),
+      monotonic: true,
+    });
     advertise(
       ['monthlyChargingCapacity'],
       sensorComponent<number>({
@@ -173,7 +183,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         state_class: 'total_increasing',
       }),
     );
-    field({ key: 'ele_y', path: ['yearlyChargingCapacity'], transform: divide(100) });
+    field({
+      key: 'ele_y',
+      path: ['yearlyChargingCapacity'],
+      transform: divide(100),
+      monotonic: true,
+    });
     advertise(
       ['yearlyChargingCapacity'],
       sensorComponent<number>({
@@ -228,7 +243,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         state_class: 'measurement',
       }),
     );
-    field({ key: 'grd_d', path: ['dailyDischargeCapacity'], transform: divide(100) });
+    field({
+      key: 'grd_d',
+      path: ['dailyDischargeCapacity'],
+      transform: divide(100),
+      monotonic: true,
+    });
     advertise(
       ['dailyDischargeCapacity'],
       sensorComponent<number>({
@@ -243,6 +263,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'grd_m',
       path: ['monthlyDischargeCapacity'],
       transform: divide(100),
+      monotonic: true,
     });
     advertise(
       ['monthlyDischargeCapacity'],

--- a/src/device/mi800.ts
+++ b/src/device/mi800.ts
@@ -70,7 +70,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     );
 
     // Energy statistics - divide by 100 to convert to kWh
-    field({ key: 'ele_d', path: ['dailyEnergyGenerated'], transform: divide(100) });
+    field({
+      key: 'ele_d',
+      path: ['dailyEnergyGenerated'],
+      transform: divide(100),
+      monotonic: true,
+    });
     advertise(
       ['dailyEnergyGenerated'],
       sensorComponent<number>({
@@ -82,7 +87,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    field({ key: 'ele_w', path: ['weeklyEnergyGenerated'], transform: divide(100) });
+    field({
+      key: 'ele_w',
+      path: ['weeklyEnergyGenerated'],
+      transform: divide(100),
+      monotonic: true,
+    });
     advertise(
       ['weeklyEnergyGenerated'],
       sensorComponent<number>({
@@ -94,7 +104,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    field({ key: 'ele_m', path: ['monthlyEnergyGenerated'], transform: divide(100) });
+    field({
+      key: 'ele_m',
+      path: ['monthlyEnergyGenerated'],
+      transform: divide(100),
+      monotonic: true,
+    });
     advertise(
       ['monthlyEnergyGenerated'],
       sensorComponent<number>({
@@ -106,7 +121,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    field({ key: 'ele_s', path: ['totalEnergyGenerated'], transform: divide(100) });
+    field({
+      key: 'ele_s',
+      path: ['totalEnergyGenerated'],
+      transform: divide(100),
+      monotonic: true,
+    });
     advertise(
       ['totalEnergyGenerated'],
       sensorComponent<number>({

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -209,6 +209,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'tot_i',
       path: ['totalChargingCapacity'],
       transform: divide(100), // Convert to kWh
+      monotonic: true,
     });
     advertise(
       ['totalChargingCapacity'],
@@ -225,6 +226,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'tot_o',
       path: ['totalDischargeCapacity'],
       transform: divide(100), // Convert to kWh
+      monotonic: true,
     });
     advertise(
       ['totalDischargeCapacity'],
@@ -241,6 +243,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'ele_d',
       path: ['dailyChargingCapacity'],
       transform: divide(100), // Convert to kWh
+      monotonic: true,
     });
     advertise(
       ['dailyChargingCapacity'],
@@ -257,6 +260,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'ele_m',
       path: ['monthlyChargingCapacity'],
       transform: divide(100), // Convert to kWh
+      monotonic: true,
     });
     advertise(
       ['monthlyChargingCapacity'],
@@ -273,6 +277,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'grd_d',
       path: ['dailyDischargeCapacity'],
       transform: divide(100), // Convert to kWh
+      monotonic: true,
     });
     advertise(
       ['dailyDischargeCapacity'],
@@ -289,6 +294,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'grd_m',
       path: ['monthlyDischargeCapacity'],
       transform: divide(100), // Convert to kWh
+      monotonic: true,
     });
     advertise(
       ['monthlyDischargeCapacity'],

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -70,6 +70,13 @@ export type FieldDefinition<
   key: K;
   path: KP;
   transform?: TransformSpec<K, TypeAtPath<T, KP>>;
+  /**
+   * Marks a never-decreasing cumulative counter. When set, a reading lower than
+   * the last good value is rejected unless a subsequent reading confirms the
+   * drop (see the monotonic guard in DeviceManager.updateDeviceState). Protects
+   * Home Assistant `total_increasing` sensors from transient corrupt readings.
+   */
+  monotonic?: boolean;
 } & (TypeAtPath<T, KP> extends number | undefined
   ? {}
   : {

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -180,4 +180,79 @@ describe('DeviceManager', () => {
     expect(topics?.deviceTopicNew).toBe('marstek_energy/HMB-1/device/test123/ctrl');
     expect(topics?.deviceControlTopicNew).toBe('marstek_energy/HMB-1/App/test123/ctrl');
   });
+
+  describe('monotonic counter guard', () => {
+    const venusConfig: MqttConfig = {
+      brokerUrl: 'mqtt://localhost',
+      clientId: 'test-client',
+      topicPrefix: DEFAULT_TOPIC_PREFIX,
+      autodiscoveryTopicPrefix: 'homeassistant',
+      devices: [{ deviceType: 'VNSE3-0', deviceId: 'venus123' }],
+    };
+
+    let dm: DeviceManager;
+    const device = venusConfig.devices[0];
+
+    beforeEach(() => {
+      dm = new DeviceManager(venusConfig, jest.fn());
+    });
+
+    const setCharging = (totalChargingCapacity: number) =>
+      dm.updateDeviceState(device, 'data', () => ({ totalChargingCapacity }));
+    const setDaily = (dailyChargingCapacity: number) =>
+      dm.updateDeviceState(device, 'data', () => ({ dailyChargingCapacity }));
+    const charging = () => (dm.getDeviceState(device) as any).totalChargingCapacity;
+    const daily = () => (dm.getDeviceState(device) as any).dailyChargingCapacity;
+
+    it('accepts the first reading', () => {
+      setCharging(339.93);
+      expect(charging()).toBe(339.93);
+    });
+
+    it('accepts normal non-decreasing readings', () => {
+      setCharging(339.93);
+      setCharging(340.5);
+      expect(charging()).toBe(340.5);
+    });
+
+    it('suppresses a single corrupt backward jump and recovers', () => {
+      setCharging(339.93);
+      setCharging(33.99); // dropped-digit corruption
+      expect(charging()).toBe(339.93); // rejected, last good value kept
+      setCharging(339.93); // next poll recovers
+      expect(charging()).toBe(339.93);
+    });
+
+    it('accepts a genuine reset once a following reading confirms it', () => {
+      setDaily(5.0);
+      setDaily(0.1); // first drop -> rejected pending confirmation
+      expect(daily()).toBe(5.0);
+      setDaily(0.2); // second consecutive low reading -> confirmed reset
+      expect(daily()).toBe(0.2);
+    });
+
+    it('clears the pending drop when the value recovers before confirmation', () => {
+      setDaily(5.0);
+      setDaily(0.5); // glitch -> rejected
+      expect(daily()).toBe(5.0);
+      setDaily(5.1); // recovery resets the confirmation counter
+      expect(daily()).toBe(5.1);
+      setDaily(0.5); // a later isolated glitch must again be rejected (count reset)
+      expect(daily()).toBe(5.1);
+    });
+
+    it('guards nested cumulative paths without dropping sibling fields', () => {
+      const b2500 = new DeviceManager(mockConfig, jest.fn());
+      const hma = mockConfig.devices[0];
+      b2500.updateDeviceState(hma, 'data', () => ({
+        dailyStats: { batteryChargingPower: 100, batteryDischargePower: 50 },
+      }));
+      b2500.updateDeviceState(hma, 'data', () => ({
+        dailyStats: { batteryChargingPower: 10, batteryDischargePower: 60 },
+      }));
+      const stats = (b2500.getDeviceState(hma) as any).dailyStats;
+      expect(stats.batteryChargingPower).toBe(100); // corrupt drop rejected
+      expect(stats.batteryDischargePower).toBe(60); // sibling increase preserved
+    });
+  });
 });

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -1,7 +1,21 @@
 import { Device, MqttConfig } from './types';
-import { getDeviceDefinition, extractBaseType, getSuggestedDeviceType } from './deviceDefinition';
+import {
+  getDeviceDefinition,
+  extractBaseType,
+  getSuggestedDeviceType,
+  FieldDefinition,
+  KeyPath,
+} from './deviceDefinition';
 import { calculateNewVersionTopicId, decryptNewVersionTopicId } from './utils/crypt';
 import logger from './logger';
+
+/**
+ * Number of confirming readings (beyond the first drop) required before a
+ * backward jump in a `monotonic` counter is accepted as a genuine reset.
+ * A transient corrupt reading recovers on the next poll and is rejected; a real
+ * period reset persists and is accepted once confirmed.
+ */
+const MONOTONIC_RESET_CONFIRMATIONS = 1;
 
 /**
  * Interface for device state data
@@ -34,6 +48,8 @@ export class DeviceManager {
   private deviceTopics: Record<DeviceKey, DeviceTopics> = {};
   private deviceStates: Record<DeviceKey, Record<string, DeviceStateData> | undefined> = {};
   private deviceResponseTimeouts: Record<DeviceKey, NodeJS.Timeout[]> = {};
+  // Consecutive below-previous reading counts per device, per monotonic field id.
+  private monotonicBelowCount: Record<DeviceKey, Record<string, number>> = {};
   private readonly encryptedDeviceTypes = new Set(['HMA', 'HMF', 'HMK', 'HMJ']);
 
   constructor(
@@ -164,9 +180,11 @@ export class DeviceManager {
     updater: (state: DeviceStateData) => T,
   ): DeviceStateData & T {
     const deviceKey = this.getDeviceKey(device);
+    const candidate = updater(this.getDeviceStateForPath(device, path));
+    this.guardMonotonicFields(device, path, this.getDeviceStateForPath(device, path), candidate);
     let newDeviceState: T = {
       ...this.getDeviceStateForPath(device, path),
-      ...updater(this.getDeviceStateForPath(device, path)),
+      ...candidate,
     };
     this.deviceStates[deviceKey] = {
       ...this.deviceStates[deviceKey],
@@ -174,6 +192,62 @@ export class DeviceManager {
     };
     this.onUpdateState(device, path, newDeviceState);
     return newDeviceState as DeviceStateData & T;
+  }
+
+  /**
+   * Suppress transient corrupt backward jumps in cumulative (`monotonic`)
+   * counters. A reading lower than the last good value is rejected — the last
+   * good value is written back into the candidate — until a subsequent reading
+   * confirms the drop persists, at which point it is accepted as a genuine
+   * period reset. Mutates `candidate` in place.
+   */
+  private guardMonotonicFields(
+    device: Device,
+    path: string,
+    prevState: DeviceStateData | undefined,
+    candidate: DeviceStateData | undefined,
+  ): void {
+    if (candidate == null) {
+      return;
+    }
+    const fields =
+      getDeviceDefinition(device.deviceType)?.messages.find(msg => msg.publishPath === path)
+        ?.fields ?? [];
+    const deviceKey = this.getDeviceKey(device);
+
+    for (const field of fields) {
+      if (!field.monotonic) {
+        continue;
+      }
+      const fieldPath = (field as FieldDefinition<any, KeyPath<any>>).path;
+      const nextVal = getAtPath(candidate, fieldPath);
+      if (typeof nextVal !== 'number' || !Number.isFinite(nextVal)) {
+        continue;
+      }
+
+      const fieldId = `${path}|${fieldPath.join('.')}`;
+      const prevVal = getAtPath(prevState, fieldPath);
+      const counts = (this.monotonicBelowCount[deviceKey] ??= {});
+
+      if (typeof prevVal !== 'number' || !Number.isFinite(prevVal) || nextVal >= prevVal) {
+        // First good reading, or a normal non-decreasing value: accept.
+        delete counts[fieldId];
+        continue;
+      }
+
+      // Backward jump.
+      const count = (counts[fieldId] ?? 0) + 1;
+      if (count > MONOTONIC_RESET_CONFIRMATIONS) {
+        // Drop confirmed across consecutive readings: accept as a genuine reset.
+        delete counts[fieldId];
+        continue;
+      }
+      counts[fieldId] = count;
+      logger.warn(
+        `Rejecting backward jump for ${device.deviceType}:${device.deviceId} ${fieldPath.join('.')}: ${prevVal} -> ${nextVal} (keeping previous value, awaiting confirmation)`,
+      );
+      setAtPath(candidate, fieldPath, prevVal);
+    }
   }
 
   /**
@@ -308,4 +382,33 @@ export class DeviceManager {
   getResponseTimeout(): number {
     return this.config.responseTimeout || 15000; // Default to 15 seconds if not specified
   }
+}
+
+/**
+ * Read the value at a nested path, or undefined if any segment is missing.
+ */
+function getAtPath(obj: unknown, path: ReadonlyArray<string | number>): unknown {
+  let current: any = obj;
+  for (const key of path) {
+    if (current == null) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+/**
+ * Set the value at a nested path, creating intermediate objects as needed.
+ */
+function setAtPath(obj: any, path: ReadonlyArray<string | number>, value: unknown): void {
+  let current = obj;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    if (current[key] == null) {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+  current[path[path.length - 1]] = value;
 }

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,5 +1,11 @@
 import { parseMessage } from './parser';
-import { B2500V2DeviceData, JupiterBMSInfo, JupiterDeviceData, MI800DeviceData } from './types';
+import {
+  B2500V2DeviceData,
+  JupiterBMSInfo,
+  JupiterDeviceData,
+  MI800DeviceData,
+  VenusDeviceData,
+} from './types';
 
 describe('MQTT Message Parser', () => {
   test('should parse comma-separated key-value pairs correctly', () => {
@@ -578,5 +584,19 @@ describe('MQTT Message Parser', () => {
 
     result = parsed['data'] as B2500V2DeviceData;
     expect(result).toHaveProperty('surplusFeedInEnabled', true);
+  });
+
+  test('parses a corrupt Venus reading verbatim (suppression is the guard’s job, not the parser’s)', () => {
+    // A real dropped-trailing-digit reading from issue #296: tot_i=3399 (vs 33993),
+    // tot_o=4318 (vs 43187). The parser must not hide the bad value; the monotonic
+    // guard in DeviceManager is responsible for rejecting it.
+    const message =
+      'cd=1,tot_i=3399,tot_o=4318,ele_d=3399,ele_m=3399,grd_d=4318,grd_m=4318,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=100,err_a=4,dev_n=148,grd_y=0,wor_m=0,tim_0=0|0|0|0|0|0|0,cts_m=0,bac_u=0,tra_a=75,tra_i=0,tra_o=0,htt_p=0,prc_c=0,prc_d=3,wif_s=35,inc_a=0,set_v=0,mcp_w=2500,mdp_w=2500,ct_t=3,phase_t=1,dchrg_t=1,bms_v=113,fc_v=202409090159,wifi_n=maekan,seq_s=3,ctrl_r=0,par=0,gen=0,ble=1,shelly_p=1010,c_ratio=100';
+    const parsed = parseMessage(message, 'VNSE3-0', 'venus123');
+
+    expect(parsed).toHaveProperty('data');
+    const result = parsed['data'] as VenusDeviceData;
+    expect(result).toHaveProperty('totalChargingCapacity', 33.99);
+    expect(result).toHaveProperty('totalDischargeCapacity', 43.18);
   });
 });


### PR DESCRIPTION
## Summary
Implements a monotonic counter guard in `DeviceManager` to suppress transient corrupt backward jumps in cumulative counters while accepting genuine period resets. This protects Home Assistant `total_increasing` sensors from isolated corrupt readings that would otherwise break their monotonic invariant.

## Key Changes

- **Added monotonic field guard logic** (`guardMonotonicFields` method in `DeviceManager`):
  - Tracks consecutive below-previous readings per device and field
  - Rejects isolated backward jumps by restoring the previous good value
  - Accepts genuine resets once confirmed by a subsequent reading at the same low level
  - Clears confirmation counter when value recovers, requiring re-confirmation for later drops

- **Added helper utilities** for nested path access:
  - `getAtPath()`: Safely reads values from nested object paths
  - `setAtPath()`: Sets values at nested paths, creating intermediate objects as needed

- **Marked cumulative fields as monotonic** across device definitions:
  - Venus: `totalChargingCapacity`, `totalDischargeCapacity`, daily/monthly variants
  - Jupiter: `dailyChargingCapacity`, `monthlyChargingCapacity`, `yearlyChargingCapacity`, discharge variants
  - MI800: `dailyEnergyGenerated`, `weeklyEnergyGenerated`, `monthlyEnergyGenerated`, `totalEnergyGenerated`
  - B2500V2: `batteryChargingPower`, `batteryDischargePower` (nested in `dailyStats`)

- **Added comprehensive test coverage**:
  - Tests for first reading acceptance, normal non-decreasing sequences
  - Tests for single corrupt jump suppression and recovery
  - Tests for genuine reset confirmation across consecutive readings
  - Tests for confirmation counter reset on value recovery
  - Tests for nested field guarding without affecting sibling fields
  - Parser test verifying corrupt readings are parsed verbatim (guard's responsibility, not parser's)

## Implementation Details

- Confirmation threshold is configurable via `MONOTONIC_RESET_CONFIRMATIONS` constant (currently 1)
- Guard operates on candidate state before committing to device state
- Mutates candidate in place to avoid unnecessary object allocations
- Tracks state per device and per field using composite key (`path|fieldPath`)
- Works with both flat and nested field paths

https://claude.ai/code/session_01R1WJE8zUZ4taXSmrWExR5x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cumulative energy counter glitches that were corrupting Home Assistant statistics. Transient backward jumps in readings (e.g., dropped digits) are now suppressed, while genuine period resets continue to be recognized and applied correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/hm2mqtt/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->