### PR TITLE
fix(ci): prevent duplicate needs-logs comment via concurrency group

### DIFF
--- a/.github/workflows/bug-needs-logs.yml
+++ b/.github/workflows/bug-needs-logs.yml
@@ -7,6 +7,13 @@ on:
 permissions:
   issues: write
 
+# Serialize runs per issue so the "opened" and "labeled" events (which both
+# fire when an issue is created from the bug template that auto-applies the
+# "bug" label) don't race past the duplicate-comment check and post twice.
+concurrency:
+  group: needs-logs-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   ask-for-logs:
     # Only run when the issue has the "bug" label


### PR DESCRIPTION
## Problem

The "Bug reports: ask for logs" workflow posted its needs-logs comment **twice** on new bug issues (e.g. [#301](https://github.com/tomquist/hm2mqtt/issues/301), where both comments landed at the exact same second).

### Root cause

The workflow triggers on both `opened` and `labeled` events:

```yaml
on:
  issues:
    types: [opened, labeled]
```

The bug report template auto-applies the `bug` label at creation (`labels: bug` in `bug_report.yml`). So opening a bug issue fires **two events nearly simultaneously**:

- `opened` — the issue already carries the `bug` label, so the `if: contains(...'bug')` guard passes
- `labeled` — for the `bug` label being added, which also passes

Both workflow runs execute concurrently. The dedup guard reads existing comments before posting:

```js
const alreadyCommented = comments.some(c => (c.body || '').includes(marker));
if (alreadyCommented) { return; }
```

But because both runs call `listComments` *before* either has posted, neither sees the other's comment — they both pass the guard and both post. Classic time-of-check/time-of-use race.

## Fix

Add a per-issue `concurrency` group with `cancel-in-progress: false` so the two runs serialize instead of racing. The second run then sees the first run's comment and exits via the existing marker check.

```yaml
concurrency:
  group: needs-logs-${{ github.event.issue.number }}
  cancel-in-progress: false
```

This keeps the workflow's intended behavior (it still comments when `bug` is added to an existing issue later) while eliminating the duplicate.

https://claude.ai/code/session_01LbUwPrMSeQ6mEKkXdoYNtG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbUwPrMSeQ6mEKkXdoYNtG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved GitHub workflow efficiency for bug report processing. Enhanced concurrency handling prevents duplicate executions when bug reports are simultaneously opened and labeled, ensuring more reliable automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->