### PR TITLE
Rename MI800 to HMI inverter and add 4-PV support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Log the build commit hash at application startup to make it easier to verify which exact source revision a running container/add-on was built from
 - Add configurable Home Assistant MQTT discovery topic prefix via `AUTODISCOVERY_TOPIC_PREFIX` (add-on option: `autodiscoveryTopicPrefix`, default: `homeassistant`) (#248)
 - Include `connections` field with formatted MAC address in device discovery payloads, allowing Home Assistant to correlate devices by their Bluetooth address
+- HMI inverter: Support 4-PV variants such as the HMI-2000 by adding PV3/PV4 voltage, current, power and status sensors. These are only advertised when the device actually reports them, so 2-PV inverters (e.g. MI800) are unaffected. Also expose the Bluetooth signal and WiFi RSSI diagnostics already received from these devices (fixes #301)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ hm2mqtt is a bridge application that connects Hame energy storage devices (like 
 - Marstek Jupiter E
 - Marstek Jupiter Plus
 - Marstek CT002 Smart Meter
-- Marstek MI800 Micro Inverter
+- Marstek HMI micro inverters (MI800, HMI-2000 with 4 PV inputs)
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ hm2mqtt is a bridge application that connects Hame energy storage devices (like 
    
      **Warning:** Enabling MQTT on the device will disable the cloud connection. You will not be able to use the PowerZero or Marstek app to monitor or control your device anymore. You can re-enable the cloud connection by installing [Hame Relay](https://github.com/tomquist/hame-relay#mode-1-storage-configured-with-local-broker-inverse_forwarding-false) in Mode 1.
   2. The **Marstek Venus**, **Marstek Jupiter** and **Jupiter Plus** don't officially support MQTT. However, you can install the [Hame Relay](https://github.com/tomquist/hame-relay) in [Mode 2](https://github.com/tomquist/hame-relay#mode-2-storage-configured-with-hame-broker-inverse_forwarding-true) to forward the Cloud MQTT data to your local MQTT broker.
-  3. The **Marstek MI800 Micro Inverter** requires the same setup as Venus/Jupiter devices. Use [Hame Relay](https://github.com/tomquist/hame-relay) in [Mode 2](https://github.com/tomquist/hame-relay#mode-2-storage-configured-with-hame-broker-inverse_forwarding-true) to forward the Cloud MQTT data to your local MQTT broker.
+  3. The **Marstek HMI micro inverters** (MI800, HMI-2000) require the same setup as Venus/Jupiter devices. Use [Hame Relay](https://github.com/tomquist/hame-relay) in [Mode 2](https://github.com/tomquist/hame-relay#mode-2-storage-configured-with-hame-broker-inverse_forwarding-true) to forward the Cloud MQTT data to your local MQTT broker.
   
 ## Installation
 
@@ -324,7 +324,7 @@ The device type can be one of the following:
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus
 - **HME-X**: (e.g. HME-3) Marstek CT002 Smart Meter
-- **HMI-X**: (e.g. HMI-1) Marstek MI800 Micro Inverter
+- **HMI-X**: (e.g. HMI-1) Marstek HMI micro inverters, including the MI800 and the 4-PV HMI-2000
 
 ## Using the Development Version
 

--- a/src/device/hmiInverter.ts
+++ b/src/device/hmiInverter.ts
@@ -1,5 +1,5 @@
 import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
-import { CommandParams, MI800DeviceData, isValidMI800Mode } from '../types';
+import { CommandParams, HmiInverterDeviceData, isValidHmiInverterMode } from '../types';
 import {
   sensorComponent,
   binarySensorComponent,
@@ -10,7 +10,7 @@ import {
 import { number, divide, identity, equalsBoolean, map } from '../transforms';
 
 /**
- * Command types supported by the MI800 device
+ * Command types supported by the HMI inverter (Marstek HMI family)
  */
 enum CommandType {
   READ_DEVICE_INFO = 1, // -> ele_d=53,ele_w=3984,ele_m=3984,pv1_v=335,pv1_i=3,pv1_p=39,pv1_s=1,pv2_v=341,pv2_i=11,pv2_p=38,pv2_s=1,pe1_v=17,fb1_v=832,fb2_v=773,grd_f=5001,grd_v=2543,grd_s=1,grd_o=72,chp_t=36,rel_s=1,err_t=0,err_c=0,err_d=0,ver_s=106,mpt_m=1,ble_s=2
@@ -27,9 +27,9 @@ function processCommand(command: CommandType, params: CommandParams = {}): strin
 }
 
 /**
- * Check if the message is an MI800 runtime info message
+ * Check if the message is an HMI inverter runtime info message
  */
-function isMI800RuntimeInfoMessage(values: Record<string, string>): boolean {
+function isHmiInverterRuntimeInfoMessage(values: Record<string, string>): boolean {
   return (
     'ele_d' in values &&
     'pv1_v' in values &&
@@ -47,17 +47,17 @@ function isMI800RuntimeInfoMessage(values: Record<string, string>): boolean {
 function registerRuntimeInfoMessage(message: BuildMessageFn) {
   const options = {
     refreshDataPayload: 'cd=1',
-    isMessage: isMI800RuntimeInfoMessage,
+    isMessage: isHmiInverterRuntimeInfoMessage,
     publishPath: 'data',
     defaultState: {},
-    getAdditionalDeviceInfo: (state: MI800DeviceData) => ({
+    getAdditionalDeviceInfo: (state: HmiInverterDeviceData) => ({
       firmwareVersion: state.firmwareVersion?.toString(),
     }),
     pollInterval: globalPollInterval,
     controlsDeviceAvailability: true,
   };
 
-  message<MI800DeviceData>(options, ({ field, advertise, command }) => {
+  message<HmiInverterDeviceData>(options, ({ field, advertise, command }) => {
     // Timestamp
     advertise(
       ['timestamp'],
@@ -232,6 +232,108 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
+    // PV Input 3 - only present on 4-PV variants (e.g. HMI-2000); gate discovery on data presence
+    field({ key: 'pv3_v', path: ['pv3Voltage'], transform: divide(10) });
+    advertise(
+      ['pv3Voltage'],
+      sensorComponent<number>({
+        id: 'pv3_voltage',
+        name: 'PV3 Voltage',
+        device_class: 'voltage',
+        unit_of_measurement: 'V',
+        state_class: 'measurement',
+      }),
+      { enabled: (state: HmiInverterDeviceData) => (state.pv3Voltage != null ? true : undefined) },
+    );
+
+    field({ key: 'pv3_i', path: ['pv3Current'], transform: divide(10) });
+    advertise(
+      ['pv3Current'],
+      sensorComponent<number>({
+        id: 'pv3_current',
+        name: 'PV3 Current',
+        device_class: 'current',
+        unit_of_measurement: 'A',
+        state_class: 'measurement',
+      }),
+      { enabled: (state: HmiInverterDeviceData) => (state.pv3Current != null ? true : undefined) },
+    );
+
+    field({ key: 'pv3_p', path: ['pv3Power'], transform: number() });
+    advertise(
+      ['pv3Power'],
+      sensorComponent<number>({
+        id: 'pv3_power',
+        name: 'PV3 Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+      { enabled: (state: HmiInverterDeviceData) => (state.pv3Power != null ? true : undefined) },
+    );
+
+    field({ key: 'pv3_s', path: ['pv3Status'], transform: equalsBoolean('1') });
+    advertise(
+      ['pv3Status'],
+      binarySensorComponent({
+        id: 'pv3_status',
+        name: 'PV3 Active',
+        device_class: 'power',
+      }),
+      { enabled: (state: HmiInverterDeviceData) => (state.pv3Status != null ? true : undefined) },
+    );
+
+    // PV Input 4 - only present on 4-PV variants (e.g. HMI-2000); gate discovery on data presence
+    field({ key: 'pv4_v', path: ['pv4Voltage'], transform: divide(10) });
+    advertise(
+      ['pv4Voltage'],
+      sensorComponent<number>({
+        id: 'pv4_voltage',
+        name: 'PV4 Voltage',
+        device_class: 'voltage',
+        unit_of_measurement: 'V',
+        state_class: 'measurement',
+      }),
+      { enabled: (state: HmiInverterDeviceData) => (state.pv4Voltage != null ? true : undefined) },
+    );
+
+    field({ key: 'pv4_i', path: ['pv4Current'], transform: divide(10) });
+    advertise(
+      ['pv4Current'],
+      sensorComponent<number>({
+        id: 'pv4_current',
+        name: 'PV4 Current',
+        device_class: 'current',
+        unit_of_measurement: 'A',
+        state_class: 'measurement',
+      }),
+      { enabled: (state: HmiInverterDeviceData) => (state.pv4Current != null ? true : undefined) },
+    );
+
+    field({ key: 'pv4_p', path: ['pv4Power'], transform: number() });
+    advertise(
+      ['pv4Power'],
+      sensorComponent<number>({
+        id: 'pv4_power',
+        name: 'PV4 Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+      { enabled: (state: HmiInverterDeviceData) => (state.pv4Power != null ? true : undefined) },
+    );
+
+    field({ key: 'pv4_s', path: ['pv4Status'], transform: equalsBoolean('1') });
+    advertise(
+      ['pv4Status'],
+      binarySensorComponent({
+        id: 'pv4_status',
+        name: 'PV4 Active',
+        device_class: 'power',
+      }),
+      { enabled: (state: HmiInverterDeviceData) => (state.pv4Status != null ? true : undefined) },
+    );
+
     // Grid information
     field({ key: 'grd_f', path: ['gridFrequency'], transform: divide(100) });
     advertise(
@@ -356,6 +458,28 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
+    // Connectivity diagnostics
+    field({ key: 'ble_s', path: ['bluetoothSignal'], transform: number() });
+    advertise(
+      ['bluetoothSignal'],
+      sensorComponent<number>({
+        id: 'bluetooth_signal',
+        name: 'Bluetooth Signal',
+      }),
+    );
+
+    field({ key: 'wif_r', path: ['wifiRssi'], transform: number() });
+    advertise(
+      ['wifiRssi'],
+      sensorComponent<number>({
+        id: 'wifi_rssi',
+        name: 'WiFi RSSI',
+        device_class: 'signal_strength',
+        unit_of_measurement: 'dBm',
+        state_class: 'measurement',
+      }),
+    );
+
     // Mode - use map transform for string mappings
     field({
       key: 'mpt_m',
@@ -371,7 +495,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     });
     advertise(
       ['mode'],
-      selectComponent<NonNullable<MI800DeviceData['mode']>>({
+      selectComponent<NonNullable<HmiInverterDeviceData['mode']>>({
         id: 'mode',
         name: 'Mode',
         icon: 'mdi:cog',
@@ -408,7 +532,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
 
     command('mode', {
       handler: ({ message, publishCallback, updateDeviceState }) => {
-        if (!isValidMI800Mode(message)) {
+        if (!isValidHmiInverterMode(message)) {
           return;
         }
 
@@ -442,7 +566,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
   });
 }
 
-// Register the MI800 device
+// Register the HMI inverter device
 registerDeviceDefinition(
   {
     deviceTypes: ['HMI'],

--- a/src/device/registry.ts
+++ b/src/device/registry.ts
@@ -3,4 +3,4 @@ import './b2500V2';
 import './venus';
 import './jupiter';
 import './ct002';
-import './mi800';
+import './hmiInverter';

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1034,33 +1034,33 @@ const commandTestCases: CommandTestCase[] = [
   },
 
   // ============================================================
-  // MI800 (HMI) COMMANDS
+  // HMI INVERTER COMMANDS
   // ============================================================
 
   // max-output-power command
   {
-    description: 'MI800 max-output-power valid',
+    description: 'HMI inverter max-output-power valid',
     deviceType: 'HMI-1',
     command: 'max-output-power',
     input: '500',
     expectedOutput: 'cd=8,p1=500',
   },
   {
-    description: 'MI800 max-output-power minimum',
+    description: 'HMI inverter max-output-power minimum',
     deviceType: 'HMI-1',
     command: 'max-output-power',
     input: '0',
     expectedOutput: 'cd=8,p1=0',
   },
   {
-    description: 'MI800 max-output-power maximum',
+    description: 'HMI inverter max-output-power maximum',
     deviceType: 'HMI-1',
     command: 'max-output-power',
     input: '800',
     expectedOutput: 'cd=8,p1=800',
   },
   {
-    description: 'MI800 max-output-power non-numeric (no validation in handler)',
+    description: 'HMI inverter max-output-power non-numeric (no validation in handler)',
     deviceType: 'HMI-1',
     command: 'max-output-power',
     input: 'abc',
@@ -1069,28 +1069,28 @@ const commandTestCases: CommandTestCase[] = [
 
   // mode command
   {
-    description: 'MI800 mode default',
+    description: 'HMI inverter mode default',
     deviceType: 'HMI-1',
     command: 'mode',
     input: 'default',
     expectedOutput: 'cd=11,p1=0',
   },
   {
-    description: 'MI800 mode b2500Boost',
+    description: 'HMI inverter mode b2500Boost',
     deviceType: 'HMI-1',
     command: 'mode',
     input: 'b2500Boost',
     expectedOutput: 'cd=11,p1=1',
   },
   {
-    description: 'MI800 mode reverseCurrentProtection',
+    description: 'HMI inverter mode reverseCurrentProtection',
     deviceType: 'HMI-1',
     command: 'mode',
     input: 'reverseCurrentProtection',
     expectedOutput: 'cd=11,p1=2',
   },
   {
-    description: 'MI800 mode invalid',
+    description: 'HMI inverter mode invalid',
     deviceType: 'HMI-1',
     command: 'mode',
     input: 'invalid',
@@ -1099,28 +1099,28 @@ const commandTestCases: CommandTestCase[] = [
 
   // grid-connection-ban command
   {
-    description: 'MI800 grid-connection-ban enable',
+    description: 'HMI inverter grid-connection-ban enable',
     deviceType: 'HMI-1',
     command: 'grid-connection-ban',
     input: 'true',
     expectedOutput: 'cd=22,p1=1',
   },
   {
-    description: 'MI800 grid-connection-ban disable',
+    description: 'HMI inverter grid-connection-ban disable',
     deviceType: 'HMI-1',
     command: 'grid-connection-ban',
     input: 'false',
     expectedOutput: 'cd=22,p1=0',
   },
   {
-    description: 'MI800 grid-connection-ban with on',
+    description: 'HMI inverter grid-connection-ban with on',
     deviceType: 'HMI-1',
     command: 'grid-connection-ban',
     input: 'on',
     expectedOutput: 'cd=22,p1=1',
   },
   {
-    description: 'MI800 grid-connection-ban with 1',
+    description: 'HMI inverter grid-connection-ban with 1',
     deviceType: 'HMI-1',
     command: 'grid-connection-ban',
     input: '1',

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -288,4 +288,47 @@ describe('Home Assistant Discovery', () => {
       {},
     );
   });
+
+  test('should gate HMI PV3/PV4 discovery configs on data presence', () => {
+    const device: Device = { deviceType: 'HMI-2000', deviceId: 'hmi2000' };
+    const deviceTopics: DeviceTopics = {
+      deviceTopicOld: 'hame_energy/HMI-2000/device/hmi2000/ctrl',
+      deviceTopicNew: 'marstek_energy/HMI-2000/device/hmi2000/ctrl',
+      deviceControlTopicOld: 'hame_energy/HMI-2000/App/hmi2000/ctrl',
+      deviceControlTopicNew: 'marstek_energy/HMI-2000/App/hmi2000/ctrl',
+      availabilityTopic: 'hame_energy/HMI-2000/availability/hmi2000',
+      controlSubscriptionTopic: 'hame_energy/HMI-2000/control/hmi2000/control',
+      publishTopic: 'hame_energy/HMI-2000/device/hmi2000/data',
+    };
+
+    const pv34Topics = (state: object) =>
+      generateDiscoveryConfigs(
+        device,
+        deviceTopics,
+        {},
+        DEFAULT_TOPIC_PREFIX,
+        'homeassistant',
+        state,
+      )
+        .map(c => c.topic)
+        .filter(t => /pv3_|pv4_/.test(t));
+
+    // 2-PV state (no pv3/pv4 data): no PV3/PV4 configs advertised
+    expect(pv34Topics({ pv1Voltage: 33.4 })).toHaveLength(0);
+
+    // 4-PV state (HMI-2000): PV3/PV4 configs advertised (voltage/current/power/status each)
+    const fourPv = pv34Topics({
+      pv3Voltage: 33.6,
+      pv3Current: 0.2,
+      pv3Power: 17,
+      pv3Status: true,
+      pv4Voltage: 33.7,
+      pv4Current: 0.3,
+      pv4Power: 18,
+      pv4Status: false,
+    });
+    expect(fourPv.some(t => t.includes('pv3_voltage'))).toBe(true);
+    expect(fourPv.some(t => t.includes('pv4_status'))).toBe(true);
+    expect(fourPv).toHaveLength(8);
+  });
 });

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,9 +1,9 @@
 import { parseMessage } from './parser';
 import {
   B2500V2DeviceData,
+  HmiInverterDeviceData,
   JupiterBMSInfo,
   JupiterDeviceData,
-  MI800DeviceData,
   VenusDeviceData,
 } from './types';
 
@@ -198,8 +198,8 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('wifiStatus', 2);
   });
 
-  test('should parse MI800 micro inverter message correctly', () => {
-    // Sample message from the provided MI800 inverter format
+  test('should parse HMI inverter (2-PV) message correctly', () => {
+    // Sample message from the provided MI800 (2-PV) inverter format
     const message =
       'ele_d=11,ele_s=1433,ele_m=1433,pv1_v=334,pv1_i=0,pv1_p=16,pv1_s=1,pv2_v=335,pv2_i=0,pv2_p=15,pv2_s=1,pe1_v=17,fb1_v=847,fb2_v=826,grd_f=4999,grd_v=2455,grd_s=1,grd_o=29,chp_t=33,rel_s=1,err_t=0,err_c=0,err_d=0,ver_s=120,mpt_m=1,ble_s=1,mpt1=1,mpt2=1,wif_r=69,fc4_v=202406141323,gc=0,pl=800,ct_r=0,ct_f=0,ct_c=0';
     const deviceType = 'HMI-1';
@@ -208,7 +208,7 @@ describe('MQTT Message Parser', () => {
     const parsed = parseMessage(message, deviceType, deviceId);
     expect(parsed).toHaveProperty('data');
 
-    const result = parsed['data'] as MI800DeviceData;
+    const result = parsed['data'] as HmiInverterDeviceData;
 
     // Check the structure
     expect(result).toHaveProperty('deviceType', deviceType);
@@ -256,9 +256,52 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('mode', 'b2500Boost');
     expect(result).toHaveProperty('fc4Version', '202406141323');
     expect(result).toHaveProperty('gridConnectionBan', false);
+
+    // Connectivity diagnostics
+    expect(result).toHaveProperty('bluetoothSignal', 1);
+    expect(result).toHaveProperty('wifiRssi', 69);
+
+    // 2-PV variant: no PV3/PV4 data
+    expect(result.pv3Voltage).toBeUndefined();
+    expect(result.pv4Voltage).toBeUndefined();
   });
 
-  test('should handle MI800 message with different PV status values', () => {
+  test('should parse HMI-2000 (4-PV) inverter message correctly', () => {
+    // HMI-2000 reports four PV inputs (pv3_*/pv4_*) in addition to the base fields
+    const message =
+      'ele_d=11,ele_s=1433,ele_m=1433,pv1_v=334,pv1_i=0,pv1_p=16,pv1_s=1,pv2_v=335,pv2_i=0,pv2_p=15,pv2_s=1,pv3_v=336,pv3_i=2,pv3_p=17,pv3_s=1,pv4_v=337,pv4_i=3,pv4_p=18,pv4_s=0,grd_f=4999,grd_v=2455,grd_s=1,grd_o=66,chp_t=33,ver_s=120,mpt_m=1,ble_s=4,wif_r=72,fc4_v=202406141323,gc=0,pl=2000';
+    const deviceType = 'HMI-2000';
+    const deviceId = '24197287YYYY';
+
+    const parsed = parseMessage(message, deviceType, deviceId);
+    expect(parsed).toHaveProperty('data');
+
+    const result = parsed['data'] as HmiInverterDeviceData;
+
+    expect(result).toHaveProperty('deviceType', deviceType);
+
+    // PV1/PV2 still parse
+    expect(result).toHaveProperty('pv1Voltage', 33.4);
+    expect(result).toHaveProperty('pv2Voltage', 33.5);
+
+    // PV3 (voltage/current /10, power raw, status boolean)
+    expect(result).toHaveProperty('pv3Voltage', 33.6);
+    expect(result).toHaveProperty('pv3Current', 0.2);
+    expect(result).toHaveProperty('pv3Power', 17);
+    expect(result).toHaveProperty('pv3Status', true);
+
+    // PV4
+    expect(result).toHaveProperty('pv4Voltage', 33.7);
+    expect(result).toHaveProperty('pv4Current', 0.3);
+    expect(result).toHaveProperty('pv4Power', 18);
+    expect(result).toHaveProperty('pv4Status', false);
+
+    // Connectivity diagnostics
+    expect(result).toHaveProperty('bluetoothSignal', 4);
+    expect(result).toHaveProperty('wifiRssi', 72);
+  });
+
+  test('should handle HMI inverter message with different PV status values', () => {
     // Test with PV inputs inactive
     const message =
       'ele_d=25,ele_w=1500,ele_m=1500,pv1_v=0,pv1_i=0,pv1_p=0,pv1_s=0,pv2_v=0,pv2_i=0,pv2_p=0,pv2_s=0,grd_f=5000,grd_v=2400,grd_s=0,grd_o=0,chp_t=25,err_t=0,err_c=0,err_d=0,ver_s=105';
@@ -268,7 +311,7 @@ describe('MQTT Message Parser', () => {
     const parsed = parseMessage(message, deviceType, deviceId);
     expect(parsed).toHaveProperty('data');
 
-    const result = parsed['data'] as MI800DeviceData;
+    const result = parsed['data'] as HmiInverterDeviceData;
 
     // Check PV status is false when inputs are inactive
     expect(result).toHaveProperty('pv1Status', false);
@@ -287,7 +330,7 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('gridVoltage', 240.0);
   });
 
-  test('should handle MI800 message with error conditions', () => {
+  test('should handle HMI inverter message with error conditions', () => {
     // Test with error conditions
     const message =
       'ele_d=100,ele_w=2000,ele_m=2000,pv1_v=300,pv1_i=5,pv1_p=50,pv1_s=1,pv2_v=305,pv2_i=6,pv2_p=55,pv2_s=1,grd_f=4980,grd_v=2200,grd_s=1,grd_o=100,chp_t=45,err_t=1,err_c=3,err_d=255,ver_s=107';
@@ -297,7 +340,7 @@ describe('MQTT Message Parser', () => {
     const parsed = parseMessage(message, deviceType, deviceId);
     expect(parsed).toHaveProperty('data');
 
-    const result = parsed['data'] as MI800DeviceData;
+    const result = parsed['data'] as HmiInverterDeviceData;
 
     // Check error conditions are properly parsed
     expect(result).toHaveProperty('errorType', 1);

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -199,7 +199,7 @@ describe('MQTT Message Parser', () => {
   });
 
   test('should parse HMI inverter (2-PV) message correctly', () => {
-    // Sample message from the provided MI800 (2-PV) inverter format
+    // Sample message from an HMI inverter (2-PV variant, formerly MI800)
     const message =
       'ele_d=11,ele_s=1433,ele_m=1433,pv1_v=334,pv1_i=0,pv1_p=16,pv1_s=1,pv2_v=335,pv2_i=0,pv2_p=15,pv2_s=1,pe1_v=17,fb1_v=847,fb2_v=826,grd_f=4999,grd_v=2455,grd_s=1,grd_o=29,chp_t=33,rel_s=1,err_t=0,err_c=0,err_d=0,ver_s=120,mpt_m=1,ble_s=1,mpt1=1,mpt2=1,wif_r=69,fc4_v=202406141323,gc=0,pl=800,ct_r=0,ct_f=0,ct_c=0';
     const deviceType = 'HMI-1';

--- a/src/types.ts
+++ b/src/types.ts
@@ -466,15 +466,15 @@ export interface JupiterDeviceData extends BaseDeviceData {
 }
 
 /**
- * MI800 micro inverter data interface
+ * HMI inverter data interface (Marstek HMI family, e.g. MI800 / HMI-2000)
  */
-const validMI800Modes = ['default', 'b2500Boost', 'reverseCurrentProtection'] as const;
-export type MI800Mode = (typeof validMI800Modes)[number];
-export function isValidMI800Mode(mode: string): mode is MI800Mode {
-  return validMI800Modes.includes(mode as MI800Mode);
+const validHmiInverterModes = ['default', 'b2500Boost', 'reverseCurrentProtection'] as const;
+export type HmiInverterMode = (typeof validHmiInverterModes)[number];
+export function isValidHmiInverterMode(mode: string): mode is HmiInverterMode {
+  return validHmiInverterModes.includes(mode as HmiInverterMode);
 }
 
-export interface MI800DeviceData extends BaseDeviceData {
+export interface HmiInverterDeviceData extends BaseDeviceData {
   // Energy statistics
   dailyEnergyGenerated?: number; // ele_d
   weeklyEnergyGenerated?: number; // ele_w
@@ -482,7 +482,7 @@ export interface MI800DeviceData extends BaseDeviceData {
   totalEnergyGenerated?: number; // ele_s
   maximumOutputPower?: number; // pl
   fc4Version?: string; // fc4_v
-  mode?: MI800Mode; // mpt_m
+  mode?: HmiInverterMode; // mpt_m
   gridConnectionBan?: boolean; // gc
 
   // PV Input 1
@@ -496,6 +496,22 @@ export interface MI800DeviceData extends BaseDeviceData {
   pv2Current?: number; // pv2_i
   pv2Power?: number; // pv2_p
   pv2Status?: boolean; // pv2_s
+
+  // PV Input 3 (HMI-2000 4-PV variant)
+  pv3Voltage?: number; // pv3_v
+  pv3Current?: number; // pv3_i
+  pv3Power?: number; // pv3_p
+  pv3Status?: boolean; // pv3_s
+
+  // PV Input 4 (HMI-2000 4-PV variant)
+  pv4Voltage?: number; // pv4_v
+  pv4Current?: number; // pv4_i
+  pv4Power?: number; // pv4_p
+  pv4Status?: boolean; // pv4_s
+
+  // Connectivity diagnostics (field names reused from ct002.ts)
+  bluetoothSignal?: number; // ble_s
+  wifiRssi?: number; // wif_r
 
   // Grid information
   gridFrequency?: number; // grd_f


### PR DESCRIPTION
## Summary
Rebrand the MI800 device support to the more generic "HMI inverter" naming to reflect the Marstek HMI family of devices, and add support for 4-PV input variants like the HMI-2000.

## Key Changes

- **File rename**: `src/device/mi800.ts` → `src/device/hmiInverter.ts`
- **Type rename**: `MI800DeviceData` → `HmiInverterDeviceData` and `MI800Mode` → `HmiInverterMode`
- **Function rename**: `isMI800RuntimeInfoMessage()` → `isHmiInverterRuntimeInfoMessage()` and `isValidMI800Mode()` → `isValidHmiInverterMode()`
- **Added 4-PV support**: New fields for PV3 and PV4 inputs (voltage, current, power, status) with conditional discovery gating on data presence
- **Added connectivity diagnostics**: Bluetooth signal strength (`bluetoothSignal`) and WiFi RSSI (`wifiRssi`) fields
- **Updated tests**: Expanded test coverage to include HMI-2000 4-PV variant parsing and discovery config gating
- **Updated documentation**: README now references "Marstek HMI micro inverters (MI800, HMI-2000 with 4 PV inputs)"

## Implementation Details

- PV3/PV4 fields use the same transform patterns as PV1/PV2 (divide by 10 for voltage/current, raw number for power)
- Discovery configs for PV3/PV4 are conditionally enabled only when the corresponding data fields are present in device state
- Connectivity fields reuse field names from existing ct002.ts implementation for consistency
- All existing MI800 functionality is preserved; this is primarily a rename and extension

https://claude.ai/code/session_01UZatsnjm7VPaU1iJKQyNiG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for HMI micro inverter family including HMI-2000 (4 PV inputs). PV3/PV4 voltage, current, power and status are now exposed when present; devices with only 2 PVs remain unchanged.
  * Added connectivity diagnostics: Bluetooth signal and WiFi RSSI sensors.

* **Documentation**
  * Updated docs and prerequisites to reflect support for HMI micro inverters (MI800 and HMI-2000 variants).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->