### PR TITLE
fix: add missing state_class and device_class to sensor entities

### DIFF
--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -82,6 +82,7 @@ export function registerBaseMessage({
       name: 'Battery Percentage',
       device_class: 'battery',
       unit_of_measurement: '%',
+      state_class: 'measurement',
     }),
   );
   field({
@@ -96,6 +97,7 @@ export function registerBaseMessage({
       name: 'Battery Capacity',
       device_class: 'energy_storage',
       unit_of_measurement: 'Wh',
+      state_class: 'measurement',
     }),
   );
   field({
@@ -284,6 +286,7 @@ export function registerBaseMessage({
       name: 'Temperature Min',
       device_class: 'temperature',
       unit_of_measurement: '°C',
+      state_class: 'measurement',
     }),
   );
   field({
@@ -298,6 +301,7 @@ export function registerBaseMessage({
       name: 'Temperature Max',
       device_class: 'temperature',
       unit_of_measurement: '°C',
+      state_class: 'measurement',
     }),
   );
   field({
@@ -551,6 +555,7 @@ export function registerBaseMessage({
       name: 'Host Battery SoC',
       device_class: 'battery',
       unit_of_measurement: '%',
+      state_class: 'measurement',
     }),
   );
   field({
@@ -565,6 +570,7 @@ export function registerBaseMessage({
       name: 'Extra 1 Battery SoC',
       device_class: 'battery',
       unit_of_measurement: '%',
+      state_class: 'measurement',
       enabled_by_default: false,
     }),
   );
@@ -580,6 +586,7 @@ export function registerBaseMessage({
       name: 'Extra 2 Battery SoC',
       device_class: 'battery',
       unit_of_measurement: '%',
+      state_class: 'measurement',
       enabled_by_default: false,
     }),
   );
@@ -725,6 +732,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
           name: `Min Cell Voltage ${battery}`,
           device_class: 'voltage',
           unit_of_measurement: 'V',
+          state_class: 'measurement',
           enabled_by_default: battery === 'host',
         }),
       );
@@ -740,6 +748,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
           name: `Max Cell Voltage ${battery}`,
           device_class: 'voltage',
           unit_of_measurement: 'V',
+          state_class: 'measurement',
           enabled_by_default: battery === 'host',
         }),
       );
@@ -755,6 +764,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
           name: `Cell Voltage Difference ${battery}`,
           device_class: 'voltage',
           unit_of_measurement: 'V',
+          state_class: 'measurement',
           enabled_by_default: battery === 'host',
         }),
       );
@@ -770,6 +780,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
           name: `Average Cell Voltage ${battery}`,
           device_class: 'voltage',
           unit_of_measurement: 'V',
+          state_class: 'measurement',
           enabled_by_default: battery === 'host',
         }),
       );
@@ -787,6 +798,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
             name: `Cell Voltage ${battery} ${(i + 1).toString().padStart(2, '0')}`,
             device_class: 'voltage',
             unit_of_measurement: 'V',
+            state_class: 'measurement',
             enabled_by_default: battery === 'host',
           }),
         );

--- a/src/device/b2500V1.ts
+++ b/src/device/b2500V1.ts
@@ -230,6 +230,7 @@ function registerExtraBatteryData(message: BuildMessageFn) {
           name: `Input Voltage ${input}`,
           device_class: 'voltage',
           unit_of_measurement: 'V',
+          state_class: 'measurement',
         }),
       );
       field({

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -186,6 +186,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Battery Capacity',
         device_class: 'energy_storage',
         unit_of_measurement: 'Wh',
+        state_class: 'measurement',
       }),
     );
 
@@ -201,6 +202,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Battery State of Charge',
         device_class: 'battery',
         unit_of_measurement: '%',
+        state_class: 'measurement',
       }),
     );
 
@@ -368,6 +370,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Off Grid Power',
         device_class: 'apparent_power',
         unit_of_measurement: 'VA',
+        state_class: 'measurement',
       }),
     );
 
@@ -1244,6 +1247,7 @@ function registerBMSInfoMessage(message: BuildMessageFn) {
             name: `Cell Voltage ${i}`,
             unit_of_measurement: 'mV',
             device_class: 'voltage',
+            state_class: 'measurement',
             enabled_by_default: false,
           }),
         );
@@ -1259,6 +1263,7 @@ function registerBMSInfoMessage(message: BuildMessageFn) {
             name: `Cell Temperature ${i}`,
             unit_of_measurement: '°C',
             device_class: 'temperature',
+            state_class: 'measurement',
             enabled_by_default: false,
           }),
         );
@@ -1269,17 +1274,17 @@ function registerBMSInfoMessage(message: BuildMessageFn) {
         ['b_soc', { id: 'soc' }],
         ['b_soh', { id: 'soh' }],
         ['b_cap', { id: 'capacity' }],
-        ['b_vol', { id: 'voltage', deviceClass: 'voltage', unitOfMeasurement: 'V' }],
-        ['b_cur', { id: 'current', deviceClass: 'current', unitOfMeasurement: 'mA' }],
-        ['b_tem', { id: 'temperature', deviceClass: 'temperature', unitOfMeasurement: '°C' }],
-        ['b_chv', { id: 'chargeVoltage', deviceClass: 'voltage', unitOfMeasurement: 'V' }],
+        ['b_vol', { id: 'voltage', deviceClass: 'voltage', unitOfMeasurement: 'V', stateClass: 'measurement' }],
+        ['b_cur', { id: 'current', deviceClass: 'current', unitOfMeasurement: 'mA', stateClass: 'measurement' }],
+        ['b_tem', { id: 'temperature', deviceClass: 'temperature', unitOfMeasurement: '°C', stateClass: 'measurement' }],
+        ['b_chv', { id: 'chargeVoltage', deviceClass: 'voltage', unitOfMeasurement: 'V', stateClass: 'measurement' }],
         ['b_chf', { id: 'fullChargeCapacity' }],
         ['b_cpc', { id: 'cellCycle' }],
         ['b_err', { id: 'error' }],
         ['b_war', { id: 'warning' }],
         ['b_ret', { id: 'totalRuntime' }],
         ['b_ent', { id: 'energyThroughput' }],
-        ['b_mot', { id: 'mosfetTemp', deviceClass: 'temperature', unitOfMeasurement: '°C' }],
+        ['b_mot', { id: 'mosfetTemp', deviceClass: 'temperature', unitOfMeasurement: '°C', stateClass: 'measurement' }],
       ] as const;
 
       for (const [key, info] of bmsFields) {
@@ -1291,6 +1296,7 @@ function registerBMSInfoMessage(message: BuildMessageFn) {
             name: `BMS ${info.id.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}`,
             unit_of_measurement: 'unitOfMeasurement' in info ? info.unitOfMeasurement : undefined,
             device_class: 'deviceClass' in info ? info.deviceClass : undefined,
+            state_class: 'stateClass' in info ? info.stateClass : undefined,
             enabled_by_default: false,
           }),
         );

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1411,8 +1411,24 @@ function registerBMSInfoMessage(
             stateClass: 'measurement',
           },
         ],
-        ['b_cur', { id: 'current', deviceClass: 'current', unitOfMeasurement: 'mA', stateClass: 'measurement' }],
-        ['b_tem', { id: 'temperature', deviceClass: 'temperature', unitOfMeasurement: '°C', stateClass: 'measurement' }],
+        [
+          'b_cur',
+          {
+            id: 'current',
+            deviceClass: 'current',
+            unitOfMeasurement: 'mA',
+            stateClass: 'measurement',
+          },
+        ],
+        [
+          'b_tem',
+          {
+            id: 'temperature',
+            deviceClass: 'temperature',
+            unitOfMeasurement: '°C',
+            stateClass: 'measurement',
+          },
+        ],
         // Charge voltage is reported in decivolts (e.g. 468 -> 46.8 V)
         [
           'b_chv',
@@ -1437,7 +1453,7 @@ function registerBMSInfoMessage(
             deviceClass: 'temperature',
             unitOfMeasurement: '°C',
             transform: scaleTemperatures ? divide(10) : undefined,
-            stateClass: 'measurement'
+            stateClass: 'measurement',
           },
         ],
       ] as const;


### PR DESCRIPTION
Several sensor entities were missing `state_class`, preventing Home Assistant from recording long-term statistics and excluding them from the Energy Dashboard.

Affected sensors across `b2500Base`, `b2500V1`, and `venus` devices:

- **Battery percentage / SoC** — `device_class: battery` sensors were missing `state_class: measurement`, so they did not appear as selectable options in HA's Energy Dashboard battery configuration.
- **Voltage sensors** — cell voltages (min, max, diff, avg, individual cells) and solar input voltages had `device_class: voltage` but no `state_class`.
- **Temperature sensors** — `temperature_min`/`temperature_max` and BMS cell temperatures had `device_class: temperature` but no `state_class`.
- **BMS physical measurements** (venus) — voltage, current, temperature, charge voltage, and MOSFET temperature in the BMS field loop were missing `state_class: measurement`.
- **Off-grid power** (venus) — had `device_class: apparent_power` but was missing `state_class: measurement`.

The Jupiter device already had these correctly set and served as the reference. All added values are `state_class: measurement` (instantaneous, non-cumulative readings). No logic changes — discovery payload fields only.

**Tested:** manually published a modified MQTT discovery payload with `state_class: measurement` via MQTT Explorer and confirmed the entity appeared in HA Developer Tools with the correct attribute and became selectable in the Energy Dashboard.

__AI Transparency Note: Change was prepared and implemented with Claude Code__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Home Assistant sensors for battery level, capacity, SoC, and off‑grid power now use measurement state classification for more accurate telemetry and history.
  * Per‑cell voltages, per‑cell temperatures, and aggregate cell voltage metrics (min/max/avg/diff) now expose measurement classification and improved metadata for clearer display and recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->