### PR TITLE
fix: add missing state_class to Jupiter and B2500 V2 sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Add missing `state_class: measurement` to battery, voltage, current and temperature sensors across the B2500, Venus and Jupiter devices so Home Assistant records long-term statistics and the *State of Charge* sensors can be added to the Energy Dashboard battery configuration introduced in Home Assistant 2026.6 (#311, #312). Thanks @michikrug! (fixes #310)
 - Venus: Scale the BMS battery voltage and charge voltage to volts (they were previously published as raw centivolt/decivolt values, e.g. 4328 instead of 43.28 V) (fixes #218)
 - Venus A (VNSA): Scale the BMS cell and MOSFET temperatures to °C (they were previously published 10× too high, e.g. 164 instead of 16.4 °C) (fixes #218)
 

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -790,6 +790,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
           name: `Input Voltage ${input}`,
           device_class: 'voltage',
           unit_of_measurement: 'V',
+          state_class: 'measurement',
         }),
       );
       field({
@@ -804,6 +805,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
           name: `Input Current ${input}`,
           device_class: 'current',
           unit_of_measurement: 'A',
+          state_class: 'measurement',
         }),
       );
       field({
@@ -823,6 +825,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
           name: `Output Voltage ${input}`,
           device_class: 'voltage',
           unit_of_measurement: 'V',
+          state_class: 'measurement',
         }),
       );
       field({
@@ -837,6 +840,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
           name: `Output Current ${input}`,
           device_class: 'current',
           unit_of_measurement: 'A',
+          state_class: 'measurement',
         }),
       );
       field({
@@ -861,6 +865,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         name: 'Host Battery Voltage',
         device_class: 'voltage',
         unit_of_measurement: 'V',
+        state_class: 'measurement',
       }),
     );
     field({
@@ -875,6 +880,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         name: 'Host Battery Current',
         device_class: 'current',
         unit_of_measurement: 'A',
+        state_class: 'measurement',
       }),
     );
     field({
@@ -893,6 +899,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         name: 'Extra Battery 1 Voltage',
         device_class: 'voltage',
         unit_of_measurement: 'V',
+        state_class: 'measurement',
         enabled_by_default: false,
       }),
     );
@@ -908,6 +915,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         name: 'Extra Battery 1 Current',
         device_class: 'current',
         unit_of_measurement: 'A',
+        state_class: 'measurement',
         enabled_by_default: false,
       }),
     );
@@ -927,6 +935,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         name: 'Extra Battery 2 Voltage',
         device_class: 'voltage',
         unit_of_measurement: 'V',
+        state_class: 'measurement',
         enabled_by_default: false,
       }),
     );
@@ -942,6 +951,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         name: 'Extra Battery 2 Current',
         device_class: 'current',
         unit_of_measurement: 'A',
+        state_class: 'measurement',
         enabled_by_default: false,
       }),
     );

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -1054,7 +1054,15 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
           { id: 'soc', deviceClass: 'battery', unitOfMeasurement: '%', stateClass: 'measurement' },
         ],
         ['soh', { id: 'soh' }],
-        ['b_cap', { id: 'capacity', deviceClass: 'energy_storage', unitOfMeasurement: 'Wh' }],
+        [
+          'b_cap',
+          {
+            id: 'capacity',
+            deviceClass: 'energy_storage',
+            unitOfMeasurement: 'Wh',
+            stateClass: 'measurement',
+          },
+        ],
         [
           'b_vol',
           {
@@ -1097,6 +1105,7 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
             id: 'chargeVoltage',
             deviceClass: 'voltage',
             unitOfMeasurement: 'V',
+            stateClass: 'measurement',
             // My unit always reports 600 which, when divided by 10, gives a
             // close to adequate 60 V charging voltage.
             transform: divide(10),


### PR DESCRIPTION
Completes the state_class additions from #311 for the remaining devices:

- Jupiter: BMS capacity (energy_storage) and charge voltage (voltage) were missing state_class: measurement.
- B2500 V2: solar input voltage/current, output voltage/current and host/extra battery voltage/current sensors were missing state_class: measurement.

Without state_class, Home Assistant does not record long-term statistics for these sensors and the State of Charge sensors cannot be added to the Energy Dashboard battery configuration introduced in HA 2026.6.

fixes #310