### PR TITLE
Defer Home Assistant discovery until first cd=1 response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Next]
 
+### Changed
+
+- Home Assistant discovery messages are now only published after the device responds to a `cd=1` request at least once, instead of immediately on connect. This prevents devices that never reply from creating unavailable "ghost" entities in Home Assistant.
 
 ## [1.7.1] - 2026-06-06
 

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -22,6 +22,8 @@ jest.mock('./deviceDefinition', () => ({
   getDeviceDefinition: jest.fn(() => ({
     messages: [
       {
+        refreshDataPayload: 'cd=1',
+        publishPath: 'data',
         getAdditionalDeviceInfo: (state: any) => ({
           firmwareVersion: state?.fw,
         }),
@@ -82,5 +84,48 @@ describe('MqttClient discovery re-publish', () => {
       'homeassistant',
       expect.objectContaining({ fw: '116.6' }),
     );
+  });
+
+  test('only publishes discovery after a cd=1 response, not on non-cd=1 paths', () => {
+    const { publishDiscoveryConfigs } = require('./generateDiscoveryConfigs');
+    publishDiscoveryConfigs.mockClear();
+
+    const device: Device = { deviceType: 'HMJ-2', deviceId: 'abc123' };
+    const topics = {
+      deviceTopicOld: 'hame_energy/HMJ-2/device/abc123/ctrl',
+      deviceTopicNew: 'marstek_energy/HMJ-2/device/abc123/ctrl',
+      publishTopic: 'homeassistant/HMJ-2/device/abc123/data',
+      deviceControlTopicOld: 'hame_energy/HMJ-2/App/abc123/ctrl',
+      deviceControlTopicNew: 'marstek_energy/HMJ-2/App/abc123/ctrl',
+      controlSubscriptionTopic: 'homeassistant/HMJ-2/control/abc123/control',
+      availabilityTopic: 'homeassistant/HMJ-2/availability/abc123',
+    };
+
+    const deviceManager: any = {
+      getDeviceTopics: jest.fn(() => topics),
+      getDeviceState: jest.fn(() => ({})),
+      getDevices: jest.fn(() => []),
+    };
+
+    const config: any = {
+      brokerUrl: 'mqtt://localhost:1883',
+      clientId: 'test-client',
+      topicPrefix: 'homeassistant',
+      autodiscoveryTopicPrefix: 'homeassistant',
+    };
+
+    const mqttClient = new MqttClient(config, deviceManager, jest.fn());
+
+    // A response on a non-cd=1 path (e.g. BMS data) must not announce discovery
+    mqttClient.onDeviceDataReceived(device, 'bms');
+    expect(publishDiscoveryConfigs).not.toHaveBeenCalled();
+
+    // The first cd=1 response unlocks discovery
+    mqttClient.onDeviceDataReceived(device, 'data');
+    expect(publishDiscoveryConfigs).toHaveBeenCalledTimes(1);
+
+    // The previously-seen non-cd=1 path still gets its normal first-data publish
+    mqttClient.onDeviceDataReceived(device, 'bms');
+    expect(publishDiscoveryConfigs).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -13,6 +13,7 @@ export class MqttClient {
   private allowedConsecutiveTimeouts: number;
   private devicePathsWithData: Set<string> = new Set();
   private lastDiscoveryInfoSignatureByDevice: Map<string, string> = new Map();
+  private devicesRespondedToCd1: Set<string> = new Set();
 
   constructor(
     private config: MqttConfig,
@@ -87,7 +88,12 @@ export class MqttClient {
       this.subscribe(topics.deviceTopicNew);
       this.subscribeToControlTopics(device);
       this.publish(topics.availabilityTopic, 'offline', { qos: 1, retain: true });
-      this.publishDiscoveryConfigs(device);
+      // Only (re-)publish discovery for devices that have already responded to a
+      // cd=1 request in this process lifetime. Devices that have never replied are
+      // not announced until their first cd=1 response arrives.
+      if (this.devicesRespondedToCd1.has(this.getDeviceKey(device))) {
+        this.publishDiscoveryConfigs(device);
+      }
     });
 
     // Set up periodic polling to trigger device data
@@ -119,6 +125,23 @@ export class MqttClient {
 
   private getDiscoveryInfoSignature(device: Device): string {
     return this.getDiscoveryInfoSignatureFromInfo(this.getAdditionalDeviceInfo(device));
+  }
+
+  /**
+   * Determine whether the given publish path corresponds to a cd=1 request for
+   * this device, i.e. data received on this path is a response to a cd=1 poll.
+   *
+   * @param device - The device configuration
+   * @param publishPath - The message path that received data
+   */
+  private isCd1Path(device: Device, publishPath: string): boolean {
+    const deviceDefinition = getDeviceDefinition(device.deviceType);
+    if (!deviceDefinition) {
+      return false;
+    }
+    return deviceDefinition.messages.some(
+      message => message.refreshDataPayload === 'cd=1' && message.publishPath === publishPath,
+    );
   }
 
   /**
@@ -207,10 +230,13 @@ export class MqttClient {
       clearInterval(this.discoveryInterval);
     }
 
-    // Republish Home Assistant discovery configurations every hour
+    // Republish Home Assistant discovery configurations every hour, but only for
+    // devices that have responded to a cd=1 request at least once.
     this.discoveryInterval = setInterval(() => {
       this.deviceManager.getDevices().forEach(device => {
-        this.publishDiscoveryConfigs(device);
+        if (this.devicesRespondedToCd1.has(this.getDeviceKey(device))) {
+          this.publishDiscoveryConfigs(device);
+        }
       });
     }, 3600000); // Every hour
     // Prevent tests/process from being kept alive by the interval
@@ -249,6 +275,25 @@ export class MqttClient {
   onDeviceDataReceived(device: Device, publishPath: string): void {
     const devicePathKey = `${device.deviceType}:${device.deviceId}:${publishPath}`;
     const deviceKey = this.getDeviceKey(device);
+
+    // Discovery is only announced after the device has responded to a cd=1 request.
+    if (!this.devicesRespondedToCd1.has(deviceKey)) {
+      // Ignore responses on other paths (e.g. BMS/cell data) until the device has
+      // answered a cd=1 request. We deliberately do not record those paths in
+      // devicePathsWithData yet, so they still get their normal first-data publish
+      // once the device is unlocked below.
+      if (!this.isCd1Path(device, publishPath)) {
+        return;
+      }
+      logger.debug(
+        `First cd=1 response received for ${device.deviceType}:${device.deviceId} on path ${publishPath}, publishing discovery configs`,
+      );
+      this.devicesRespondedToCd1.add(deviceKey);
+      this.devicePathsWithData.add(devicePathKey);
+      this.publishDiscoveryConfigs(device);
+      return;
+    }
+
     const previousSignature = this.lastDiscoveryInfoSignatureByDevice.get(deviceKey);
     const currentSignature = this.getDiscoveryInfoSignature(device);
 


### PR DESCRIPTION
## Summary
This change prevents Home Assistant discovery messages from being published immediately when a device connects. Instead, discovery is only announced after the device responds to at least one `cd=1` (refresh data) request. This prevents "ghost" unavailable entities from being created in Home Assistant for devices that never respond.

## Key Changes
- Added `devicesRespondedToCd1` Set to track which devices have responded to a `cd=1` request
- Added `isCd1Path()` method to identify whether a publish path corresponds to a `cd=1` response
- Modified `onDeviceDataReceived()` to gate discovery publication on first `cd=1` response:
  - Non-`cd=1` responses are ignored until the device responds to a `cd=1` request
  - Once a `cd=1` response is received, discovery configs are published and the device is "unlocked"
  - Subsequent non-`cd=1` responses are processed normally
- Updated the hourly discovery re-publish interval to only republish for devices that have responded to `cd=1`
- Updated device initialization to only publish discovery for devices that have previously responded to `cd=1`

## Implementation Details
- The `devicesRespondedToCd1` set persists for the lifetime of the process, so devices remain "unlocked" even if they temporarily disconnect
- Non-`cd=1` data paths (e.g., BMS/cell data) are deliberately not recorded in `devicePathsWithData` until after the first `cd=1` response, ensuring they still trigger their normal first-data publish behavior
- Added comprehensive test coverage verifying that discovery is only published after a `cd=1` response, not on other data paths

https://claude.ai/code/session_01WHxa1M1F5ShuNHhqGwm7ZE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Home Assistant discovery now waits for device responsiveness confirmation before publishing, preventing unavailable ghost entities for non-responsive devices.

* **Tests**
  * Added regression test verifying discovery publishing behavior after device responsiveness is confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->