### PR TITLE
Make B2500 flash commands setting persistent across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Changed
 
+- B2500: The *Use Flash Commands* switch now publishes its command as a retained MQTT message. This makes the setting survive a restart of hm2mqtt — on reconnect the broker re-delivers the retained command and the flash-commands mode is re-applied automatically.
 - Home Assistant discovery messages are now only published after the device responds to a `cd=1` request at least once, instead of immediately on connect. This prevents devices that never reply from creating unavailable "ghost" entities in Home Assistant.
 
 ## [1.7.1] - 2026-06-06

--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ homeassistant/{component}/{node_id}/{object_id}/config
 ### B2500 Commands (All Versions)
 - `discharge-depth`: Controls battery discharge depth (0-100%)
 - `restart`: Restarts the device
-- `use-flash-commands`: Toggles flash command mode
+- `use-flash-commands`: Toggles flash command mode. The Home Assistant switch publishes this command as a retained message, so the setting is automatically re-applied after hm2mqtt restarts.
 
 ### B2500 V1 Specific Commands
 - `charging-mode`: Sets charging mode (`pv2PassThrough` or `chargeThenDischarge`)

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -684,6 +684,10 @@ export function registerBaseMessage({
       icon: 'mdi:flash',
       command: 'use-flash-commands',
       enabled_by_default: false,
+      // Publish the toggle as a retained command so the setting survives a
+      // restart of hm2mqtt: on reconnect the broker re-delivers the retained
+      // command and the flash-commands state is re-applied automatically.
+      retain: true,
     }),
   );
 }

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -99,6 +99,8 @@ describe('Home Assistant Discovery', () => {
     expect(flashCommandsSwitch).toBeDefined();
     expect(flashCommandsSwitch?.config!.payload_on).toBe('true');
     expect(flashCommandsSwitch?.config!.payload_off).toBe('false');
+    // The switch publishes a retained command so the setting survives a restart
+    expect(flashCommandsSwitch?.config!.retain).toBe(true);
 
     // Check factory reset button
     const factoryResetButton = configs.find(c => c.topic.includes('factory_reset'));

--- a/src/homeAssistantDiscovery.ts
+++ b/src/homeAssistantDiscovery.ts
@@ -33,6 +33,7 @@ export interface HaSwitchComponent extends HaBaseStateComponent {
   payload_off: string | number | boolean;
   state_on: string | number | boolean;
   state_off: string | number | boolean;
+  retain?: boolean;
 }
 
 export interface HaNumberComponent extends Omit<HaSensorComponent, 'type'> {
@@ -96,6 +97,7 @@ export interface HaDiscoveryConfig {
   step?: number;
   payload_press?: string | number | boolean;
   pattern?: string;
+  retain?: boolean;
   icon?: string;
   device: {
     ids: string[];
@@ -240,6 +242,7 @@ export const switchComponent =
   (
     definition: HaBaseStateComponentArgs & {
       command: string;
+      retain?: boolean;
     },
   ): HaStatefulAdvertiseBuilder<boolean> =>
   args => ({
@@ -251,6 +254,7 @@ export const switchComponent =
     payload_off: 'false',
     state_on: true,
     state_off: false,
+    ...(definition.retain != null ? { retain: definition.retain } : {}),
   });
 export const textComponent =
   <T extends string = string>(


### PR DESCRIPTION
## Summary
This change makes the B2500 "Use Flash Commands" switch setting persistent across hm2mqtt restarts by publishing the command as a retained MQTT message.

## Key Changes
- Added `retain: true` option to the flash-commands switch definition in `b2500Base.ts`
- Extended the Home Assistant discovery interfaces to support an optional `retain` property:
  - Added `retain?: boolean` to `HaSwitchComponent`
  - Added `retain?: boolean` to `HaDiscoveryConfig`
  - Added `retain?: boolean` parameter to `switchComponent` function
- Updated `switchComponent` to conditionally include the `retain` property in the generated configuration
- Added test coverage to verify the flash-commands switch has `retain: true`
- Updated documentation in README.md and CHANGELOG.md to explain the behavior

## Implementation Details
When the flash-commands switch is toggled in Home Assistant, the MQTT broker will retain the command message. Upon hm2mqtt reconnection, the broker automatically re-delivers the retained message, causing the flash-commands mode to be re-applied without manual intervention. This ensures the setting survives service restarts.

The implementation uses conditional spreading (`...(definition.retain != null ? { retain: definition.retain } : {})`) to only include the `retain` property when explicitly set, maintaining backward compatibility with other switch definitions.

https://claude.ai/code/session_01KQEJZQyqEFtzE2ovcopMWN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Flash command settings now persist across device restarts and reconnections using retained MQTT messages.
  * Home Assistant discovery messages are only published after the device responds to initial requests, preventing "ghost" unavailable entities for unresponsive devices.

* **Documentation**
  * Updated MQTT command documentation and changelog to reflect retained-message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->