### PR TITLE
Fix console-style log calls dropping trailing arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Next]
 
+### Fixed
+
+- Log messages no longer drop their trailing values (e.g. `Current period 1 settings:` was logged without the actual settings, and error logs were missing the error details). Pino only interpolates extra arguments into `%s`-style placeholders, so console-style log calls silently lost everything after the message (fixes #326)
+
 ### Changed
 
 - B2500: The *Use Flash Commands* switch now publishes its command as a retained MQTT message. This makes the setting survive a restart of hm2mqtt — on reconnect the broker re-delivers the retained command and the flash-commands mode is re-applied automatically.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Log messages no longer drop their trailing values (e.g. `Current period 1 settings:` was logged without the actual settings, and error logs were missing the error details). Pino only interpolates extra arguments into `%s`-style placeholders, so console-style log calls silently lost everything after the message (fixes #326)
+- B2500: The `Current period X settings:` message logged for every received time-period command is now logged at `debug` level instead of `info`, so automations that frequently update time periods no longer flood the log (fixes #326)
 
 ### Changed
 

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -81,7 +81,7 @@ export const timePeriodSettingHandler = (
           return;
       }
 
-      logger.info(`Current period ${periodNumber} settings:`, newTimePeriodSettings[periodIndex]);
+      logger.debug(`Current period ${periodNumber} settings:`, newTimePeriodSettings[periodIndex]);
 
       // Build time period parameters for all periods
       const params = buildTimePeriodParams(newTimePeriodSettings);

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,103 @@
+import pino from 'pino';
+import { consoleStyleLogMethod } from './logger';
+
+describe('consoleStyleLogMethod', () => {
+  function createTestLogger(lines: string[]) {
+    return pino(
+      {
+        level: 'debug',
+        hooks: { logMethod: consoleStyleLogMethod },
+      },
+      {
+        write(chunk: string) {
+          lines.push(chunk);
+        },
+      },
+    );
+  }
+
+  function lastMessage(lines: string[]): string {
+    return JSON.parse(lines[lines.length - 1]).msg;
+  }
+
+  it('appends a trailing object to the message', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.info('Current period 1 settings:', {
+      enabled: true,
+      startTime: '00:00',
+      endTime: '23:59',
+      outputValue: 800,
+    });
+
+    expect(lastMessage(lines)).toBe(
+      "Current period 1 settings: { enabled: true, startTime: '00:00', endTime: '23:59', outputValue: 800 }",
+    );
+  });
+
+  it('appends a trailing string to the message', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.warn('Invalid output value (should be 0-800):', 'abc');
+
+    expect(lastMessage(lines)).toBe('Invalid output value (should be 0-800): abc');
+  });
+
+  it('appends multiple trailing arguments', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.error('Unhandled rejection at:', { promise: true }, 'reason:', 'boom');
+
+    expect(lastMessage(lines)).toBe('Unhandled rejection at: { promise: true } reason: boom');
+  });
+
+  it('includes error details', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.error('MQTT client error:', new Error('connection refused'));
+
+    expect(lastMessage(lines)).toContain('MQTT client error: Error: connection refused');
+  });
+
+  it('leaves messages without extra arguments untouched', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.info('Connected to MQTT broker');
+
+    expect(lastMessage(lines)).toBe('Connected to MQTT broker');
+  });
+
+  it('keeps pino-style placeholder interpolation working', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.info('Device %s is online', 'HMA-1');
+
+    expect(lastMessage(lines)).toBe('Device HMA-1 is online');
+  });
+
+  it('appends only the arguments not consumed by placeholders', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.info('Device %s reported:', 'HMA-1', { soc: 42 });
+
+    expect(lastMessage(lines)).toBe('Device HMA-1 reported: { soc: 42 }');
+  });
+
+  it('keeps pino-style object-first calls working', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.info({ deviceId: 'abc' }, 'Device registered');
+
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.msg).toBe('Device registered');
+    expect(entry.deviceId).toBe('abc');
+  });
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,5 @@
 import pino from 'pino';
+import { inspect } from 'util';
 
 const resolvedLevel = process.env.LOG_LEVEL
   ? process.env.LOG_LEVEL
@@ -6,8 +7,42 @@ const resolvedLevel = process.env.LOG_LEVEL
     ? 'silent'
     : 'info';
 
+/**
+ * Pino only interpolates extra arguments into `%s`/`%d`/`%o`-style placeholders
+ * and silently drops any surplus ones. Most call sites in this codebase use
+ * console.log-style calls like `logger.info('Settings:', settings)`, so without
+ * this hook the trailing values would never be logged (see issue #326).
+ *
+ * This rewrites such calls by appending the surplus arguments to the message.
+ */
+export function consoleStyleLogMethod(
+  this: pino.Logger,
+  inputArgs: Parameters<pino.LogFn>,
+  method: pino.LogFn,
+): void {
+  const [first, ...rest] = inputArgs;
+  if (typeof first === 'string' && rest.length > 0) {
+    const placeholderCount = (first.match(/%[sdjoO]/g) ?? []).length;
+    const surplus = rest.slice(placeholderCount);
+    if (surplus.length > 0) {
+      const formatted = surplus
+        .map(arg => (typeof arg === 'string' ? arg : inspect(arg, { breakLength: Infinity })))
+        .join(' ');
+      method.apply(this, [
+        `${first} ${formatted}`,
+        ...rest.slice(0, placeholderCount),
+      ] as Parameters<pino.LogFn>);
+      return;
+    }
+  }
+  method.apply(this, inputArgs);
+}
+
 const logger = pino({
   level: resolvedLevel,
+  hooks: {
+    logMethod: consoleStyleLogMethod,
+  },
   transport: {
     targets: [
       {


### PR DESCRIPTION
## Summary

This PR fixes an issue where log messages with trailing arguments (e.g., `logger.info('Settings:', settings)`) were silently dropping those arguments. Pino's default behavior only interpolates arguments into `%s`/`%d`/`%o`-style placeholders, causing console-style calls to lose their values.

## Changes

- **Added `consoleStyleLogMethod` hook** to the Pino logger configuration that rewrites console-style log calls by appending surplus arguments to the message string. The hook:
  - Detects when a string message has trailing arguments not consumed by placeholders
  - Formats surplus arguments using Node's `util.inspect()` for objects
  - Preserves standard Pino placeholder interpolation behavior
  - Leaves unaffected calls (no trailing args, object-first calls) unchanged

- **Reduced log verbosity** for B2500 time-period updates by changing the `Current period X settings:` message from `info` to `debug` level, preventing log flooding when automations frequently update time periods

- **Added comprehensive test suite** (`logger.test.ts`) covering:
  - Trailing objects and strings
  - Multiple trailing arguments
  - Error details preservation
  - Pino placeholder interpolation compatibility
  - Object-first call patterns

Fixes #326

https://claude.ai/code/session_01FabntpT8xFWGr2p3tEhYWB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed console-style logging calls that were dropping trailing interpolated values
  * Reduced B2500 log verbosity by lowering recurring period settings entries to debug level, preventing log flooding during frequent period commands

* **Tests**
  * Added test suite for console-style logging to verify proper argument handling and error details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->