### PR TITLE
Add cell voltage aggregate statistics for Venus and Jupiter BMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Next]
 
+### Added
+
+- Venus & Jupiter: Add aggregate cell-voltage sensors so all devices that expose cell voltages now provide *Min Cell Voltage*, *Max Cell Voltage*, *Cell Voltage Difference* (drift) and *Average Cell Voltage*. Venus computes these from its individual cell voltages (ignoring unused cells reported as `0`), and Jupiter derives drift and average from its reported highest/lowest cell voltage per battery. These match the equivalent sensors already available on the B2500. All sensors are disabled by default.
+
 ### Fixed
 
 - Log messages no longer drop their trailing values (e.g. `Current period 1 settings:` was logged without the actual settings, and error logs were missing the error details). Pino only interpolates extra arguments into `%s`-style placeholders, so console-style log calls silently lost everything after the message (fixes #326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 ### Added
 
-- Venus & Jupiter: Add aggregate cell-voltage sensors so all devices that expose cell voltages now provide *Min Cell Voltage*, *Max Cell Voltage*, *Cell Voltage Difference* (drift) and *Average Cell Voltage*. Venus computes these from its individual cell voltages (ignoring unused cells reported as `0`), and Jupiter derives drift and average from its reported highest/lowest cell voltage per battery. These match the equivalent sensors already available on the B2500. All sensors are disabled by default.
+- Venus: Add aggregate cell-voltage sensors (*Min Cell Voltage*, *Max Cell Voltage*, *Cell Voltage Difference* and *Average Cell Voltage*) computed from the individual cell voltages, ignoring unused cells reported as `0`. These match the equivalent sensors already available on the B2500.
+- Jupiter: Add a *Cell Voltage Difference* (drift) sensor per battery, derived from the reported highest/lowest cell voltage. (Jupiter only reports the highest and lowest cell voltage, not individual cells, so a true average cannot be computed.)
+- All new sensors are disabled by default.
 
 ### Fixed
 

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -32,6 +32,8 @@ import {
   temperature,
   highByte,
   lowByte,
+  diff,
+  average,
 } from '../transforms';
 
 /**
@@ -1019,6 +1021,42 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
           sensorComponent<number>({
             id: `battery_${batteryIndex}_cell_voltage_min`,
             name: `${batteryLabel} Lowest Cell Voltage`,
+            unit_of_measurement: 'mV',
+            device_class: 'voltage',
+            state_class: 'measurement',
+            enabled_by_default: false,
+          }),
+        );
+
+        // Cell voltage difference (drift) between highest and lowest cell
+        field({
+          key: [maxVoltageKey, minVoltageKey],
+          path: [...pathPrefix, 'voltageDiff'],
+          transform: diff(),
+        });
+        advertise(
+          [...pathPrefix, 'voltageDiff'],
+          sensorComponent<number>({
+            id: `battery_${batteryIndex}_cell_voltage_diff`,
+            name: `${batteryLabel} Cell Voltage Difference`,
+            unit_of_measurement: 'mV',
+            device_class: 'voltage',
+            state_class: 'measurement',
+            enabled_by_default: false,
+          }),
+        );
+
+        // Average cell voltage (midpoint of highest and lowest cell)
+        field({
+          key: [maxVoltageKey, minVoltageKey],
+          path: [...pathPrefix, 'voltageAvg'],
+          transform: average(undefined, true),
+        });
+        advertise(
+          [...pathPrefix, 'voltageAvg'],
+          sensorComponent<number>({
+            id: `battery_${batteryIndex}_cell_voltage_avg`,
+            name: `${batteryLabel} Average Cell Voltage`,
             unit_of_measurement: 'mV',
             device_class: 'voltage',
             state_class: 'measurement',

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -33,7 +33,6 @@ import {
   highByte,
   lowByte,
   diff,
-  average,
 } from '../transforms';
 
 /**
@@ -1039,24 +1038,6 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
           sensorComponent<number>({
             id: `battery_${batteryIndex}_cell_voltage_diff`,
             name: `${batteryLabel} Cell Voltage Difference`,
-            unit_of_measurement: 'mV',
-            device_class: 'voltage',
-            state_class: 'measurement',
-            enabled_by_default: false,
-          }),
-        );
-
-        // Average cell voltage (midpoint of highest and lowest cell)
-        field({
-          key: [maxVoltageKey, minVoltageKey],
-          path: [...pathPrefix, 'voltageAvg'],
-          transform: average(undefined, true),
-        });
-        advertise(
-          [...pathPrefix, 'voltageAvg'],
-          sensorComponent<number>({
-            id: `battery_${batteryIndex}_cell_voltage_avg`,
-            name: `${batteryLabel} Average Cell Voltage`,
             unit_of_measurement: 'mV',
             device_class: 'voltage',
             state_class: 'measurement',

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -28,6 +28,10 @@ import {
   chain,
   inRange,
   sum,
+  min,
+  max,
+  diff,
+  average,
   venusPvField,
 } from '../transforms';
 
@@ -1374,6 +1378,74 @@ function registerBMSInfoMessage(
           }),
         );
       }
+
+      // Aggregate cell voltage statistics across all cells (b_vo1-b_vo16).
+      // Unused cells on smaller batteries report 0, so they are ignored.
+      const cellVoltageKeys = Array.from({ length: 16 }, (_, i) => `b_vo${i + 1}`);
+      field({
+        key: cellVoltageKeys,
+        path: ['cells', 'minVoltage'],
+        transform: min(undefined, true),
+      });
+      advertise(
+        ['cells', 'minVoltage'],
+        sensorComponent<number>({
+          id: 'min_cell_voltage',
+          name: 'Min Cell Voltage',
+          unit_of_measurement: 'mV',
+          device_class: 'voltage',
+          state_class: 'measurement',
+          enabled_by_default: false,
+        }),
+      );
+      field({
+        key: cellVoltageKeys,
+        path: ['cells', 'maxVoltage'],
+        transform: max(undefined, true),
+      });
+      advertise(
+        ['cells', 'maxVoltage'],
+        sensorComponent<number>({
+          id: 'max_cell_voltage',
+          name: 'Max Cell Voltage',
+          unit_of_measurement: 'mV',
+          device_class: 'voltage',
+          state_class: 'measurement',
+          enabled_by_default: false,
+        }),
+      );
+      field({
+        key: cellVoltageKeys,
+        path: ['cells', 'voltageDiff'],
+        transform: diff(undefined, true),
+      });
+      advertise(
+        ['cells', 'voltageDiff'],
+        sensorComponent<number>({
+          id: 'diff_cell_voltage',
+          name: 'Cell Voltage Difference',
+          unit_of_measurement: 'mV',
+          device_class: 'voltage',
+          state_class: 'measurement',
+          enabled_by_default: false,
+        }),
+      );
+      field({
+        key: cellVoltageKeys,
+        path: ['cells', 'voltageAvg'],
+        transform: average(undefined, true, true),
+      });
+      advertise(
+        ['cells', 'voltageAvg'],
+        sensorComponent<number>({
+          id: 'avg_cell_voltage',
+          name: 'Average Cell Voltage',
+          unit_of_measurement: 'mV',
+          device_class: 'voltage',
+          state_class: 'measurement',
+          enabled_by_default: false,
+        }),
+      );
 
       for (let i = 1; i <= 4; i++) {
         const key = `b_tp${i}`;

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -477,6 +477,9 @@ describe('MQTT Message Parser', () => {
     expect(result.batteries?.[0]?.cellVoltages?.maxVoltageCell).toBe(208);
     // High byte: 0x0C = 12
     expect(result.batteries?.[0]?.cellVoltages?.minVoltageCell).toBe(12);
+    // Drift and average derived from highest/lowest cell voltage
+    expect(result.batteries?.[0]?.cellVoltages?.voltageDiff).toBe(2);
+    expect(result.batteries?.[0]?.cellVoltages?.voltageAvg).toBe(3282);
 
     // Battery 1 (external 1): vol4=3283 (0x0CD3), vol5=3283, vol6=3280, vol7=3284
     expect(result.batteries?.[1]).toHaveProperty('cellVoltages');
@@ -709,6 +712,12 @@ describe('MQTT Message Parser', () => {
     expect(result.bms?.temperature).toBe(16);
     // Cell voltages are already reported in mV and stay unscaled.
     expect(result.cells?.voltages?.[0]).toBe(3334);
+    // Aggregate cell voltage statistics ignore unused cells reported as 0
+    // (b_vo14-b_vo16 are 0 on this battery).
+    expect(result.cells?.minVoltage).toBe(3332);
+    expect(result.cells?.maxVoltage).toBe(3335);
+    expect(result.cells?.voltageDiff).toBe(3);
+    expect(result.cells?.voltageAvg).toBe(3334);
   });
 
   test('Venus E (VNSE3) BMS scales voltages but keeps raw temperatures', () => {
@@ -722,5 +731,10 @@ describe('MQTT Message Parser', () => {
     // Other Venus variants already report temperatures in whole degrees.
     expect(result.bms?.mosfetTemp).toBe(23);
     expect(result.cells?.temperatures?.[0]).toBe(18);
+    // Aggregate cell voltage statistics across all 16 cells.
+    expect(result.cells?.minVoltage).toBe(3262);
+    expect(result.cells?.maxVoltage).toBe(3265);
+    expect(result.cells?.voltageDiff).toBe(3);
+    expect(result.cells?.voltageAvg).toBe(3265);
   });
 });

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -477,9 +477,8 @@ describe('MQTT Message Parser', () => {
     expect(result.batteries?.[0]?.cellVoltages?.maxVoltageCell).toBe(208);
     // High byte: 0x0C = 12
     expect(result.batteries?.[0]?.cellVoltages?.minVoltageCell).toBe(12);
-    // Drift and average derived from highest/lowest cell voltage
+    // Drift (difference) between highest and lowest cell voltage
     expect(result.batteries?.[0]?.cellVoltages?.voltageDiff).toBe(2);
-    expect(result.batteries?.[0]?.cellVoltages?.voltageAvg).toBe(3282);
 
     // Battery 1 (external 1): vol4=3283 (0x0CD3), vol5=3283, vol6=3280, vol7=3284
     expect(result.batteries?.[1]).toHaveProperty('cellVoltages');

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -445,6 +445,22 @@ describe('transforms', () => {
       it('should apply scale', () => {
         expect(executeMultiKeyTransform(min(1000), { a: '3000', b: '2000' })).toBe(2);
       });
+
+      it('should ignore zero values when ignoreZero is set', () => {
+        expect(
+          executeMultiKeyTransform(min(undefined, true), { a: '3334', b: '3332', c: '0', d: '0' }),
+        ).toBe(3332);
+      });
+
+      it('should include zero values by default', () => {
+        expect(executeMultiKeyTransform(min(), { a: '3334', b: '3332', c: '0' })).toBe(0);
+      });
+
+      it('should generate Jinja2 that filters zeros when ignoreZero is set', () => {
+        expect(multiKeyTransformToJinja2(min(undefined, true), ['a', 'b'], 'value_json')).toContain(
+          "reject('equalto', 0)",
+        );
+      });
     });
 
     describe('max transform', () => {
@@ -455,6 +471,12 @@ describe('transforms', () => {
       it('should apply scale', () => {
         expect(executeMultiKeyTransform(max(1000), { a: '3000', b: '2000' })).toBe(3);
       });
+
+      it('should ignore zero values when ignoreZero is set', () => {
+        expect(
+          executeMultiKeyTransform(max(undefined, true), { a: '3334', b: '3332', c: '0' }),
+        ).toBe(3334);
+      });
     });
 
     describe('diff transform', () => {
@@ -464,6 +486,13 @@ describe('transforms', () => {
 
       it('should apply scale', () => {
         expect(executeMultiKeyTransform(diff(1000), { a: '3000', b: '1000' })).toBe(2);
+      });
+
+      it('should ignore zero values when ignoreZero is set', () => {
+        // Without ignoreZero the diff would be 3334 - 0 = 3334
+        expect(
+          executeMultiKeyTransform(diff(undefined, true), { a: '3334', b: '3332', c: '0' }),
+        ).toBe(2);
       });
     });
 
@@ -480,6 +509,13 @@ describe('transforms', () => {
         expect(
           executeMultiKeyTransform(average(undefined, true), { a: '10', b: '20', c: '25' }),
         ).toBe(18);
+      });
+
+      it('should ignore zero values when ignoreZero is set', () => {
+        // Without ignoreZero the average would be (30 + 0) / 2 = 15
+        expect(
+          executeMultiKeyTransform(average(undefined, true, true), { a: '20', b: '40', c: '0' }),
+        ).toBe(30);
       });
     });
   });

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -198,18 +198,24 @@ export interface SumTransform {
 export interface MinTransform {
   type: 'min';
   scale?: number;
+  /** Ignore values that are exactly 0 (e.g. unused battery cells) */
+  ignoreZero?: boolean;
 }
 
 /** Get maximum value */
 export interface MaxTransform {
   type: 'max';
   scale?: number;
+  /** Ignore values that are exactly 0 (e.g. unused battery cells) */
+  ignoreZero?: boolean;
 }
 
 /** Get difference between max and min */
 export interface DiffTransform {
   type: 'diff';
   scale?: number;
+  /** Ignore values that are exactly 0 (e.g. unused battery cells) */
+  ignoreZero?: boolean;
 }
 
 /** Get average of all values */
@@ -217,6 +223,8 @@ export interface AverageTransform {
   type: 'average';
   scale?: number;
   round?: boolean;
+  /** Ignore values that are exactly 0 (e.g. unused battery cells) */
+  ignoreZero?: boolean;
 }
 
 // =============================================================================
@@ -335,19 +343,36 @@ export const bitMaskToWeekday = (): BitMaskToWeekdayTransform => ({ type: 'bitMa
 export const sum = (scale?: number): SumTransform => ({ type: 'sum', scale });
 
 /** Create a min transform */
-export const min = (scale?: number): MinTransform => ({ type: 'min', scale });
+export const min = (scale?: number, ignoreZero?: boolean): MinTransform => ({
+  type: 'min',
+  scale,
+  ignoreZero,
+});
 
 /** Create a max transform */
-export const max = (scale?: number): MaxTransform => ({ type: 'max', scale });
+export const max = (scale?: number, ignoreZero?: boolean): MaxTransform => ({
+  type: 'max',
+  scale,
+  ignoreZero,
+});
 
 /** Create a diff transform */
-export const diff = (scale?: number): DiffTransform => ({ type: 'diff', scale });
+export const diff = (scale?: number, ignoreZero?: boolean): DiffTransform => ({
+  type: 'diff',
+  scale,
+  ignoreZero,
+});
 
 /** Create an average transform */
-export const average = (scale?: number, roundResult?: boolean): AverageTransform => ({
+export const average = (
+  scale?: number,
+  roundResult?: boolean,
+  ignoreZero?: boolean,
+): AverageTransform => ({
   type: 'average',
   scale,
   round: roundResult,
+  ignoreZero,
 });
 
 // =============================================================================
@@ -490,28 +515,36 @@ export function executeMultiKeyTransform(
     }
 
     case 'min': {
-      const validValues = numericValues.filter(v => !isNaN(v));
+      const validValues = numericValues.filter(
+        v => !isNaN(v) && (!transform.ignoreZero || v !== 0),
+      );
       if (validValues.length === 0) return 0;
       const result = Math.min(...validValues);
       return transform.scale ? result / transform.scale : result;
     }
 
     case 'max': {
-      const validValues = numericValues.filter(v => !isNaN(v));
+      const validValues = numericValues.filter(
+        v => !isNaN(v) && (!transform.ignoreZero || v !== 0),
+      );
       if (validValues.length === 0) return 0;
       const result = Math.max(...validValues);
       return transform.scale ? result / transform.scale : result;
     }
 
     case 'diff': {
-      const validValues = numericValues.filter(v => !isNaN(v));
+      const validValues = numericValues.filter(
+        v => !isNaN(v) && (!transform.ignoreZero || v !== 0),
+      );
       if (validValues.length === 0) return 0;
       const result = Math.max(...validValues) - Math.min(...validValues);
       return transform.scale ? result / transform.scale : result;
     }
 
     case 'average': {
-      const validValues = numericValues.filter(v => !isNaN(v));
+      const validValues = numericValues.filter(
+        v => !isNaN(v) && (!transform.ignoreZero || v !== 0),
+      );
       if (validValues.length === 0) return 0;
       let result = validValues.reduce((acc, v) => acc + v, 0) / validValues.length;
       if (transform.round) result = Math.round(result);
@@ -740,8 +773,11 @@ export function multiKeyTransformToJinja2(
   // Use float(none) so invalid values become None instead of 0
   const values = keys.map(k => `${valuePrefix}.${k} | float(none)`);
   const rawListExpr = `[${values.join(', ')}]`;
-  // Filter out None values
-  const filteredListExpr = `${rawListExpr} | reject('equalto', none) | list`;
+  // Filter out None values, and optionally values that are exactly 0
+  const ignoreZero = transform.type !== 'sum' && transform.ignoreZero;
+  const filteredListExpr = ignoreZero
+    ? `${rawListExpr} | reject('equalto', none) | reject('equalto', 0) | list`
+    : `${rawListExpr} | reject('equalto', none) | list`;
 
   switch (transform.type) {
     case 'sum': {

--- a/src/types.ts
+++ b/src/types.ts
@@ -405,6 +405,10 @@ export interface VenusBMSInfo extends BaseDeviceData {
   cells?: {
     voltages?: number[];
     temperatures?: number[];
+    minVoltage?: number;
+    maxVoltage?: number;
+    voltageDiff?: number;
+    voltageAvg?: number;
   };
   bms?: {
     version?: number;
@@ -575,6 +579,8 @@ export interface JupiterBMSInfo extends BaseDeviceData {
       minVoltageCell?: number; // vol_[x*i], high byte
       maxVoltage?: number; // vol_[x*i+1]
       maxVoltageCell?: number; // vol_[x*i], low byte
+      voltageDiff?: number; // maxVoltage - minVoltage (drift)
+      voltageAvg?: number; // (maxVoltage + minVoltage) / 2
     };
   }[];
   mppt?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -580,7 +580,6 @@ export interface JupiterBMSInfo extends BaseDeviceData {
       maxVoltage?: number; // vol_[x*i+1]
       maxVoltageCell?: number; // vol_[x*i], low byte
       voltageDiff?: number; // maxVoltage - minVoltage (drift)
-      voltageAvg?: number; // (maxVoltage + minVoltage) / 2
     };
   }[];
   mppt?: {


### PR DESCRIPTION
## Summary

This PR adds aggregate cell voltage statistics sensors to Venus and Jupiter BMS implementations, providing insights into battery cell health and balance. The changes include new transform functions that intelligently ignore unused cells (reported as 0) to provide accurate statistics.

## Key Changes

- **Venus BMS**: Added four new aggregate cell voltage sensors computed from individual cell voltages (b_vo1-b_vo16):
  - Min Cell Voltage
  - Max Cell Voltage
  - Cell Voltage Difference (drift between highest and lowest)
  - Average Cell Voltage
  - All sensors ignore unused cells reported as 0 on smaller batteries

- **Jupiter BMS**: Added Cell Voltage Difference sensor per battery, derived from the already-reported highest/lowest cell voltage values (Jupiter only reports min/max, not individual cells)

- **Transform Functions**: Enhanced `min()`, `max()`, `diff()`, and `average()` transform functions with an optional `ignoreZero` parameter to filter out zero values during aggregation

- **Jinja2 Support**: Updated Jinja2 template generation to properly filter zero values when `ignoreZero` is enabled

- **Type Definitions**: Extended `VenusBMSInfo` and `JupiterBMSInfo` interfaces to include the new aggregate voltage fields

- **Tests**: Added comprehensive test coverage for the new `ignoreZero` functionality across all affected transforms

## Implementation Details

- The `ignoreZero` parameter is applied during value filtering in `executeMultiKeyTransform()`, ensuring zero values are excluded before computing min, max, diff, or average
- All new sensors are disabled by default to avoid cluttering the UI
- The implementation properly handles edge cases where all values are zero or NaN
- Jinja2 template generation uses `reject('equalto', 0)` filter when `ignoreZero` is enabled

https://claude.ai/code/session_018QpS6gmRmk6F6fBikt9ALa