### PR TITLE
Venus: expose PV inputs and additional metering/version sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Jupiter: Add a *Cell Voltage Difference* (drift) sensor per battery, derived from the reported highest/lowest cell voltage. (Jupiter only reports the highest and lowest cell voltage, not individual cells, so a true average cannot be computed.)
 - All new sensors are disabled by default.
 - Venus: Expose per-string PV input power (PV1–PV4), their connection status and a combined Total PV Power sensor on any Venus model that reports them (e.g. Venus A and Venus D). The entities are advertised purely based on the presence of the corresponding `pv1`–`pv4` values in the payload, independent of the device type
+- Venus: Expose additional runtime info sensors: Charging Price (`prc_c`) and Discharge Price (`prc_d`), WiFi Signal Strength (`wif_s`), CT Type (`ct_t`), Phase Type (`phase_t`), Recharge Mode (`dchrg_t`), BMS Version (`bms_v`), Communication Module Version (`fc_v`) and Shelly Port (`shelly_p`)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Venus D (VNSD): Scale the BMS cell and MOSFET temperatures to °C (they were previously published 10× too high, e.g. 164 instead of 16.4 °C), matching the existing Venus A behavior
 - Log messages no longer drop their trailing values (e.g. `Current period 1 settings:` was logged without the actual settings, and error logs were missing the error details). Pino only interpolates extra arguments into `%s`-style placeholders, so console-style log calls silently lost everything after the message (fixes #326)
 - B2500: The `Current period X settings:` message logged for every received time-period command is now logged at `debug` level instead of `info`, so automations that frequently update time periods no longer flood the log (fixes #326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Venus: Add aggregate cell-voltage sensors (*Min Cell Voltage*, *Max Cell Voltage*, *Cell Voltage Difference* and *Average Cell Voltage*) computed from the individual cell voltages, ignoring unused cells reported as `0`. These match the equivalent sensors already available on the B2500.
 - Jupiter: Add a *Cell Voltage Difference* (drift) sensor per battery, derived from the reported highest/lowest cell voltage. (Jupiter only reports the highest and lowest cell voltage, not individual cells, so a true average cannot be computed.)
 - All new sensors are disabled by default.
-- Venus D (VNSD): Expose per-string PV input power (PV1–PV4), their connection status and a combined Total PV Power sensor. The entities are only advertised when the device actually reports the corresponding `pv1`–`pv4` values in its payload
+- Venus: Expose per-string PV input power (PV1–PV4), their connection status and a combined Total PV Power sensor on any Venus model that reports them (e.g. Venus A and Venus D). The entities are advertised purely based on the presence of the corresponding `pv1`–`pv4` values in the payload, independent of the device type
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Venus: Add aggregate cell-voltage sensors (*Min Cell Voltage*, *Max Cell Voltage*, *Cell Voltage Difference* and *Average Cell Voltage*) computed from the individual cell voltages, ignoring unused cells reported as `0`. These match the equivalent sensors already available on the B2500.
 - Jupiter: Add a *Cell Voltage Difference* (drift) sensor per battery, derived from the reported highest/lowest cell voltage. (Jupiter only reports the highest and lowest cell voltage, not individual cells, so a true average cannot be computed.)
 - All new sensors are disabled by default.
+- Venus D (VNSD): Expose per-string PV input power (PV1–PV4), their connection status and a combined Total PV Power sensor. The entities are only advertised when the device actually reports the corresponding `pv1`–`pv4` values in its payload
 
 ### Fixed
 

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -158,6 +158,10 @@ Description of the above parameters:
 | fc_v | Communication module version number |
 | wifi_n | WIFI Name |
 | dod | Depth of discharge (%) (configurable 30-88% in the Marstek app; the maximum of 88% is encoded as 0) |
+| pv1 | PV input 1 power (0.1W) \| connection status (0: Not connected; 1: Connected) (Venus A/D only) |
+| pv2 | PV input 2 power (0.1W) \| connection status (Venus A/D only) |
+| pv3 | PV input 3 power (0.1W) \| connection status (Venus A/D only) |
+| pv4 | PV input 4 power (0.1W) \| connection status (Venus A/D only) |
 
 ## 4 Set working status
 

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -158,6 +158,7 @@ Description of the above parameters:
 | fc_v | Communication module version number |
 | wifi_n | WIFI Name |
 | dod | Depth of discharge (%) (configurable 30-88% in the Marstek app; the maximum of 88% is encoded as 0) |
+| shelly_p | Shelly UDP port (only meaningful when `ct_t` is a Shelly meter) |
 | pv1 | PV input 1 power (0.1W) \| connection status (0: Not connected; 1: Connected) (only reported by Venus models with PV inputs, e.g. Venus A/D) |
 | pv2 | PV input 2 power (0.1W) \| connection status (only reported by Venus models with PV inputs) |
 | pv3 | PV input 3 power (0.1W) \| connection status (only reported by Venus models with PV inputs) |

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -158,10 +158,10 @@ Description of the above parameters:
 | fc_v | Communication module version number |
 | wifi_n | WIFI Name |
 | dod | Depth of discharge (%) (configurable 30-88% in the Marstek app; the maximum of 88% is encoded as 0) |
-| pv1 | PV input 1 power (0.1W) \| connection status (0: Not connected; 1: Connected) (Venus A/D only) |
-| pv2 | PV input 2 power (0.1W) \| connection status (Venus A/D only) |
-| pv3 | PV input 3 power (0.1W) \| connection status (Venus A/D only) |
-| pv4 | PV input 4 power (0.1W) \| connection status (Venus A/D only) |
+| pv1 | PV input 1 power (0.1W) \| connection status (0: Not connected; 1: Connected) (only reported by Venus models with PV inputs, e.g. Venus A/D) |
+| pv2 | PV input 2 power (0.1W) \| connection status (only reported by Venus models with PV inputs) |
+| pv3 | PV input 3 power (0.1W) \| connection status (only reported by Venus models with PV inputs) |
+| pv4 | PV input 4 power (0.1W) \| connection status (only reported by Venus models with PV inputs) |
 
 ## 4 Set working status
 

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -161,7 +161,7 @@ function isVenusRuntimeInfoMessage(values: Record<string, string>): boolean {
 // there is no need to special-case device types here.
 registerDeviceDefinition(
   {
-    deviceTypes: ['HMG', 'VNSE3', 'VNSD'],
+    deviceTypes: ['HMG', 'VNSE3'],
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);
@@ -169,11 +169,11 @@ registerDeviceDefinition(
   },
 );
 
-// Venus A (VNSA) uses a different scaling for the BMS cell/MOSFET temperatures
-// (factor of 10) compared to the other Venus variants.
+// Venus A (VNSA) and Venus D (VNSD) use a different scaling for the BMS
+// cell/MOSFET temperatures (factor of 10) compared to the other Venus variants.
 registerDeviceDefinition(
   {
-    deviceTypes: ['VNSA'],
+    deviceTypes: ['VNSA', 'VNSD'],
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -154,9 +154,13 @@ function isVenusRuntimeInfoMessage(values: Record<string, string>): boolean {
   return requiredRuntimeInfoKeys.every(key => key in values);
 }
 
+// Per-string PV input power (PV1–PV4) is reported by Venus models that have PV
+// inputs (e.g. Venus A/D). The corresponding entities are advertised purely
+// based on whether the device reports the `pv1`–`pv4` fields in its payload, so
+// there is no need to special-case device types here.
 registerDeviceDefinition(
   {
-    deviceTypes: ['HMG', 'VNSE3'],
+    deviceTypes: ['HMG', 'VNSE3', 'VNSD'],
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);
@@ -164,35 +168,19 @@ registerDeviceDefinition(
   },
 );
 
-// Venus A (VNSA) reports additional per-string PV input power and uses a
-// different scaling for the BMS cell/MOSFET temperatures (factor of 10)
-// compared to the other Venus variants.
+// Venus A (VNSA) uses a different scaling for the BMS cell/MOSFET temperatures
+// (factor of 10) compared to the other Venus variants.
 registerDeviceDefinition(
   {
     deviceTypes: ['VNSA'],
   },
   ({ message }) => {
-    registerRuntimeInfoMessage(message, { withPvInputs: true });
+    registerRuntimeInfoMessage(message);
     registerBMSInfoMessage(message, { scaleTemperatures: true });
   },
 );
 
-// Venus D (VNSD) also reports per-string PV input power, but uses the default
-// BMS cell/MOSFET temperature scaling like the other (non-VNSA) variants.
-registerDeviceDefinition(
-  {
-    deviceTypes: ['VNSD'],
-  },
-  ({ message }) => {
-    registerRuntimeInfoMessage(message, { withPvInputs: true });
-    registerBMSInfoMessage(message);
-  },
-);
-
-function registerRuntimeInfoMessage(
-  message: BuildMessageFn,
-  { withPvInputs = false }: { withPvInputs?: boolean } = {},
-) {
+function registerRuntimeInfoMessage(message: BuildMessageFn) {
   let options = {
     refreshDataPayload: 'cd=1',
     isMessage: isVenusRuntimeInfoMessage,
@@ -246,63 +234,63 @@ function registerRuntimeInfoMessage(
       }),
     );
 
-    // PV / solar input information
-    if (withPvInputs) {
-      // Per-string PV input power and connection status (pvN = "<power>|<connected>")
-      const pvInputs = [
-        { key: 'pv1', power: 'pv1Power', connected: 'pv1Connected', label: 'PV1' },
-        { key: 'pv2', power: 'pv2Power', connected: 'pv2Connected', label: 'PV2' },
-        { key: 'pv3', power: 'pv3Power', connected: 'pv3Connected', label: 'PV3' },
-        { key: 'pv4', power: 'pv4Power', connected: 'pv4Connected', label: 'PV4' },
-      ] as const;
-      for (const pv of pvInputs) {
-        field({ key: pv.key, path: [pv.power], transform: venusPvField('power') });
-        advertise(
-          [pv.power],
-          sensorComponent<number>({
-            id: `${pv.key}_power`,
-            name: `${pv.label} Power`,
-            device_class: 'power',
-            unit_of_measurement: 'W',
-            state_class: 'measurement',
-          }),
-          { enabled: state => (state[pv.power] != null ? true : undefined) },
-        );
-
-        field({ key: pv.key, path: [pv.connected], transform: venusPvField('connected') });
-        advertise(
-          [pv.connected],
-          binarySensorComponent({
-            id: `${pv.key}_connected`,
-            name: `${pv.label} Connected`,
-            device_class: 'connectivity',
-            icon: 'mdi:solar-power',
-            enabled_by_default: false,
-          }),
-          { enabled: state => (state[pv.connected] != null ? true : undefined) },
-        );
-      }
-
-      // Total PV power across all inputs. Each value is "<power>|<connected>"
-      // with power in deciwatts; sum() reads the leading number from each and
-      // the scale converts the deciwatt total to watts.
-      field({
-        key: ['pv1', 'pv2', 'pv3', 'pv4'],
-        path: ['totalPvPower'],
-        transform: sum(10),
-      });
+    // PV / solar input information. Only Venus models with PV inputs (e.g.
+    // Venus A/D) report the pvN fields; the entities below are advertised purely
+    // based on their presence in the payload, so they apply to any device type.
+    // Per-string PV input power and connection status (pvN = "<power>|<connected>")
+    const pvInputs = [
+      { key: 'pv1', power: 'pv1Power', connected: 'pv1Connected', label: 'PV1' },
+      { key: 'pv2', power: 'pv2Power', connected: 'pv2Connected', label: 'PV2' },
+      { key: 'pv3', power: 'pv3Power', connected: 'pv3Connected', label: 'PV3' },
+      { key: 'pv4', power: 'pv4Power', connected: 'pv4Connected', label: 'PV4' },
+    ] as const;
+    for (const pv of pvInputs) {
+      field({ key: pv.key, path: [pv.power], transform: venusPvField('power') });
       advertise(
-        ['totalPvPower'],
+        [pv.power],
         sensorComponent<number>({
-          id: 'total_pv_power',
-          name: 'Total PV Power',
+          id: `${pv.key}_power`,
+          name: `${pv.label} Power`,
           device_class: 'power',
           unit_of_measurement: 'W',
           state_class: 'measurement',
         }),
-        { enabled: state => (state.totalPvPower != null ? true : undefined) },
+        { enabled: state => (state[pv.power] != null ? true : undefined) },
+      );
+
+      field({ key: pv.key, path: [pv.connected], transform: venusPvField('connected') });
+      advertise(
+        [pv.connected],
+        binarySensorComponent({
+          id: `${pv.key}_connected`,
+          name: `${pv.label} Connected`,
+          device_class: 'connectivity',
+          icon: 'mdi:solar-power',
+          enabled_by_default: false,
+        }),
+        { enabled: state => (state[pv.connected] != null ? true : undefined) },
       );
     }
+
+    // Total PV power across all inputs. Each value is "<power>|<connected>"
+    // with power in deciwatts; sum() reads the leading number from each and
+    // the scale converts the deciwatt total to watts.
+    field({
+      key: ['pv1', 'pv2', 'pv3', 'pv4'],
+      path: ['totalPvPower'],
+      transform: sum(10),
+    });
+    advertise(
+      ['totalPvPower'],
+      sensorComponent<number>({
+        id: 'total_pv_power',
+        name: 'Total PV Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+      { enabled: state => (state.totalPvPower != null ? true : undefined) },
+    );
 
     // Power information
     field({

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -156,7 +156,7 @@ function isVenusRuntimeInfoMessage(values: Record<string, string>): boolean {
 
 registerDeviceDefinition(
   {
-    deviceTypes: ['HMG', 'VNSE3', 'VNSD'],
+    deviceTypes: ['HMG', 'VNSE3'],
   },
   ({ message }) => {
     registerRuntimeInfoMessage(message);
@@ -174,6 +174,18 @@ registerDeviceDefinition(
   ({ message }) => {
     registerRuntimeInfoMessage(message, { withPvInputs: true });
     registerBMSInfoMessage(message, { scaleTemperatures: true });
+  },
+);
+
+// Venus D (VNSD) also reports per-string PV input power, but uses the default
+// BMS cell/MOSFET temperature scaling like the other (non-VNSA) variants.
+registerDeviceDefinition(
+  {
+    deviceTypes: ['VNSD'],
+  },
+  ({ message }) => {
+    registerRuntimeInfoMessage(message, { withPvInputs: true });
+    registerBMSInfoMessage(message);
   },
 );
 
@@ -254,6 +266,7 @@ function registerRuntimeInfoMessage(
             unit_of_measurement: 'W',
             state_class: 'measurement',
           }),
+          { enabled: state => (state[pv.power] != null ? true : undefined) },
         );
 
         field({ key: pv.key, path: [pv.connected], transform: venusPvField('connected') });
@@ -266,6 +279,7 @@ function registerRuntimeInfoMessage(
             icon: 'mdi:solar-power',
             enabled_by_default: false,
           }),
+          { enabled: state => (state[pv.connected] != null ? true : undefined) },
         );
       }
 
@@ -286,6 +300,7 @@ function registerRuntimeInfoMessage(
           unit_of_measurement: 'W',
           state_class: 'measurement',
         }),
+        { enabled: state => (state.totalPvPower != null ? true : undefined) },
       );
     }
 

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -32,6 +32,7 @@ import {
   max,
   diff,
   average,
+  negate,
   venusPvField,
 } from '../transforms';
 
@@ -443,6 +444,38 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
+    // Electricity prices. Reported in the same 0.001 € unit as the income
+    // fields, so the value is divided by 1000 to convert it to euros.
+    field({
+      key: 'prc_c',
+      path: ['chargingPrice'],
+      transform: divide(1000),
+    });
+    advertise(
+      ['chargingPrice'],
+      sensorComponent<number>({
+        id: 'charging_price',
+        name: 'Charging Price',
+        device_class: 'monetary',
+        unit_of_measurement: '€',
+      }),
+    );
+
+    field({
+      key: 'prc_d',
+      path: ['dischargePrice'],
+      transform: divide(1000),
+    });
+    advertise(
+      ['dischargePrice'],
+      sensorComponent<number>({
+        id: 'discharge_price',
+        name: 'Discharge Price',
+        device_class: 'monetary',
+        unit_of_measurement: '€',
+      }),
+    );
+
     // Grid information
     field({
       key: 'grd_f',
@@ -537,6 +570,109 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
+    field({
+      key: 'ct_t',
+      path: ['ctType'],
+      transform: map(
+        {
+          '0': 'none',
+          '1': 'ct1',
+          '2': 'ct2',
+          '3': 'ct3',
+          '4': 'shellyPro',
+          '5': 'p1Meter',
+        },
+        'none',
+      ),
+    });
+    advertise(
+      ['ctType'],
+      sensorComponent<NonNullable<VenusDeviceData['ctType']>>({
+        id: 'ct_type',
+        name: 'CT Type',
+        icon: 'mdi:current-ac',
+        valueMappings: {
+          none: 'No Meter Detected',
+          ct1: 'CT1',
+          ct2: 'CT2',
+          ct3: 'CT3',
+          shellyPro: 'Shelly Pro',
+          p1Meter: 'P1 Meter',
+        },
+      }),
+    );
+
+    // Shelly UDP port, only meaningful when a Shelly meter is configured as the
+    // CT type.
+    field({
+      key: 'shelly_p',
+      path: ['shellyPort'],
+      transform: number(),
+    });
+    advertise(
+      ['shellyPort'],
+      sensorComponent<number>({
+        id: 'shelly_port',
+        name: 'Shelly Port',
+        icon: 'mdi:lan',
+        enabled_by_default: false,
+      }),
+    );
+
+    field({
+      key: 'phase_t',
+      path: ['phaseType'],
+      transform: map(
+        {
+          '0': 'unknown',
+          '1': 'phaseA',
+          '2': 'phaseB',
+          '3': 'phaseC',
+          '4': 'notDetected',
+        },
+        'unknown',
+      ),
+    });
+    advertise(
+      ['phaseType'],
+      sensorComponent<NonNullable<VenusDeviceData['phaseType']>>({
+        id: 'phase_type',
+        name: 'Phase Type',
+        icon: 'mdi:sine-wave',
+        valueMappings: {
+          unknown: 'Unknown',
+          phaseA: 'Phase A',
+          phaseB: 'Phase B',
+          phaseC: 'Phase C',
+          notDetected: 'Not Detected',
+        },
+      }),
+    );
+
+    field({
+      key: 'dchrg_t',
+      path: ['rechargeMode'],
+      transform: map(
+        {
+          '0': 'singlePhase',
+          '1': 'threePhase',
+        },
+        'singlePhase',
+      ),
+    });
+    advertise(
+      ['rechargeMode'],
+      sensorComponent<NonNullable<VenusDeviceData['rechargeMode']>>({
+        id: 'recharge_mode',
+        name: 'Recharge Mode',
+        icon: 'mdi:flash',
+        valueMappings: {
+          singlePhase: 'Single Phase',
+          threePhase: 'Three Phase',
+        },
+      }),
+    );
+
     // Battery status
     field({
       key: 'cel_s',
@@ -606,6 +742,52 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         id: 'device_version',
         name: 'Device Version',
         icon: 'mdi:information',
+      }),
+    );
+
+    field({
+      key: 'bms_v',
+      path: ['bmsVersion'],
+      transform: number(),
+    });
+    advertise(
+      ['bmsVersion'],
+      sensorComponent<number>({
+        id: 'bms_version',
+        name: 'BMS Version',
+        icon: 'mdi:information',
+        enabled_by_default: false,
+      }),
+    );
+
+    field({
+      key: 'fc_v',
+      path: ['communicationModuleVersion'],
+      transform: identity(),
+    });
+    advertise(
+      ['communicationModuleVersion'],
+      sensorComponent<string>({
+        id: 'communication_module_version',
+        name: 'Communication Module Version',
+        icon: 'mdi:information',
+        enabled_by_default: false,
+      }),
+    );
+
+    field({
+      key: 'wif_s',
+      path: ['wifiSignalStrength'],
+      transform: negate(),
+    });
+    advertise(
+      ['wifiSignalStrength'],
+      sensorComponent<number>({
+        id: 'wifi_signal_strength',
+        name: 'WiFi Signal Strength',
+        device_class: 'signal_strength',
+        unit_of_measurement: 'dBm',
+        state_class: 'measurement',
       }),
     );
 

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -365,4 +365,48 @@ describe('Home Assistant Discovery', () => {
     expect(withDod[0].config).not.toBeNull();
     expect(withDod[0].config).toMatchObject({ min: 30, max: 88, step: 1 });
   });
+
+  test('should gate Venus D PV input discovery configs on data presence', () => {
+    const device: Device = { deviceType: 'VNSD-0', deviceId: 'venusD123' };
+    const deviceTopics: DeviceTopics = {
+      deviceTopicOld: 'hame_energy/VNSD-0/device/venusD123/ctrl',
+      deviceTopicNew: 'marstek_energy/VNSD-0/device/venusD123/ctrl',
+      deviceControlTopicOld: 'hame_energy/VNSD-0/App/venusD123/ctrl',
+      deviceControlTopicNew: 'marstek_energy/VNSD-0/App/venusD123/ctrl',
+      availabilityTopic: 'hame_energy/VNSD-0/availability/venusD123',
+      controlSubscriptionTopic: 'hame_energy/VNSD-0/control/venusD123/control',
+      publishTopic: 'hame_energy/VNSD-0/device/venusD123/data',
+    };
+
+    const pvTopics = (state: object) =>
+      generateDiscoveryConfigs(
+        device,
+        deviceTopics,
+        {},
+        DEFAULT_TOPIC_PREFIX,
+        'homeassistant',
+        state,
+      )
+        .map(c => c.topic)
+        .filter(t => /pv\d_power|pv\d_connected|total_pv_power/.test(t));
+
+    // No PV data: PV configs are deferred (nothing published)
+    expect(pvTopics({ batterySoc: 94 })).toHaveLength(0);
+
+    // PV data present: power, connected and total PV configs are advertised
+    const withPv = pvTopics({
+      pv1Power: 259.8,
+      pv1Connected: true,
+      pv2Power: 0,
+      pv2Connected: false,
+      totalPvPower: 259.8,
+    });
+    expect(withPv.some(t => t.includes('pv1_power'))).toBe(true);
+    expect(withPv.some(t => t.includes('pv1_connected'))).toBe(true);
+    expect(withPv.some(t => t.includes('pv2_power'))).toBe(true);
+    expect(withPv.some(t => t.includes('total_pv_power'))).toBe(true);
+    // pv3/pv4 have no data, so they remain deferred
+    expect(withPv.some(t => t.includes('pv3_'))).toBe(false);
+    expect(withPv.some(t => t.includes('pv4_'))).toBe(false);
+  });
 });

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -684,10 +684,23 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('totalPvPower', 107.6);
   });
 
-  test('does not expose PV inputs for non-PV Venus variants (VNSE3)', () => {
+  test('exposes PV inputs based on payload presence regardless of device type (VNSE3)', () => {
+    // PV handling is device-type independent: any Venus that reports the pvN
+    // fields exposes the corresponding values.
     const message =
-      'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0,pv1=1076|1';
+      'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0,pv1=1076|1,pv2=0|0,pv3=0|0,pv4=0|0';
     const parsed = parseMessage(message, 'VNSE3-0', 'venus123');
+
+    const result = parsed['data'] as VenusDeviceData;
+    expect(result).toHaveProperty('pv1Power', 107.6);
+    expect(result).toHaveProperty('pv1Connected', true);
+    expect(result).toHaveProperty('totalPvPower', 107.6);
+  });
+
+  test('does not expose PV inputs when the payload omits them', () => {
+    const message =
+      'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
 
     const result = parsed['data'] as VenusDeviceData;
     expect(result).not.toHaveProperty('pv1Power');

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -771,6 +771,19 @@ describe('MQTT Message Parser', () => {
     expect(result.cells?.voltageAvg).toBe(3334);
   });
 
+  test('scales Venus D (VNSD) BMS cell/MOSFET temperatures like Venus A', () => {
+    const message =
+      'cd=14,b_ver=116,b_chv=468,b_soc=94,b_soh=100,b_cap=5120,b_vol=4328,b_cur=20,b_tem=16,b_chf=3,b_cpc=157,b_err=0,b_war=0,b_ret=0,b_ent=0,b_mot=173,b_tp1=164,b_tp2=166,b_tp3=168,b_tp4=166,b_vo1=3334,b_vo2=3332,b_vo3=3333,b_vo4=3333,b_vo5=3334,b_vo6=3335,b_vo7=3334,b_vo8=3334,b_vo9=3334,b_vo10=3334,b_vo11=3333,b_vo12=3333,b_vo13=3333,b_vo14=0,b_vo15=0,b_vo16=0';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
+
+    const result = parsed['bms'] as VenusBMSInfo;
+    // Cell/MOSFET temperatures are reported in deci-degrees and scaled to °C.
+    expect(result.bms?.mosfetTemp).toBeCloseTo(17.3);
+    expect(result.cells?.temperatures?.[0]).toBeCloseTo(16.4);
+    // Battery temperature (b_tem) is already in whole degrees and stays unscaled.
+    expect(result.bms?.temperature).toBe(16);
+  });
+
   test('Venus E (VNSE3) BMS scales voltages but keeps raw temperatures', () => {
     const message =
       'cd=14,b_ver=212,b_chv=571,b_soc=65,b_soh=100,b_cap=5120,b_vol=5223,b_cur=-94,b_tem=25,b_chf=192,b_cpc=332,b_err=0,b_war=0,b_ret=0,b_ent=0,b_mot=23,b_tp1=18,b_tp2=19,b_tp3=18,b_tp4=19,b_vo1=3265,b_vo2=3265,b_vo3=3265,b_vo4=3265,b_vo5=3264,b_vo6=3264,b_vo7=3265,b_vo8=3265,b_vo9=3264,b_vo10=3265,b_vo11=3264,b_vo12=3265,b_vo13=3265,b_vo14=3265,b_vo15=3264,b_vo16=3262';

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -725,6 +725,27 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('totalPvPower', 525);
   });
 
+  test('parses Venus metering, pricing and version fields', () => {
+    // Full Venus D dump exercising the CT/phase/pricing/version sensors.
+    const message =
+      'cd=1,tot_i=1,tot_o=212,ele_d=0,ele_m=1,grd_d=212,grd_m=212,inc_d=0,inc_m=0,grd_f=0,grd_o=423,grd_t=3,gct_s=1,cel_s=2,cel_p=483,cel_c=94,err_t=800,err_a=8,dev_n=142,grd_y=0,wor_m=0,cts_m=0,bac_u=0,tra_a=74,tra_i=0,tra_o=0,htt_p=0,prc_c=0,prc_d=3,wif_s=72,inc_a=0,set_v=1,mcp_w=2200,mdp_w=800,ct_t=3,phase_t=1,dchrg_t=1,bms_v=116,fc_v=202409090159,wifi_n=unten,shelly_p=1010';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
+
+    expect(parsed).toHaveProperty('data');
+    const result = parsed['data'] as VenusDeviceData;
+    // Prices use the same 0.001 € unit as the income fields
+    expect(result).toHaveProperty('chargingPrice', 0);
+    expect(result).toHaveProperty('dischargePrice', 0.003);
+    // WiFi signal strength is negated into a dBm-style value
+    expect(result).toHaveProperty('wifiSignalStrength', -72);
+    expect(result).toHaveProperty('ctType', 'ct3');
+    expect(result).toHaveProperty('phaseType', 'phaseA');
+    expect(result).toHaveProperty('rechargeMode', 'threePhase');
+    expect(result).toHaveProperty('bmsVersion', 116);
+    expect(result).toHaveProperty('communicationModuleVersion', '202409090159');
+    expect(result).toHaveProperty('shellyPort', 1010);
+  });
+
   test('scales Venus A (VNSA) BMS voltages and temperatures (issue #218)', () => {
     // Real BMS reading from a Venus A. Battery voltage is in centivolts,
     // charge voltage in decivolts, cell/MOSFET temperatures in deci-degrees.

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -684,7 +684,7 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('totalPvPower', 107.6);
   });
 
-  test('does not expose PV inputs for non-Venus-A variants (VNSE3)', () => {
+  test('does not expose PV inputs for non-PV Venus variants (VNSE3)', () => {
     const message =
       'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0,pv1=1076|1';
     const parsed = parseMessage(message, 'VNSE3-0', 'venus123');
@@ -692,6 +692,24 @@ describe('MQTT Message Parser', () => {
     const result = parsed['data'] as VenusDeviceData;
     expect(result).not.toHaveProperty('pv1Power');
     expect(result).not.toHaveProperty('totalPvPower');
+  });
+
+  test('parses Venus D (VNSD) PV input power and connection status', () => {
+    // Real runtime reading from a Venus D: pv1 connected and producing, pv2-4 idle.
+    const message =
+      'cd=1,tot_i=1,tot_o=212,ele_d=0,ele_m=1,grd_d=212,grd_m=212,inc_d=0,inc_m=0,grd_f=0,grd_o=423,grd_t=3,gct_s=1,cel_s=2,cel_p=483,cel_c=94,err_t=800,err_a=8,dev_n=142,grd_y=0,wor_m=0,inc_a=0,mcp_w=2200,mdp_w=800,pv1=2598|1,pv2=2652|1,pv3=0|1,pv4=0|1,pack=2|3|1|0,pv=697|697,fu=0|0,em=0';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
+
+    expect(parsed).toHaveProperty('data');
+    const result = parsed['data'] as VenusDeviceData;
+    // PV power is reported in deciwatts: 2598 -> 259.8 W
+    expect(result).toHaveProperty('pv1Power', 259.8);
+    expect(result).toHaveProperty('pv2Power', 265.2);
+    expect(result).toHaveProperty('pv3Power', 0);
+    expect(result).toHaveProperty('pv1Connected', true);
+    expect(result).toHaveProperty('pv2Connected', true);
+    // 2598 + 2652 -> 5250 deciwatts -> 525 W
+    expect(result).toHaveProperty('totalPvPower', 525);
   });
 
   test('scales Venus A (VNSA) BMS voltages and temperatures (issue #218)', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -395,6 +395,7 @@ export interface VenusDeviceData extends BaseDeviceData {
   rechargeMode?: VenusRechargeMode;
   bmsVersion?: number;
   communicationModuleVersion?: string;
+  shellyPort?: number;
   wifiName?: string;
   localApiEnabled?: boolean;
   localApiPort?: number;


### PR DESCRIPTION
## Summary

Adds Home Assistant entities for several Venus runtime-info (`cd=1`) fields that were previously parsed/typed but never exposed, and extends per-string PV input support to all Venus models.

## What changed

**PV inputs (device-type independent)**
- Expose per-string PV input power (PV1–PV4), per-string connection status, and a combined Total PV Power sensor.
- Previously these were wired only for Venus A (VNSA). They're now registered for every Venus device type and advertised purely based on the presence of the `pv1`–`pv4` fields in the payload (via the discovery `enabled` predicate), so e.g. Venus D (VNSD) gets them too while devices that don't report PV stay unaffected.

**Additional runtime-info sensors**
- Charging Price (`prc_c`) and Discharge Price (`prc_d`) — monetary €, using the same `0.001 €` unit as the existing income fields.
- WiFi Signal Strength (`wif_s`) — negated to a dBm-style value, mirroring the Jupiter sensor.
- CT Type (`ct_t`), Phase Type (`phase_t`), Recharge Mode (`dchrg_t`) — enum sensors with friendly value mappings.
- BMS Version (`bms_v`), Communication Module Version (`fc_v`), Shelly Port (`shelly_p`) — diagnostic sensors, disabled by default.

The enum types and most data fields already existed in `types.ts`; only `shellyPort` was added.

## Why

A Venus D dump confirmed it reports PV input power (`pv1`–`pv4`, `<power>|<connected>`, power in deciwatts) alongside AC in/out, and the runtime payload carries a number of metering/version fields that had no corresponding entity.

## Assumptions worth a reviewer's eye

- **Price scaling** (`prc_c`/`prc_d`): units are undocumented; assumed `0.001 €` to match the income fields. Observed values are small, so the scale is a best guess.
- **WiFi signal** (`wif_s`): the protocol describes this as a *weakness* scale rather than true dBm; negating keeps it consistent with the existing Jupiter `signal_strength`/dBm sensor.

## How it was validated

```bash
npm test -- --runInBand   # 325 passed
npm run build             # tsc clean
npm run format:check      # prettier clean
```

Added parser tests for the VNSD PV dump and the new metering/version fields, plus a discovery-gating test confirming PV configs are only advertised when present in the payload.

https://claude.ai/code/session_01VsPvTWnWenCvkjZWKVDLiM