### PR TITLE
Add Venus/Jupiter AI mode, meter config, and device control features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Venus & Jupiter: Add support for the *AI* working mode (`wor_m=5`). It is now decoded as a working mode value and can be selected via the *Working Mode* entity.
 - Venus & Jupiter: Add a *Meter Type* select and *Meter MAC* text entity to configure the external meter (CT001, Shelly Pro 3EM, CT002, CT003, Shelly EM Gen3, Shelly Pro EM50) via `cd=18,meter=…,mac=…`. CT002/CT003 and the Shelly EM Gen3/Pro EM50 require the MAC to be set first; Shelly Pro 3EM uses a fixed all-zero MAC. Both entities are disabled by default.
+- Venus: Add a *Backup Power* switch to toggle the backup/EPS ("UPS") function (`cd=11`, reported as `bac_u`).
+- Venus: Add a *Status LED* switch (`cd=59`, reported as `led`) on firmware that reports the LED state.
+- Venus: Add a *Surplus Feed-in* switch (`cd=43`) on models with PV inputs (Venus A/D). The device does not report the state back, so it is tracked optimistically.
+- Venus: Add a *Bluetooth Advertising* switch (`cd=55`). Disabled by default because the polarity is not fully confirmed; tracked optimistically.
+- Venus: Add a *Phase Diagnosis* button (`cd=18,seq_check`) plus a *Phase Diagnosis Status* sensor (`seq_s`).
+- Venus: Expose *Inverter Version* (`inv_v`) and *MPPT Version* (`mppt`) sensors on firmware that reports them.
+- Venus: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP) parsed from the `cd=26` response. Only the IP Address is enabled by default.
+- Venus: Add per-pack BMS sensors (per-pack State of Charge, State and Temperature, plus Pack Charge/Discharge Power) parsed from the `cd=42` response. Like the detailed BMS data, these are only polled when `POLL_CELL_DATA=true` and are disabled by default.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## [Next]
+
+### Added
+
+- Venus & Jupiter: Add support for the *AI* working mode (`wor_m=5`). It is now decoded as a working mode value and can be selected via the *Working Mode* entity.
+
 ## [1.8.0] - 2026-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Venus & Jupiter: Add support for the *AI* working mode (`wor_m=5`). It is now decoded as a working mode value and can be selected via the *Working Mode* entity.
 
+### Changed
+
+- Venus & Jupiter: The *Recharge Mode* entity is now a settable select (Single Phase / Three Phase) instead of a read-only sensor, so the grid recharge mode can be switched from Home Assistant (`cd=18,dchrg=0|1`).
+
 ## [1.8.0] - 2026-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Venus: Add a *Backup Power* switch to toggle the backup/EPS ("UPS") function (`cd=11`, reported as `bac_u`).
 - Venus: Add a *Status LED* switch (`cd=59`, reported as `led`) on firmware that reports the LED state.
 - Venus: Add a *Surplus Feed-in* switch (`cd=43`) on models with PV inputs (Venus A/D). The device does not report the state back, so it is tracked optimistically.
-- Venus: Add a *Bluetooth Advertising* switch (`cd=55`). Disabled by default because the polarity is not fully confirmed; tracked optimistically.
+- Venus: Add a *Bluetooth Advertising* switch (`cd=55`; `adv=1` enables advertising, `adv=0` disables it). The device does not report the state back, so it is tracked optimistically.
 - Venus: Add a *Phase Diagnosis* button (`cd=18,seq_check`) plus a *Phase Diagnosis Status* sensor (`seq_s`).
 - Venus: Expose *Inverter Version* (`inv_v`) and *MPPT Version* (`mppt`) sensors on firmware that reports them.
 - Venus: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP) parsed from the `cd=26` response. Only the IP Address is enabled by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Venus & Jupiter: Add support for the *AI* working mode (`wor_m=5`). It is now decoded as a working mode value and can be selected via the *Working Mode* entity.
+- Venus & Jupiter: Add a *Meter Type* select and *Meter MAC* text entity to configure the external meter (CT001, Shelly Pro 3EM, CT002, CT003, Shelly EM Gen3, Shelly Pro EM50) via `cd=18,meter=…,mac=…`. CT002/CT003 and the Shelly EM Gen3/Pro EM50 require the MAC to be set first; Shelly Pro 3EM uses a fixed all-zero MAC. Both entities are disabled by default.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ homeassistant/{component}/{node_id}/{object_id}/config
 ### Venus Device Commands
 - `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`)
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
-- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, separators optional)
+- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped)
 - `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, or `shellyProEm50`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
 - `auto-switch-working-mode`: Toggles automatic mode switching (`on` or `off`)
 - `time-period/[0-9]/enabled`: Enables/disables time period (`on` or `off`)
@@ -636,7 +636,7 @@ The following commands are supported by both Jupiter C, Jupiter E and Jupiter Pl
 - `sync-time`: Synchronizes device time with server
 - `working-mode`: Sets working mode (`automatic`, `manual`, or `ai`)
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
-- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, separators optional)
+- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped)
 - `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, or `shellyProEm50`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
 - `time-period/[0-4]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-4]/start-time`: Sets start time for period (HH:MM format)

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `backup-enabled`: Toggles the backup/EPS ("UPS") power function (`on` or `off`)
 - `led-enabled`: Toggles the status LED (`on` or `off`). Only available on firmware that reports the LED state.
 - `surplus-feed-in`: Toggles surplus feed-in into the grid (`on` or `off`). Only available on Venus models with PV inputs (Venus A/D).
-- `bluetooth-advertising`: Toggles Bluetooth advertising (`on` or `off`). Disabled by default.
+- `bluetooth-advertising`: Toggles Bluetooth advertising (`on` enables advertising, `off` disables it / "Bluetooth lock")
 - `phase-diagnosis`: Starts the grid-phase detection routine
 
 ### Jupiter Device Commands

--- a/README.md
+++ b/README.md
@@ -621,6 +621,11 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `get-ct-power`: Gets current transformer power readings
 - `transaction-mode`: Sets transaction mode parameters
 - `discharge-depth`: Sets the battery depth of discharge (30-88%). Only available on devices that report it.
+- `backup-enabled`: Toggles the backup/EPS ("UPS") power function (`on` or `off`)
+- `led-enabled`: Toggles the status LED (`on` or `off`). Only available on firmware that reports the LED state.
+- `surplus-feed-in`: Toggles surplus feed-in into the grid (`on` or `off`). Only available on Venus models with PV inputs (Venus A/D).
+- `bluetooth-advertising`: Toggles Bluetooth advertising (`on` or `off`). Disabled by default.
+- `phase-diagnosis`: Starts the grid-phase detection routine
 
 ### Jupiter Device Commands
 

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `surplus-feed-in`: Toggles Surplus Feed-in mode (`on` or `off`). When enabled, surplus PV power is fed into the home grid when the battery is nearly full.
 
 ### Venus Device Commands
-- `working-mode`: Sets working mode (`automatic`, `manual`, or `trading`)
+- `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`)
 - `auto-switch-working-mode`: Toggles automatic mode switching (`on` or `off`)
 - `time-period/[0-9]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-9]/start-time`: Sets start time for period (HH:MM format)
@@ -626,7 +626,7 @@ The following commands are supported by both Jupiter C, Jupiter E and Jupiter Pl
 - `refresh`: Refreshes the device data
 - `factory-reset`: Resets the device to factory settings
 - `sync-time`: Synchronizes device time with server
-- `working-mode`: Sets working mode (`automatic` or `manual`)
+- `working-mode`: Sets working mode (`automatic`, `manual`, or `ai`)
 - `time-period/[0-4]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-4]/start-time`: Sets start time for period (HH:MM format)
 - `time-period/[0-4]/end-time`: Sets end time for period (HH:MM format)

--- a/README.md
+++ b/README.md
@@ -610,6 +610,8 @@ homeassistant/{component}/{node_id}/{object_id}/config
 ### Venus Device Commands
 - `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`)
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
+- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, separators optional)
+- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, or `shellyProEm50`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
 - `auto-switch-working-mode`: Toggles automatic mode switching (`on` or `off`)
 - `time-period/[0-9]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-9]/start-time`: Sets start time for period (HH:MM format)
@@ -629,6 +631,8 @@ The following commands are supported by both Jupiter C, Jupiter E and Jupiter Pl
 - `sync-time`: Synchronizes device time with server
 - `working-mode`: Sets working mode (`automatic`, `manual`, or `ai`)
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
+- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, separators optional)
+- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, or `shellyProEm50`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
 - `time-period/[0-4]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-4]/start-time`: Sets start time for period (HH:MM format)
 - `time-period/[0-4]/end-time`: Sets end time for period (HH:MM format)

--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ homeassistant/{component}/{node_id}/{object_id}/config
 
 ### Venus Device Commands
 - `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`)
+- `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
 - `auto-switch-working-mode`: Toggles automatic mode switching (`on` or `off`)
 - `time-period/[0-9]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-9]/start-time`: Sets start time for period (HH:MM format)
@@ -627,6 +628,7 @@ The following commands are supported by both Jupiter C, Jupiter E and Jupiter Pl
 - `factory-reset`: Resets the device to factory settings
 - `sync-time`: Synchronizes device time with server
 - `working-mode`: Sets working mode (`automatic`, `manual`, or `ai`)
+- `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
 - `time-period/[0-4]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-4]/start-time`: Sets start time for period (HH:MM format)
 - `time-period/[0-4]/end-time`: Sets end time for period (HH:MM format)

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `surplus-feed-in`: Toggles Surplus Feed-in mode (`on` or `off`). When enabled, surplus PV power is fed into the home grid when the battery is nearly full.
 
 ### Venus Device Commands
-- `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`)
+- `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`). The `ai` value expands to `cd=2,md=5,nl=1` (AI mode requires both `md=5` and `nl=1`).
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
 - `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped)
 - `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, or `shellyProEm50`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
@@ -634,7 +634,7 @@ The following commands are supported by both Jupiter C, Jupiter E and Jupiter Pl
 - `refresh`: Refreshes the device data
 - `factory-reset`: Resets the device to factory settings
 - `sync-time`: Synchronizes device time with server
-- `working-mode`: Sets working mode (`automatic`, `manual`, or `ai`)
+- `working-mode`: Sets working mode (`automatic`, `manual`, or `ai`). The `ai` value expands to `cd=2,md=5,nl=1` (AI mode requires both `md=5` and `nl=1`).
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
 - `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped)
 - `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, or `shellyProEm50`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -884,9 +884,8 @@ Payload:
 ### 27.2 Receive
 
 The device echoes the resulting state:
-1. `cd=55,ret=1` - Advertising enabled
-2. `cd=55,ret=0` - Advertising disabled
+1. `cd=55,ret=1` - Advertising enabled (discoverable; Bluetooth lock off)
+2. `cd=55,ret=0` - Advertising disabled (Bluetooth lock on)
 
-> Note: the exact polarity (`adv=1` = enabled vs. disabled) is inferred and not
-> fully confirmed. The related Bluetooth state is also reflected in the `ble`
-> field of the `cd=1` response.
+The related Bluetooth state is also reflected in the `ble` field of the `cd=1`
+response.

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -614,7 +614,7 @@ hame_energy/{type}/App/{uid or mac}/ctrl
 **Step 1 — push image metadata (`cd=53`):**
 
 ```
-cd=53,num=2,type2=VNSD,mod2=2,size2=372736,crc2=42516,ver2=147,len2=83,url2=http://static-eu.marstekenergy.com/uploads/ota/20260128/202601281721320b2053125.bin,type1=VNSD,mod1=1,size1=115712,crc1=9636,ver1=115,len1=83,url1=http://static-eu.marstekenergy.com/uploads/ota/20260123/202601230921310c0e30687.bin
+cd=53,num=2,type2=VNSD,mod2=2,size2=372736,crc2=42516,ver2=147,len2=<url length>,url2=<control image URL>,type1=VNSD,mod1=1,size1=115712,crc1=9636,ver1=115,len1=<url length>,url1=<micro image URL>
 ```
 
 `num` is the number of images included; the remaining parameters are repeated
@@ -643,7 +643,7 @@ The image metadata matches the firmware OTA API (the `data.control` and
     "control": {
       "mcu_type": "control",
       "type": "VNSD-0",
-      "url": "https://static-eu.marstekenergy.com/uploads/ota/20260128/202601281721320b2053125.bin",
+      "url": "<control image URL>",
       "version": 147,
       "crc": "42516",
       "size": 372736,
@@ -652,7 +652,7 @@ The image metadata matches the firmware OTA API (the `data.control` and
     "micro": {
       "mcu_type": "micro",
       "type": "VNSD-0",
-      "url": "https://static-eu.marstekenergy.com/uploads/ota/20260123/202601230921310c0e30687.bin",
+      "url": "<micro image URL>",
       "version": 115,
       "crc": "9636",
       "size": 115712,

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -240,6 +240,7 @@ Payload:
 1. `cd=2,md=0` - Automatic mode
 2. `cd=2,md=1` - Manual mode
 3. `cd=2,md=2` - Trading mode
+4. `cd=2,md=5,nl=1` - AI mode (the `nl=1` flag is required to enable AI mode)
 
 ## 5 Set automatic discharge time period
 

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -57,6 +57,21 @@
 22. [Start an OTA update](#22-start-an-ota-update)
     1. [Public](#221-public)
     2. [Receive](#222-receive)
+23. [Read network information](#23-read-network-information)
+    1. [Public](#231-public)
+    2. [Receive](#232-receive)
+24. [Read BMS pack details](#24-read-bms-pack-details)
+    1. [Public](#241-public)
+    2. [Receive](#242-receive)
+25. [Read power history](#25-read-power-history)
+    1. [Public](#251-public)
+    2. [Receive](#252-receive)
+26. [Enable/disable the status LED](#26-enabledisable-the-status-led)
+    1. [Public](#261-public)
+    2. [Receive](#262-receive)
+27. [Configure Bluetooth advertising](#27-configure-bluetooth-advertising)
+    1. [Public](#271-public)
+    2. [Receive](#272-receive)
 
 ## 1 MQTT Core Concepts
 
@@ -176,6 +191,41 @@ Description of the above parameters:
 | pv2 | PV input 2 power (0.1W) \| connection status (only reported by Venus models with PV inputs) |
 | pv3 | PV input 3 power (0.1W) \| connection status (only reported by Venus models with PV inputs) |
 | pv4 | PV input 4 power (0.1W) \| connection status (only reported by Venus models with PV inputs) |
+
+The following additional fields have been observed on newer firmware (e.g.
+Venus D control firmware v147). Meanings marked *(unconfirmed)* are educated
+guesses based on context and cross-referencing other commands:
+
+| Key | Description |
+|-----|-------------|
+| seq_s | Phase-diagnosis status *(unconfirmed)* — changes after running `cd=18,seq_check` |
+| ctrl_r | *(unconfirmed)* |
+| par | Parallel-operation flag *(unconfirmed)* |
+| gen | Generator flag *(unconfirmed)* |
+| ble | Bluetooth state *(unconfirmed)* (see `cd=55`) |
+| c_ratio | CT ratio (%) *(unconfirmed)* |
+| udp | UDP enabled *(unconfirmed)* |
+| api | Local API enabled (0: disabled; 1: enabled) (see `cd=30`) |
+| net | *(unconfirmed)* |
+| port | Local API port (see `cd=30`) |
+| inv_v | Inverter / micro module version number (matches the `micro` OTA image version) |
+| id | *(unconfirmed)*, pipe-separated list |
+| lk | Lock flag *(unconfirmed)* |
+| bp | Battery power (W) *(unconfirmed)* |
+| ei | *(unconfirmed)* |
+| eb | *(unconfirmed)* |
+| rp | *(unconfirmed)* power (W) |
+| gp | Grid power (W) *(unconfirmed)* |
+| vp | *(unconfirmed)* power (W) |
+| bl | *(unconfirmed)* |
+| bl_p | *(unconfirmed)* |
+| led | Status LED state (0: off; 1: on) (see `cd=59`) |
+| as | *(unconfirmed)* |
+| mppt | MPPT module version number *(unconfirmed)* |
+| pack | Battery pack summary `num\|mask\|idx\|?` — matches the `cd=42` BMS response (number of packs \| present-pack bitmask \| index) |
+| pv | Total PV power `value\|value` (0.1W) *(unconfirmed)* |
+| fu | *(unconfirmed)*, pipe-separated |
+| em | *(unconfirmed)* |
 
 ## 4 Set working status
 
@@ -483,6 +533,10 @@ Description of the above parameters:
 | cd | Instruction identification |
 | dod | Depth of discharge (%) (configurable 30-88% in the Marstek app; the maximum of 88% is encoded as 0) |
 
+This command does not produce a response. On newer firmware (e.g. Venus D
+v147) the value is reported back as-is, e.g. `cd=56,dod=84` sets the depth of
+discharge to 84%.
+
 The current depth of discharge is reported as the `dod` field in the device information (see [Read device information](#3-read-device-information)).
 
 ## 18 Enable surplus feed-in
@@ -685,3 +739,154 @@ cd=54,ret=1
 
 > Warning: this initiates a real firmware flash. Use known-good image URLs,
 > CRCs and sizes (e.g. from the official OTA API) for the correct device type.
+
+## 23 Read network information
+
+Returns the device's current network configuration. Observed on Venus D v147.
+
+### 23.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+```
+cd=26
+```
+
+### 23.2 Receive
+
+```
+cd=26,dev_net_info:ip:192.168.178.134,gate:192.168.178.1,mask:255.255.255.0,dns:192.168.178.1,ct_connect_ip:192.168.178.255
+```
+
+Note the unusual format: after `cd=26,` the payload is a `dev_net_info:`
+prefix followed by colon-separated `key:value` pairs (comma-separated).
+
+| Key | Description |
+|-----|-------------|
+| ip | Device IP address |
+| gate | Gateway address |
+| mask | Subnet mask |
+| dns | DNS server address |
+| ct_connect_ip | Address used to reach the CT/meter (a broadcast address in the example) |
+
+## 24 Read BMS pack details
+
+Returns per-pack details for the connected battery packs. Observed on Venus D
+v147.
+
+### 24.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+```
+cd=42,bms_idx=255
+```
+
+`bms_idx=255` appears to request all packs.
+
+### 24.2 Receive
+
+```
+cd=42, BMS: num=2,mask=3,idx=2,charge_pow=2643,discharge_pow=2643,soc1=424,state1=0,temp1=278,soc2=482,state2=2,temp2=254,soc3=0,state3=0,temp3=0,soc4=0,state4=0,temp4=0,soc5=0,state5=0,temp5=0,soc6=0,state6=0,temp6=0
+```
+
+| Key | Description |
+|-----|-------------|
+| num | Number of battery packs present |
+| mask | Bitmask of present packs (bit 0 = pack 1, bit 1 = pack 2, ...; `3` = packs 1 & 2) |
+| idx | *(unconfirmed)* pack index / count |
+| charge_pow | Allowed charge power (W) |
+| discharge_pow | Allowed discharge power (W) |
+| soc*N* | Pack *N* state of charge (0.1%; `424` = 42.4%) |
+| state*N* | Pack *N* working state *(unconfirmed: 0 = idle, 2 = charging, mirrors `cel_s`)* |
+| temp*N* | Pack *N* temperature (0.1 °C; `278` = 27.8 °C) |
+
+Fields are reported for up to 6 packs (`*1` … `*6`); unused packs report zeros.
+The `num`/`mask`/`idx` values match the `pack` field in the `cd=1` response.
+
+## 25 Read power history
+
+Returns recent power-curve samples. Observed on Venus D v147.
+
+### 25.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+```
+cd=29,num=15
+```
+
+`num` is the number of samples to return.
+
+### 25.2 Receive
+
+```
+cd=29,p1=[801,...],p2=[0,...],p3=[686,...],p4=[694,...],p5=[803,...],p6=[809,...],p7=[-502,...]
+```
+
+The response contains seven series (`p1` … `p7`), each an array of `num`
+values. The exact meaning of each series has **not been confirmed**; from
+context they appear to be a recent history of the various power readings (PV
+inputs, battery, grid and output power), with the most recent sample first.
+
+## 26 Enable/disable the status LED
+
+Turns the device's status LED on or off. Observed on Venus D v147.
+
+### 26.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+1. `cd=59,led=0` - Turn the LED off
+2. `cd=59,led=1` - Turn the LED on
+
+### 26.2 Receive
+
+The device echoes the resulting state:
+1. `cd=59,ret=0` - LED is now off
+2. `cd=59,ret=1` - LED is now on
+
+The current LED state is reported as the `led` field in the `cd=1` response.
+
+## 27 Configure Bluetooth advertising
+
+Enables or disables the device's Bluetooth (BLE) advertising. When advertising
+is disabled the device is no longer discoverable over Bluetooth (a "Bluetooth
+lock"). Observed on Venus D v147.
+
+### 27.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+1. `cd=55,adv=1` - Enable Bluetooth advertising (discoverable)
+2. `cd=55,adv=0` - Disable Bluetooth advertising (lock)
+
+### 27.2 Receive
+
+The device echoes the resulting state:
+1. `cd=55,ret=1` - Advertising enabled
+2. `cd=55,ret=0` - Advertising disabled
+
+> Note: the exact polarity (`adv=1` = enabled vs. disabled) is inferred and not
+> fully confirmed. The related Bluetooth state is also reflected in the `ble`
+> field of the `cd=1` response.

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -54,6 +54,9 @@
 21. [Pre-update check](#21-pre-update-check)
     1. [Public](#211-public)
     2. [Receive](#212-receive)
+22. [Start an OTA update](#22-start-an-ota-update)
+    1. [Public](#221-public)
+    2. [Receive](#222-receive)
 
 ## 1 MQTT Core Concepts
 
@@ -594,3 +597,91 @@ The exact meaning of the fields has not been confirmed. Based on the context
 | type | Update or device type |
 | mod | Module to update / module flag |
 | cnt | Counter (e.g. retries or available updates; 0 observed) |
+
+## 22 Start an OTA update
+
+Triggers a firmware OTA update over MQTT. This is a two-step sequence: first
+push the image metadata for each module with `cd=53`, then start the actual
+update with `cd=54`.
+
+### 22.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+**Step 1 — push image metadata (`cd=53`):**
+
+```
+cd=53,num=2,type2=VNSD,mod2=2,size2=372736,crc2=42516,ver2=147,len2=83,url2=http://static-eu.marstekenergy.com/uploads/ota/20260128/202601281721320b2053125.bin,type1=VNSD,mod1=1,size1=115712,crc1=9636,ver1=115,len1=83,url1=http://static-eu.marstekenergy.com/uploads/ota/20260123/202601230921310c0e30687.bin
+```
+
+`num` is the number of images included; the remaining parameters are repeated
+per image with a 1-based index suffix (`type1`/`mod1`/... for image 1,
+`type2`/`mod2`/... for image 2, etc.):
+
+| Key | Description |
+|-----|-------------|
+| num | Number of images included |
+| type*N* | Device type prefix (e.g. `VNSD`) |
+| mod*N* | Target module (observed: `1` = micro/inverter, `2` = control/MCU) |
+| size*N* | Image size in bytes |
+| crc*N* | Image CRC checksum |
+| ver*N* | Firmware version contained in the image |
+| len*N* | Length of the URL string |
+| url*N* | Download URL of the firmware image |
+
+The image metadata matches the firmware OTA API (the `data.control` and
+`data.micro` objects map to the `mod=2` and `mod=1` images respectively):
+
+```json
+{
+  "code": 1,
+  "msg": "success",
+  "data": {
+    "control": {
+      "mcu_type": "control",
+      "type": "VNSD-0",
+      "url": "https://static-eu.marstekenergy.com/uploads/ota/20260128/202601281721320b2053125.bin",
+      "version": 147,
+      "crc": "42516",
+      "size": 372736,
+      "force_update": "N"
+    },
+    "micro": {
+      "mcu_type": "micro",
+      "type": "VNSD-0",
+      "url": "https://static-eu.marstekenergy.com/uploads/ota/20260123/202601230921310c0e30687.bin",
+      "version": 115,
+      "crc": "9636",
+      "size": 115712,
+      "force_update": "N"
+    }
+  }
+}
+```
+
+**Step 2 — start the update (`cd=54`):** send immediately after `cd=53`.
+
+```
+cd=54,start
+```
+
+### 22.2 Receive
+
+After `cd=53` the device acknowledges with the number of images accepted:
+```
+cd=53,ret=2
+```
+(`ret` matches the `num` value when all images are accepted.)
+
+After `cd=54` the device confirms the update has started:
+```
+cd=54,ret=1
+```
+1. `ret=0` - Failed to start
+2. `ret=1` - Update started
+
+> Warning: this initiates a real firmware flash. Use known-good image URLs,
+> CRCs and sizes (e.g. from the official OTA API) for the correct device type.

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -44,6 +44,16 @@
     2. [Receive](#162-receive)
 17. [Set depth of discharge](#17-set-depth-of-discharge)
     1. [Public](#171-public)
+18. [Enable surplus feed-in](#18-enable-surplus-feed-in)
+    1. [Public](#181-public)
+    2. [Receive](#182-receive)
+19. [Configure the local API](#19-configure-the-local-api)
+    1. [Public](#191-public)
+20. [Start phase diagnosis](#20-start-phase-diagnosis)
+    1. [Public](#201-public)
+21. [Pre-update check](#21-pre-update-check)
+    1. [Public](#211-public)
+    2. [Receive](#212-receive)
 
 ## 1 MQTT Core Concepts
 
@@ -254,6 +264,18 @@ Description of the above parameters:
 | hh | Hour [0,23] |
 | mn | Minute [0,59] |
 
+### 7.2 Receive
+
+The device echoes the time it applied, e.g.:
+
+```
+cd=4,2026-5-14 16:55:0
+```
+
+Note that the month is echoed as the raw value that was sent, i.e. it is
+0-indexed (`mm=5` is June and is echoed back as `5`). The time is the device's
+configured local time.
+
 ## 8 Restore factory settings
 
 ### 8.1 Public
@@ -292,6 +314,10 @@ hame_energy/{type}/App/{uid or mac}/ctrl
 Payload:
 1. `cd=11,bc=0` - Disable the back up function
 2. `cd=11,bc=1` - Enable the back up function
+
+This is the same setting exposed in the Marstek app as "UPS mode" / the backup
+power supply toggle (German: "Backup-Stromversorgung aktivieren"). The current
+state is reported as the `bac_u` field in the device information.
 
 ### 10.2 Receive
 
@@ -455,3 +481,116 @@ Description of the above parameters:
 | dod | Depth of discharge (%) (configurable 30-88% in the Marstek app; the maximum of 88% is encoded as 0) |
 
 The current depth of discharge is reported as the `dod` field in the device information (see [Read device information](#3-read-device-information)).
+
+## 18 Enable surplus feed-in
+
+Enables/disables surplus feed-in (feeding excess PV power into the grid) on
+Venus A and Venus D.
+
+### 18.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+1. `cd=43,full_d=1` - Enable surplus feed-in
+2. `cd=43,full_d=0` - Disable surplus feed-in
+
+### 18.2 Receive
+
+You will receive a message echoing the resulting state:
+1. `cd=43,ret=1` - Surplus feed-in is now enabled
+2. `cd=43,ret=0` - Surplus feed-in is now disabled
+
+> Note: unlike most other commands (where `ret=1` means "success" and `ret=0`
+> means "failure"), here `ret` echoes the new state of the setting.
+
+## 19 Configure the local API
+
+Enables/disables the device's local API (used by tools such as the Marstek
+local Modbus/UDP integrations) and configures its port.
+
+### 19.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+1. `cd=30,api=1,port=30000` - Enable the local API on the given port
+2. `cd=30,api=0,port=30000` - Disable the local API
+
+Description of the above parameters:
+
+| Key | Description |
+|-----|-------------|
+| cd | Instruction identification |
+| api | Local API enabled (0: disabled; 1: enabled) |
+| port | Local API port (e.g. 30000) |
+
+The current local API state and port are reported as the `api` and `port`
+fields in the device information.
+
+> Note: this command does not produce a response.
+
+## 20 Start phase diagnosis
+
+Triggers the phase-detection ("Phase Diagnose") routine, which determines which
+grid phase the device is connected to (reported as `phase_t`). This behaves like
+a button: it has no parameters and produces no response.
+
+### 20.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+```
+cd=18,seq_check
+```
+
+> Note: `cd=18` is also used to set the meter type and recharge phase (see
+> [Set the meter type and supplementary power type](#14-set-the-meter-type-and-supplementary-power-type)). The `seq_check` sub-command starts phase diagnosis instead.
+
+## 21 Pre-update check
+
+Observed on a Venus D when pressing the firmware "update" button, before
+confirming the update dialog. It appears to be a pre-check that reports whether
+an update can be performed.
+
+### 21.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+```
+cd=51
+```
+
+### 21.2 Receive
+
+Example response observed on a Venus D:
+```
+cd=51,state=0,way=0,net=1,type=0,mod=1,cnt=0
+```
+
+The exact meaning of the fields has not been confirmed. Based on the context
+(an OTA pre-check) the following is an educated guess and should be treated as
+**speculative**:
+
+| Key | Likely meaning (unconfirmed) |
+|-----|-------------|
+| state | Update/check state (0: idle/ready) |
+| way | Update method/channel |
+| net | Network reachability for OTA (1: online/reachable) |
+| type | Update or device type |
+| mod | Module to update / module flag |
+| cnt | Counter (e.g. retries or available updates; 0 observed) |

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -373,6 +373,19 @@ Payload:
 4. `cd=15,dchrg=0` - single-phase
 5. `cd=15,dchrg=1` - three-phase
 
+Newer firmware uses `cd=18` for the same purpose. Set the recharge phase with
+`cd=18,dchrg=0` (single-phase) or `cd=18,dchrg=1` (three-phase), and set the
+external meter type with `cd=18,meter=<code>,mac=<mac>`:
+
+| meter code | Meter type | MAC |
+| --- | --- | --- |
+| 0 | CT001 | not required (`000000000000`) |
+| 1 | Shelly Pro 3EM | fixed `000000000000` |
+| 3 | CT002 | required |
+| 4 | CT003 | required |
+| 5 | Shelly EM Gen3 | required |
+| 6 | Shelly Pro EM50 | required |
+
 ## 15 Obtain CT power
 
 ### 15.1 Public

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -127,7 +127,7 @@ Description of the above parameters:
 | err_a | Error code (warning code) |
 | dev_n | Device version number |
 | grd_y | Grid type (0: Adaptive (220-240) (50-60hz) AUTO; 1: EN50549 EN50549; 2: Netherlands; 3: Germany; 4: Austria; 5: United Kingdom; 6: Spain; 7: Poland; 8: Italy; 9: China) |
-| wor_m | Working mode (0: Automatic; 1: Manual operation; 2: Trading) |
+| wor_m | Working mode (0: Automatic; 1: Manual operation; 2: Trading; 5: AI) |
 | tim_0 | Start time (hour \| minute) \| End time (hour \| minute) \| Cycle \| Power \| Enable |
 | tim_1 | ditto |
 | tim_2 | ditto |
@@ -197,7 +197,7 @@ Description of the above parameters:
 | Key | Description |
 |-----|-------------|
 | cd | Instruction identification |
-| md | Working mode (0: Automatic; 1: Manual operation; 2: Trading) |
+| md | Working mode (0: Automatic; 1: Manual operation; 2: Trading; 5: AI) |
 | nm | [0-9] |
 | bt | Start Time |
 | et | End Time |
@@ -224,7 +224,7 @@ Description of the above parameters:
 | Key | Description |
 |-----|-------------|
 | cd | Instruction identification |
-| md | Working mode (0: Automatic; 1: Manual operation; 2: Trading) |
+| md | Working mode (0: Automatic; 1: Manual operation; 2: Trading; 5: AI) |
 | id | Region code |
 | in | Electricity price during charging |
 | on | Electricity price during discharge |

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -592,7 +592,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             mode = 1;
         }
 
-        publishCallback(processCommand(CommandType.SET_WORKING_MODE, { md: mode }));
+        const params: CommandParams = { md: mode };
+        // AI mode additionally requires the nl flag to be enabled
+        if (message === 'ai') {
+          params.nl = 1;
+        }
+        publishCallback(processCommand(CommandType.SET_WORKING_MODE, params));
       },
     });
 

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -366,6 +366,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         {
           '1': 'automatic',
           '2': 'manual',
+          '5': 'ai',
         },
         'automatic',
       ),
@@ -380,6 +381,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         valueMappings: {
           automatic: 'Automatic',
           manual: 'Manual',
+          ai: 'AI',
         },
       }),
     );
@@ -582,6 +584,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             break;
           case 'manual':
             mode = 2;
+            break;
+          case 'ai':
+            mode = 5;
             break;
           default:
             mode = 1;

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -12,6 +12,11 @@ import {
   JupiterMPPTPVInfo,
   isValidJupiterWorkingMode,
   isValidJupiterRechargeMode,
+  isValidMeterType,
+  meterTypeCommandCodes,
+  meterTypeLabels,
+  normalizeMeterMac,
+  resolveMeterMac,
   WeekdaySet,
   JupiterTimePeriod,
 } from '../types';
@@ -638,6 +643,66 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         );
       },
     });
+
+    // MAC address used when configuring an external meter (CT002/CT003/Shelly).
+    command('meter-mac', {
+      handler: ({ message, updateDeviceState }) => {
+        const mac = normalizeMeterMac(message);
+        if (!mac) {
+          logger.warn('Invalid meter MAC (expected 12 hex digits):', message);
+          return;
+        }
+        updateDeviceState(() => ({ meterMac: mac }));
+      },
+    });
+    advertise(
+      ['meterMac'],
+      textComponent({
+        id: 'meter_mac',
+        name: 'Meter MAC',
+        icon: 'mdi:identifier',
+        command: 'meter-mac',
+        pattern: '^([0-9A-Fa-f]{2}[:-]?){5}[0-9A-Fa-f]{2}$',
+        enabled_by_default: false,
+      }),
+    );
+
+    // Configure the external meter type (cd=18,meter=...,mac=...).
+    command('meter-type', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        if (!isValidMeterType(message)) {
+          logger.warn('Invalid meter type value:', message);
+          return;
+        }
+        updateDeviceState(state => {
+          const mac = resolveMeterMac(message, state.meterMac);
+          if (mac === null) {
+            logger.warn(
+              `Meter type ${message} requires a MAC; set the "Meter MAC" entity before selecting it`,
+            );
+            return;
+          }
+          publishCallback(
+            processCommand(CommandType.SET_METER_TYPE, {
+              meter: meterTypeCommandCodes[message],
+              mac,
+            }),
+          );
+          return { meterType: message };
+        });
+      },
+    });
+    advertise(
+      ['meterType'],
+      selectComponent<NonNullable<JupiterDeviceData['meterType']>>({
+        id: 'meter_type',
+        name: 'Meter Type',
+        icon: 'mdi:meter-electric',
+        command: 'meter-type',
+        valueMappings: meterTypeLabels,
+        enabled_by_default: false,
+      }),
+    );
 
     // Factory reset
     command('factory-reset', {

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -662,7 +662,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Meter MAC',
         icon: 'mdi:identifier',
         command: 'meter-mac',
-        pattern: '^([0-9A-Fa-f]{2}[:-]?){5}[0-9A-Fa-f]{2}$',
+        // The device uses a plain 12 hex digit MAC without ':'/'-' separators.
+        pattern: '^[0-9A-Fa-f]{12}$',
         enabled_by_default: false,
       }),
     );

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -11,6 +11,7 @@ import {
   JupiterBMSInfo,
   JupiterMPPTPVInfo,
   isValidJupiterWorkingMode,
+  isValidJupiterRechargeMode,
   WeekdaySet,
   JupiterTimePeriod,
 } from '../types';
@@ -45,6 +46,7 @@ enum CommandType {
   SET_DEVICE_TIME = 4,
   SET_TIME_PERIOD = 3,
   SET_WORKING_MODE = 2,
+  SET_METER_TYPE = 18,
   SURPLUS_FEED_IN = 13,
   GET_BMS_INFO = 14, // -> inv:g_state=1,w_state1=1,w_state2=1,i_err=0,i_war=0,g_vol=2399,g_cur=0,g_pf=0,g_fre=5000,b_vol=526,g_power=119,i_temp=31,mppt:m_state=244,m_err=0,m_temp=30,m_war=0,pv1=350|37|1304,pv2=349|39|1372,pv3=378|18|712,pv4=365|32|1180,b_vol=525,b_cur=85,base_v=221,pe_v=165,fail_t=0,bms:c_vol=571,c_cur=500,d_cur=500,soc=33,soh=100,b_cap=5120,b_vol=5252,b_cur=63,b_temp=250,b_err=0,b_war=0,b_err2=0,b_war2=0,c_flag=192,s_flag=0,b_num=1,vol0=3280,vol1=3281,vol2=3283,vol3=3283,vol4=3283,vol5=3283,vol6=3280,vol7=3284,vol8=3283,vol9=3284,vol10=3282,vol11=3286,vol12=3277,vol13=3286,vol14=3283,vol15=3284,b_temp0=14,b_temp1=15,b_temp2=15,b_temp3=16,env_t=27,mos_t=20,lck=0
   DEPTH_OF_DISCHARGE = 56,
@@ -428,12 +430,28 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Phase Type',
       }),
     );
-    field({ key: 'dchrg', path: ['rechargeMode'], transform: number() });
+    field({
+      key: 'dchrg',
+      path: ['rechargeMode'],
+      transform: map(
+        {
+          '0': 'singlePhase',
+          '1': 'threePhase',
+        },
+        'singlePhase',
+      ),
+    });
     advertise(
       ['rechargeMode'],
-      sensorComponent<number>({
+      selectComponent<NonNullable<JupiterDeviceData['rechargeMode']>>({
         id: 'recharge_mode',
         name: 'Recharge Mode',
+        icon: 'mdi:flash',
+        command: 'recharge-mode',
+        valueMappings: {
+          singlePhase: 'Single Phase',
+          threePhase: 'Three Phase',
+        },
       }),
     );
     field({ key: 'dev_n', path: ['deviceVersion'], transform: number() });
@@ -598,6 +616,26 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           params.nl = 1;
         }
         publishCallback(processCommand(CommandType.SET_WORKING_MODE, params));
+      },
+    });
+
+    // Recharge mode (single-/three-phase)
+    command('recharge-mode', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        if (!isValidJupiterRechargeMode(message)) {
+          logger.warn('Invalid recharge mode value:', message);
+          return;
+        }
+
+        updateDeviceState(() => ({
+          rechargeMode: message,
+        }));
+
+        publishCallback(
+          processCommand(CommandType.SET_METER_TYPE, {
+            dchrg: message === 'threePhase' ? 1 : 0,
+          }),
+        );
       },
     });
 

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -67,6 +67,22 @@ function processCommand(command: CommandType, params: CommandParams = {}): strin
   return `cd=${command}${entries.length > 0 ? ',' : ''}${entries.map(([key, value]) => `${key}=${value}`).join(',')}`;
 }
 
+/**
+ * Map the current working mode to the `md` value sent with a time-period update.
+ * This must match the encoding used by the working-mode command (automatic=1,
+ * manual=2, ai=5) so editing a time period does not change the working mode.
+ */
+function workingModeToMd(workingMode: JupiterDeviceData['workingMode']): number {
+  switch (workingMode) {
+    case 'manual':
+      return 2;
+    case 'ai':
+      return 5;
+    default:
+      return 1;
+  }
+}
+
 const requiredRuntimeInfoKeys = [
   'ele_d',
   'ele_m',
@@ -646,13 +662,28 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
 
     // MAC address used when configuring an external meter (CT002/CT003/Shelly).
     command('meter-mac', {
-      handler: ({ message, updateDeviceState }) => {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
         const mac = normalizeMeterMac(message);
         if (!mac) {
           logger.warn('Invalid meter MAC (expected 12 hex digits):', message);
           return;
         }
-        updateDeviceState(() => ({ meterMac: mac }));
+        updateDeviceState(state => {
+          // If a meter type is already configured, re-apply it with the new MAC
+          // so the device stays in sync when the MAC is edited afterwards.
+          if (state.meterType) {
+            const resolved = resolveMeterMac(state.meterType, mac);
+            if (resolved !== null) {
+              publishCallback(
+                processCommand(CommandType.SET_METER_TYPE, {
+                  meter: meterTypeCommandCodes[state.meterType],
+                  mac: resolved,
+                }),
+              );
+            }
+          }
+          return { meterMac: mac };
+        });
       },
     });
     advertise(
@@ -795,7 +826,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             };
 
             // Build the command parameters
-            const md = state.workingMode === 'manual' ? 2 : 1;
+            const md = workingModeToMd(state.workingMode);
             const params: CommandParams = { md, nm: periodIndex };
             const period = timePeriods[periodIndex];
 
@@ -849,7 +880,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             };
 
             // Build the command parameters
-            const md = state.workingMode === 'manual' ? 2 : 1;
+            const md = workingModeToMd(state.workingMode);
             const params: CommandParams = { md, nm: periodIndex };
             const period = timePeriods[periodIndex];
 
@@ -897,7 +928,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             };
 
             // Build the command parameters
-            const md = state.workingMode === 'manual' ? 2 : 1;
+            const md = workingModeToMd(state.workingMode);
             const params: CommandParams = { md, nm: periodIndex };
             const period = timePeriods[periodIndex];
 
@@ -953,7 +984,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             };
 
             // Build the command parameters
-            const md = state.workingMode === 'manual' ? 2 : 1;
+            const md = workingModeToMd(state.workingMode);
             const params: CommandParams = { md, nm: periodIndex };
             const period = timePeriods[periodIndex];
 
@@ -1008,7 +1039,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             };
 
             // Build the command parameters
-            const md = state.workingMode === 'manual' ? 2 : 1;
+            const md = workingModeToMd(state.workingMode);
             const params: CommandParams = { md, nm: periodIndex };
             const period = timePeriods[periodIndex];
 

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -10,7 +10,9 @@ import {
   normalizeMeterMac,
   resolveMeterMac,
   VenusBMSInfo,
+  VenusBMSPackInfo,
   VenusDeviceData,
+  VenusNetworkInfo,
   VenusTimePeriod,
   WeekdaySet,
 } from '../types';
@@ -58,11 +60,16 @@ enum CommandType {
   SET_DISCHARGE_POWER = 15,
   SET_MAX_CHARGING_POWER = 16,
   SET_MAX_DISCHARGE_POWER = 17,
-  SET_METER_TYPE = 18,
+  SET_METER_TYPE = 18, // also used for phase diagnosis via `cd=18,seq_check`
   GET_CT_POWER = 19,
   UPGRADE_FC4_MODULE = 20,
+  GET_NETWORK_INFO = 26,
   SET_LOCAL_API = 30,
+  GET_BMS_PACK_INFO = 42,
+  SURPLUS_FEED_IN = 43,
+  BLUETOOTH_ADVERTISING = 55,
   DEPTH_OF_DISCHARGE = 56,
+  SET_LED = 59,
 }
 
 // Minimum and maximum Depth of Discharge values based on Marstek app limits (30-88%).
@@ -172,6 +179,8 @@ registerDeviceDefinition(
   ({ message }) => {
     registerRuntimeInfoMessage(message);
     registerBMSInfoMessage(message);
+    registerBMSPackMessage(message);
+    registerNetworkInfoMessage(message);
   },
 );
 
@@ -184,6 +193,8 @@ registerDeviceDefinition(
   ({ message }) => {
     registerRuntimeInfoMessage(message);
     registerBMSInfoMessage(message, { scaleTemperatures: true });
+    registerBMSPackMessage(message, { scaleTemperatures: true });
+    registerNetworkInfoMessage(message);
   },
 );
 
@@ -957,6 +968,169 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         publishCallback(processCommand(CommandType.SET_LOCAL_API, params));
       },
     });
+
+    // Backup / EPS ("UPS mode") function (cd=11). The current state is reported
+    // as the bac_u field.
+    field({
+      key: 'bac_u',
+      path: ['backupEnabled'],
+      transform: equalsBoolean('1'),
+    });
+    advertise(
+      ['backupEnabled'],
+      switchComponent({
+        id: 'backup_enabled',
+        name: 'Backup Power',
+        icon: 'mdi:home-battery',
+        command: 'backup-enabled',
+      }),
+    );
+    command('backup-enabled', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        const enabled = message.toLowerCase() === 'true' || message === '1' || message === 'ON';
+        updateDeviceState(() => ({ backupEnabled: enabled }));
+        publishCallback(processCommand(CommandType.ENABLE_BACKUP, { bc: enabled ? 1 : 0 }));
+      },
+    });
+
+    // Status LED (cd=59). Reported as the led field on newer firmware (e.g. v147).
+    field({
+      key: 'led',
+      path: ['ledEnabled'],
+      transform: equalsBoolean('1'),
+    });
+    advertise(
+      ['ledEnabled'],
+      switchComponent({
+        id: 'led_enabled',
+        name: 'Status LED',
+        icon: 'mdi:led-on',
+        command: 'led-enabled',
+      }),
+      { enabled: state => (state.ledEnabled != null ? true : undefined) },
+    );
+    command('led-enabled', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        const enabled = message.toLowerCase() === 'true' || message === '1' || message === 'ON';
+        updateDeviceState(() => ({ ledEnabled: enabled }));
+        publishCallback(processCommand(CommandType.SET_LED, { led: enabled ? 1 : 0 }));
+      },
+    });
+
+    // Surplus feed-in (cd=43, feeding excess PV power into the grid). Venus does
+    // not report the state back, so it is tracked optimistically based on the
+    // last command. Only advertised on models with PV inputs (Venus A/D).
+    advertise(
+      ['surplusFeedInEnabled'],
+      switchComponent({
+        id: 'surplus_feed_in',
+        name: 'Surplus Feed-in',
+        icon: 'mdi:transmission-tower-export',
+        command: 'surplus-feed-in',
+      }),
+      { enabled: state => (state.pv1Power != null ? true : undefined) },
+    );
+    command('surplus-feed-in', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        const enable =
+          message.toLowerCase() === 'true' || message.toLowerCase() === 'on' || message === '1';
+        updateDeviceState(() => ({ surplusFeedInEnabled: enable }));
+        publishCallback(processCommand(CommandType.SURPLUS_FEED_IN, { full_d: enable ? 1 : 0 }));
+      },
+    });
+
+    // Bluetooth advertising / "lock" (cd=55). The polarity (adv=1 = advertising
+    // enabled) is inferred and not fully confirmed, so the switch is disabled by
+    // default and tracked optimistically.
+    advertise(
+      ['bluetoothAdvertisingEnabled'],
+      switchComponent({
+        id: 'bluetooth_advertising',
+        name: 'Bluetooth Advertising',
+        icon: 'mdi:bluetooth',
+        command: 'bluetooth-advertising',
+        enabled_by_default: false,
+      }),
+    );
+    command('bluetooth-advertising', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        const enable =
+          message.toLowerCase() === 'true' || message.toLowerCase() === 'on' || message === '1';
+        updateDeviceState(() => ({ bluetoothAdvertisingEnabled: enable }));
+        publishCallback(processCommand(CommandType.BLUETOOTH_ADVERTISING, { adv: enable ? 1 : 0 }));
+      },
+    });
+
+    // Inverter / micro module version (inv_v), reported on newer firmware.
+    field({
+      key: 'inv_v',
+      path: ['inverterVersion'],
+      transform: number(),
+    });
+    advertise(
+      ['inverterVersion'],
+      sensorComponent<number>({
+        id: 'inverter_version',
+        name: 'Inverter Version',
+        icon: 'mdi:information',
+        enabled_by_default: false,
+      }),
+      { enabled: state => (state.inverterVersion != null ? true : undefined) },
+    );
+
+    // MPPT module version (mppt), reported on newer firmware.
+    field({
+      key: 'mppt',
+      path: ['mpptVersion'],
+      transform: number(),
+    });
+    advertise(
+      ['mpptVersion'],
+      sensorComponent<number>({
+        id: 'mppt_version',
+        name: 'MPPT Version',
+        icon: 'mdi:information',
+        enabled_by_default: false,
+      }),
+      { enabled: state => (state.mpptVersion != null ? true : undefined) },
+    );
+
+    // Phase-diagnosis status (seq_s) and the button that starts the diagnosis
+    // (cd=18,seq_check). The meaning of the status value is unconfirmed.
+    field({
+      key: 'seq_s',
+      path: ['phaseDiagnosisStatus'],
+      transform: number(),
+    });
+    advertise(
+      ['phaseDiagnosisStatus'],
+      sensorComponent<number>({
+        id: 'phase_diagnosis_status',
+        name: 'Phase Diagnosis Status',
+        icon: 'mdi:sine-wave',
+        enabled_by_default: false,
+      }),
+      { enabled: state => (state.phaseDiagnosisStatus != null ? true : undefined) },
+    );
+    command('phase-diagnosis', {
+      handler: ({ message, publishCallback }) => {
+        if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
+          // The seq_check flag is sent without a value, i.e. `cd=18,seq_check`.
+          publishCallback(`cd=${CommandType.SET_METER_TYPE},seq_check`);
+        }
+      },
+    });
+    advertise(
+      [],
+      buttonComponent({
+        id: 'phase_diagnosis',
+        name: 'Phase Diagnosis',
+        icon: 'mdi:sine-wave',
+        command: 'phase-diagnosis',
+        payload_press: 'PRESS',
+        enabled_by_default: false,
+      }),
+    );
 
     // Time periods
     for (let i = 0; i < 10; i++) {
@@ -1827,6 +2001,159 @@ function registerBMSInfoMessage(
             state_class: 'stateClass' in info ? info.stateClass : undefined,
             enabled_by_default: false,
           }),
+        );
+      }
+    },
+  );
+}
+
+// The cd=42 response carries per-pack BMS details. It is parsed from the
+// standard key=value pairs (charge_pow, discharge_pow, mask, socN/stateN/tempN);
+// only the leading "BMS: num" token uses a non-standard format and is ignored.
+function isVenusBmsPackMessage(values: Record<string, string>): boolean {
+  return 'charge_pow' in values && 'soc1' in values;
+}
+
+function registerBMSPackMessage(
+  message: BuildMessageFn,
+  { scaleTemperatures = false }: { scaleTemperatures?: boolean } = {},
+) {
+  message<VenusBMSPackInfo>(
+    {
+      refreshDataPayload: `cd=${CommandType.GET_BMS_PACK_INFO},bms_idx=255`,
+      isMessage: isVenusBmsPackMessage,
+      publishPath: 'bmsPacks',
+      defaultState: {},
+      getAdditionalDeviceInfo: () => ({}),
+      pollInterval: 60000,
+      controlsDeviceAvailability: false,
+      // Gated behind the same flag as the detailed BMS data to avoid extra
+      // polling traffic by default.
+      enabled: process.env.POLL_CELL_DATA === 'true',
+    },
+    ({ field, advertise }) => {
+      field({ key: 'mask', path: ['packMask'], transform: number() });
+
+      field({ key: 'charge_pow', path: ['chargePower'], transform: number() });
+      advertise(
+        ['chargePower'],
+        sensorComponent<number>({
+          id: 'pack_charge_power',
+          name: 'Pack Charge Power',
+          device_class: 'power',
+          unit_of_measurement: 'W',
+          state_class: 'measurement',
+          enabled_by_default: false,
+        }),
+      );
+
+      field({ key: 'discharge_pow', path: ['dischargePower'], transform: number() });
+      advertise(
+        ['dischargePower'],
+        sensorComponent<number>({
+          id: 'pack_discharge_power',
+          name: 'Pack Discharge Power',
+          device_class: 'power',
+          unit_of_measurement: 'W',
+          state_class: 'measurement',
+          enabled_by_default: false,
+        }),
+      );
+
+      // Per-pack details (up to 6 packs). Each pack is only advertised when its
+      // bit is set in the present-pack bitmask. SoC and temperature are reported
+      // in 0.1 units; the temperature scaling mirrors the detailed BMS message.
+      for (let i = 1; i <= 6; i++) {
+        const packEnabled = (state: VenusBMSPackInfo) =>
+          state.packMask == null ? undefined : (state.packMask & (1 << (i - 1))) !== 0;
+
+        field({ key: `soc${i}`, path: ['packs', i - 1, 'soc'], transform: divide(10) });
+        advertise(
+          ['packs', i - 1, 'soc'],
+          sensorComponent<number>({
+            id: `pack_${i}_soc`,
+            name: `Pack ${i} State of Charge`,
+            device_class: 'battery',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+            enabled_by_default: false,
+          }),
+          { enabled: packEnabled },
+        );
+
+        field({ key: `state${i}`, path: ['packs', i - 1, 'state'], transform: number() });
+        advertise(
+          ['packs', i - 1, 'state'],
+          sensorComponent<number>({
+            id: `pack_${i}_state`,
+            name: `Pack ${i} State`,
+            icon: 'mdi:battery',
+            enabled_by_default: false,
+          }),
+          { enabled: packEnabled },
+        );
+
+        field({
+          key: `temp${i}`,
+          path: ['packs', i - 1, 'temperature'],
+          transform: scaleTemperatures ? divide(10) : number(),
+        });
+        advertise(
+          ['packs', i - 1, 'temperature'],
+          sensorComponent<number>({
+            id: `pack_${i}_temperature`,
+            name: `Pack ${i} Temperature`,
+            device_class: 'temperature',
+            unit_of_measurement: '°C',
+            state_class: 'measurement',
+            enabled_by_default: false,
+          }),
+          { enabled: packEnabled },
+        );
+      }
+    },
+  );
+}
+
+// The cd=26 response reports the device's network configuration. Its
+// non-standard colon-delimited format is normalized into ip/gate/mask/dns/
+// ct_connect_ip keys by the message parser before it reaches these fields.
+function isVenusNetworkInfoMessage(values: Record<string, string>): boolean {
+  return 'ip' in values && 'gate' in values && 'ct_connect_ip' in values;
+}
+
+function registerNetworkInfoMessage(message: BuildMessageFn) {
+  message<VenusNetworkInfo>(
+    {
+      refreshDataPayload: `cd=${CommandType.GET_NETWORK_INFO}`,
+      isMessage: isVenusNetworkInfoMessage,
+      publishPath: 'network',
+      defaultState: {},
+      getAdditionalDeviceInfo: () => ({}),
+      // Network configuration changes rarely, so poll it infrequently.
+      pollInterval: Math.max(globalPollInterval, 300000),
+      controlsDeviceAvailability: false,
+    },
+    ({ field, advertise }) => {
+      const networkFields = [
+        ['ip', 'ipAddress', 'IP Address', 'mdi:ip-network'],
+        ['gate', 'gateway', 'Gateway', 'mdi:router-network'],
+        ['mask', 'subnetMask', 'Subnet Mask', 'mdi:ip-network-outline'],
+        ['dns', 'dns', 'DNS Server', 'mdi:dns'],
+        ['ct_connect_ip', 'ctConnectIp', 'CT Connect IP', 'mdi:current-ac'],
+      ] as const;
+
+      for (const [key, path, name, icon] of networkFields) {
+        field({ key, path: [path], transform: identity() });
+        advertise(
+          [path],
+          sensorComponent<string>({
+            id: `network_${path.replace(/([A-Z])/g, '_$1').toLowerCase()}`,
+            name,
+            icon,
+            enabled_by_default: key === 'ip',
+          }),
+          { enabled: state => (state[path] != null ? true : undefined) },
         );
       }
     },

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1626,13 +1626,28 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
 
     // MAC address used when configuring an external meter (CT002/CT003/Shelly).
     command('meter-mac', {
-      handler: ({ message, updateDeviceState }) => {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
         const mac = normalizeMeterMac(message);
         if (!mac) {
           logger.warn('Invalid meter MAC (expected 12 hex digits):', message);
           return;
         }
-        updateDeviceState(() => ({ meterMac: mac }));
+        updateDeviceState(state => {
+          // If a meter type is already configured, re-apply it with the new MAC
+          // so the device stays in sync when the MAC is edited afterwards.
+          if (state.meterType) {
+            const resolved = resolveMeterMac(state.meterType, mac);
+            if (resolved !== null) {
+              publishCallback(
+                processCommand(CommandType.SET_METER_TYPE, {
+                  meter: meterTypeCommandCodes[state.meterType],
+                  mac: resolved,
+                }),
+              );
+            }
+          }
+          return { meterMac: mac };
+        });
       },
     });
     advertise(

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1039,9 +1039,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       },
     });
 
-    // Bluetooth advertising / "lock" (cd=55). The polarity (adv=1 = advertising
-    // enabled) is inferred and not fully confirmed, so the switch is disabled by
-    // default and tracked optimistically.
+    // Bluetooth advertising / "lock" (cd=55, adv=1 enables advertising, adv=0
+    // disables it). Venus does not report the state in cd=1, so it is tracked
+    // optimistically based on the last command.
     advertise(
       ['bluetoothAdvertisingEnabled'],
       switchComponent({
@@ -1049,7 +1049,6 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Bluetooth Advertising',
         icon: 'mdi:bluetooth',
         command: 'bluetooth-advertising',
-        enabled_by_default: false,
       }),
     );
     command('bluetooth-advertising', {

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1,6 +1,7 @@
 import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
 import {
   CommandParams,
+  isValidVenusRechargeMode,
   isValidVenusVersionSet,
   isValidVenusWorkingMode,
   VenusBMSInfo,
@@ -662,10 +663,11 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     });
     advertise(
       ['rechargeMode'],
-      sensorComponent<NonNullable<VenusDeviceData['rechargeMode']>>({
+      selectComponent<NonNullable<VenusDeviceData['rechargeMode']>>({
         id: 'recharge_mode',
         name: 'Recharge Mode',
         icon: 'mdi:flash',
+        command: 'recharge-mode',
         valueMappings: {
           singlePhase: 'Single Phase',
           threePhase: 'Three Phase',
@@ -1422,6 +1424,25 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           params.nl = 1;
         }
         publishCallback(processCommand(CommandType.SET_WORKING_MODE, params));
+      },
+    });
+
+    command('recharge-mode', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        if (!isValidVenusRechargeMode(message)) {
+          logger.warn('Invalid recharge mode value:', message);
+          return;
+        }
+
+        updateDeviceState(() => ({
+          rechargeMode: message,
+        }));
+
+        publishCallback(
+          processCommand(CommandType.SET_METER_TYPE, {
+            dchrg: message === 'threePhase' ? 1 : 0,
+          }),
+        );
       },
     });
 

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1416,7 +1416,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             mode = 0;
         }
 
-        publishCallback(processCommand(CommandType.SET_WORKING_MODE, { md: mode }));
+        const params: CommandParams = { md: mode };
+        // AI mode additionally requires the nl flag to be enabled
+        if (message === 'ai') {
+          params.nl = 1;
+        }
+        publishCallback(processCommand(CommandType.SET_WORKING_MODE, params));
       },
     });
 

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1642,7 +1642,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Meter MAC',
         icon: 'mdi:identifier',
         command: 'meter-mac',
-        pattern: '^([0-9A-Fa-f]{2}[:-]?){5}[0-9A-Fa-f]{2}$',
+        // The device uses a plain 12 hex digit MAC without ':'/'-' separators.
+        pattern: '^[0-9A-Fa-f]{12}$',
         enabled_by_default: false,
       }),
     );

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1,9 +1,14 @@
 import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
 import {
   CommandParams,
+  isValidMeterType,
   isValidVenusRechargeMode,
   isValidVenusVersionSet,
   isValidVenusWorkingMode,
+  meterTypeCommandCodes,
+  meterTypeLabels,
+  normalizeMeterMac,
+  resolveMeterMac,
   VenusBMSInfo,
   VenusDeviceData,
   VenusTimePeriod,
@@ -1445,6 +1450,66 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         );
       },
     });
+
+    // MAC address used when configuring an external meter (CT002/CT003/Shelly).
+    command('meter-mac', {
+      handler: ({ message, updateDeviceState }) => {
+        const mac = normalizeMeterMac(message);
+        if (!mac) {
+          logger.warn('Invalid meter MAC (expected 12 hex digits):', message);
+          return;
+        }
+        updateDeviceState(() => ({ meterMac: mac }));
+      },
+    });
+    advertise(
+      ['meterMac'],
+      textComponent({
+        id: 'meter_mac',
+        name: 'Meter MAC',
+        icon: 'mdi:identifier',
+        command: 'meter-mac',
+        pattern: '^([0-9A-Fa-f]{2}[:-]?){5}[0-9A-Fa-f]{2}$',
+        enabled_by_default: false,
+      }),
+    );
+
+    // Configure the external meter type (cd=18,meter=...,mac=...).
+    command('meter-type', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        if (!isValidMeterType(message)) {
+          logger.warn('Invalid meter type value:', message);
+          return;
+        }
+        updateDeviceState(state => {
+          const mac = resolveMeterMac(message, state.meterMac);
+          if (mac === null) {
+            logger.warn(
+              `Meter type ${message} requires a MAC; set the "Meter MAC" entity before selecting it`,
+            );
+            return;
+          }
+          publishCallback(
+            processCommand(CommandType.SET_METER_TYPE, {
+              meter: meterTypeCommandCodes[message],
+              mac,
+            }),
+          );
+          return { meterType: message };
+        });
+      },
+    });
+    advertise(
+      ['meterType'],
+      selectComponent<NonNullable<VenusDeviceData['meterType']>>({
+        id: 'meter_type',
+        name: 'Meter Type',
+        icon: 'mdi:meter-electric',
+        command: 'meter-type',
+        valueMappings: meterTypeLabels,
+        enabled_by_default: false,
+      }),
+    );
 
     field({
       key: 'mdp_w',

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -839,6 +839,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           '0': 'automatic',
           '1': 'manual',
           '2': 'trading',
+          '5': 'ai',
         },
         'automatic',
       ),
@@ -854,6 +855,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           automatic: 'Automatic',
           manual: 'Manual',
           trading: 'Trading',
+          ai: 'AI',
         },
       }),
     );
@@ -1406,6 +1408,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             break;
           case 'trading':
             mode = 2;
+            break;
+          case 'ai':
+            mode = 5;
             break;
           default:
             mode = 0;

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -985,6 +985,79 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: 'cd=19',
   },
 
+  // backup-enabled command (cd=11)
+  {
+    description: 'Venus backup-enabled enable',
+    deviceType: 'HMG-1',
+    command: 'backup-enabled',
+    input: 'true',
+    expectedOutput: 'cd=11,bc=1',
+  },
+  {
+    description: 'Venus backup-enabled disable',
+    deviceType: 'HMG-1',
+    command: 'backup-enabled',
+    input: 'false',
+    expectedOutput: 'cd=11,bc=0',
+  },
+
+  // led-enabled command (cd=59)
+  {
+    description: 'Venus led-enabled enable',
+    deviceType: 'HMG-1',
+    command: 'led-enabled',
+    input: 'true',
+    expectedOutput: 'cd=59,led=1',
+  },
+  {
+    description: 'Venus led-enabled disable',
+    deviceType: 'HMG-1',
+    command: 'led-enabled',
+    input: 'false',
+    expectedOutput: 'cd=59,led=0',
+  },
+
+  // surplus-feed-in command (cd=43)
+  {
+    description: 'Venus surplus-feed-in enable',
+    deviceType: 'HMG-1',
+    command: 'surplus-feed-in',
+    input: 'true',
+    expectedOutput: 'cd=43,full_d=1',
+  },
+  {
+    description: 'Venus surplus-feed-in disable',
+    deviceType: 'HMG-1',
+    command: 'surplus-feed-in',
+    input: 'false',
+    expectedOutput: 'cd=43,full_d=0',
+  },
+
+  // bluetooth-advertising command (cd=55)
+  {
+    description: 'Venus bluetooth-advertising enable',
+    deviceType: 'HMG-1',
+    command: 'bluetooth-advertising',
+    input: 'true',
+    expectedOutput: 'cd=55,adv=1',
+  },
+  {
+    description: 'Venus bluetooth-advertising disable',
+    deviceType: 'HMG-1',
+    command: 'bluetooth-advertising',
+    input: 'false',
+    expectedOutput: 'cd=55,adv=0',
+  },
+
+  // phase-diagnosis command (cd=18,seq_check)
+  {
+    description: 'Venus phase-diagnosis with PRESS',
+    deviceType: 'HMG-1',
+    command: 'phase-diagnosis',
+    input: 'PRESS',
+    expectedOutput: 'cd=18,seq_check',
+  },
+
   // Venus time-period commands
   {
     description: 'Venus time-period/0/enabled true',

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -679,6 +679,29 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: null,
   },
 
+  // recharge-mode command (single-/three-phase)
+  {
+    description: 'Venus recharge-mode single phase',
+    deviceType: 'HMG-1',
+    command: 'recharge-mode',
+    input: 'singlePhase',
+    expectedOutput: 'cd=18,dchrg=0',
+  },
+  {
+    description: 'Venus recharge-mode three phase',
+    deviceType: 'HMG-1',
+    command: 'recharge-mode',
+    input: 'threePhase',
+    expectedOutput: 'cd=18,dchrg=1',
+  },
+  {
+    description: 'Venus recharge-mode invalid',
+    deviceType: 'HMG-1',
+    command: 'recharge-mode',
+    input: 'invalid',
+    expectedOutput: null,
+  },
+
   // version-set command
   {
     description: 'Venus version-set 800W',
@@ -993,6 +1016,22 @@ const commandTestCases: CommandTestCase[] = [
     command: 'working-mode',
     input: 'trading', // Not valid for Jupiter
     expectedOutput: null,
+  },
+
+  // recharge-mode command (single-/three-phase)
+  {
+    description: 'Jupiter recharge-mode single phase',
+    deviceType: 'HMN-1',
+    command: 'recharge-mode',
+    input: 'singlePhase',
+    expectedOutput: 'cd=18,dchrg=0',
+  },
+  {
+    description: 'Jupiter recharge-mode three phase',
+    deviceType: 'HMN-1',
+    command: 'recharge-mode',
+    input: 'threePhase',
+    expectedOutput: 'cd=18,dchrg=1',
   },
 
   // surplus-feed-in command

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -712,6 +712,15 @@ const commandTestCases: CommandTestCase[] = [
     expectedStateChanges: { meterMac: 'aabbccddeeff' },
   },
   {
+    description: 'Venus meter-mac re-applies configured meter type with new MAC',
+    deviceType: 'HMG-1',
+    initialState: { meterType: 'ct002' },
+    command: 'meter-mac',
+    input: 'aabbccddeeff',
+    expectedOutput: 'cd=18,meter=3,mac=aabbccddeeff',
+    expectedStateChanges: { meterMac: 'aabbccddeeff' },
+  },
+  {
     description: 'Venus meter-mac invalid',
     deviceType: 'HMG-1',
     command: 'meter-mac',
@@ -1185,6 +1194,23 @@ const commandTestCases: CommandTestCase[] = [
     input: 'shellyPro3em',
     expectedOutput: 'cd=18,meter=1,mac=000000000000',
   },
+  {
+    description: 'Jupiter meter-mac re-applies configured meter type with new MAC',
+    deviceType: 'HMN-1',
+    initialState: { meterType: 'ct003' },
+    command: 'meter-mac',
+    input: 'aabbccddeeff',
+    expectedOutput: 'cd=18,meter=4,mac=aabbccddeeff',
+    expectedStateChanges: { meterMac: 'aabbccddeeff' },
+  },
+  {
+    description: 'Jupiter meter-mac without configured meter type does not publish',
+    deviceType: 'HMN-1',
+    command: 'meter-mac',
+    input: 'aabbccddeeff',
+    expectedOutput: null,
+    expectedStateChanges: { meterMac: 'aabbccddeeff' },
+  },
 
   // surplus-feed-in command
   {
@@ -1283,6 +1309,19 @@ const commandTestCases: CommandTestCase[] = [
     command: 'time-period/0/enabled',
     input: 'true',
     expectedOutput: 'cd=3,md=2,nm=0,bt=8:00,et=20:00,wk=127,vv=500,as=1',
+  },
+  {
+    description: 'Jupiter time-period/0/enabled true (ai mode preserves md=5)',
+    deviceType: 'HMN-1',
+    initialState: {
+      workingMode: 'ai',
+      timePeriods: [
+        { enabled: false, startTime: '8:00', endTime: '20:00', weekday: '0123456', power: 500 },
+      ],
+    },
+    command: 'time-period/0/enabled',
+    input: 'true',
+    expectedOutput: 'cd=3,md=5,nm=0,bt=8:00,et=20:00,wk=127,vv=500,as=1',
   },
   {
     description: 'Jupiter time-period/0/power valid',

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -665,6 +665,13 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: 'cd=2,md=2',
   },
   {
+    description: 'Venus working-mode ai',
+    deviceType: 'HMG-1',
+    command: 'working-mode',
+    input: 'ai',
+    expectedOutput: 'cd=2,md=5,nl=1',
+  },
+  {
     description: 'Venus working-mode invalid',
     deviceType: 'HMG-1',
     command: 'working-mode',
@@ -972,6 +979,13 @@ const commandTestCases: CommandTestCase[] = [
     command: 'working-mode',
     input: 'manual',
     expectedOutput: 'cd=2,md=2',
+  },
+  {
+    description: 'Jupiter working-mode ai',
+    deviceType: 'HMN-1',
+    command: 'working-mode',
+    input: 'ai',
+    expectedOutput: 'cd=2,md=5,nl=1',
   },
   {
     description: 'Jupiter working-mode invalid',

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -702,6 +702,69 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: null,
   },
 
+  // meter-mac + meter-type commands
+  {
+    description: 'Venus meter-mac normalizes separators and case',
+    deviceType: 'HMG-1',
+    command: 'meter-mac',
+    input: 'AA:BB:CC:DD:EE:FF',
+    expectedOutput: null,
+    expectedStateChanges: { meterMac: 'aabbccddeeff' },
+  },
+  {
+    description: 'Venus meter-mac invalid',
+    deviceType: 'HMG-1',
+    command: 'meter-mac',
+    input: 'not-a-mac',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus meter-type CT002 with configured MAC',
+    deviceType: 'HMG-1',
+    initialState: { meterMac: 'aabbccddeeff' },
+    command: 'meter-type',
+    input: 'ct002',
+    expectedOutput: 'cd=18,meter=3,mac=aabbccddeeff',
+    expectedStateChanges: { meterType: 'ct002' },
+  },
+  {
+    description: 'Venus meter-type CT003 with configured MAC',
+    deviceType: 'HMG-1',
+    initialState: { meterMac: '112233445566' },
+    command: 'meter-type',
+    input: 'ct003',
+    expectedOutput: 'cd=18,meter=4,mac=112233445566',
+  },
+  {
+    description: 'Venus meter-type Shelly Pro 3EM forces all-zero MAC',
+    deviceType: 'HMG-1',
+    initialState: { meterMac: 'aabbccddeeff' },
+    command: 'meter-type',
+    input: 'shellyPro3em',
+    expectedOutput: 'cd=18,meter=1,mac=000000000000',
+  },
+  {
+    description: 'Venus meter-type CT001 without MAC uses all-zero MAC',
+    deviceType: 'HMG-1',
+    command: 'meter-type',
+    input: 'ct001',
+    expectedOutput: 'cd=18,meter=0,mac=000000000000',
+  },
+  {
+    description: 'Venus meter-type CT002 without MAC is rejected',
+    deviceType: 'HMG-1',
+    command: 'meter-type',
+    input: 'ct002',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus meter-type invalid',
+    deviceType: 'HMG-1',
+    command: 'meter-type',
+    input: 'invalid',
+    expectedOutput: null,
+  },
+
   // version-set command
   {
     description: 'Venus version-set 800W',
@@ -1032,6 +1095,22 @@ const commandTestCases: CommandTestCase[] = [
     command: 'recharge-mode',
     input: 'threePhase',
     expectedOutput: 'cd=18,dchrg=1',
+  },
+  {
+    description: 'Jupiter meter-type CT002 with configured MAC',
+    deviceType: 'HMN-1',
+    initialState: { meterMac: 'aabbccddeeff' },
+    command: 'meter-type',
+    input: 'ct002',
+    expectedOutput: 'cd=18,meter=3,mac=aabbccddeeff',
+    expectedStateChanges: { meterType: 'ct002' },
+  },
+  {
+    description: 'Jupiter meter-type Shelly Pro 3EM forces all-zero MAC',
+    deviceType: 'HMN-1',
+    command: 'meter-type',
+    input: 'shellyPro3em',
+    expectedOutput: 'cd=18,meter=1,mac=000000000000',
   },
 
   // surplus-feed-in command

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -5,7 +5,9 @@ import {
   JupiterBMSInfo,
   JupiterDeviceData,
   VenusBMSInfo,
+  VenusBMSPackInfo,
   VenusDeviceData,
+  VenusNetworkInfo,
 } from './types';
 
 describe('MQTT Message Parser', () => {
@@ -764,6 +766,51 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('bmsVersion', 116);
     expect(result).toHaveProperty('communicationModuleVersion', '202409090159');
     expect(result).toHaveProperty('shellyPort', 1010);
+  });
+
+  test('parses Venus v147 LED, backup, inverter/MPPT version and phase-diagnosis fields', () => {
+    // Real Venus D v147 dump including the newer led/inv_v/mppt/seq_s fields.
+    const message =
+      'cd=1,tot_i=6,tot_o=1109,ele_d=0,ele_m=0,grd_d=27,grd_m=27,inc_d=0,inc_m=0,grd_f=0,grd_o=801,grd_t=3,gct_s=1,cel_s=2,cel_p=233,cel_c=45,err_t=800,err_a=4,dev_n=147,grd_y=0,wor_m=5,tim_0=0|0|23|59|127|250|0,cts_m=0,bac_u=0,tra_a=74,tra_i=0,tra_o=0,htt_p=0,prc_c=0,prc_d=3,wif_s=72,inc_a=0,set_v=1,mcp_w=2200,mdp_w=800,ct_t=3,phase_t=1,dchrg_t=0,bms_v=116,fc_v=202409090159,wifi_n=unten,seq_s=3,ctrl_r=0,par=0,gen=0,ble=3,shelly_p=1010,c_ratio=100,udp=0,api=0,net=0,port=30000,inv_v=115,id=2|0|0|0|0,lk=0,bp=291,ei=0,eb=0,rp=347,gp=801,vp=801,bl=1,dod=88,bl_p=-1,led=1,as=3,mppt=104,pv1=2584|1,pv2=2638|1,pv3=3180|1,pv4=3080|1,pack=2|3|2|0,pv=24|24,fu=0|0,em=0';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
+
+    expect(parsed).toHaveProperty('data');
+    const result = parsed['data'] as VenusDeviceData;
+    expect(result).toHaveProperty('ledEnabled', true);
+    expect(result).toHaveProperty('backupEnabled', false);
+    expect(result).toHaveProperty('inverterVersion', 115);
+    expect(result).toHaveProperty('mpptVersion', 104);
+    expect(result).toHaveProperty('phaseDiagnosisStatus', 3);
+  });
+
+  test('parses Venus cd=42 per-pack BMS details', () => {
+    // Real Venus D v147 response to cd=42,bms_idx=255 (two packs present).
+    const message =
+      'cd=42, BMS: num=2,mask=3,idx=2,charge_pow=2643,discharge_pow=2643,soc1=424,state1=0,temp1=278,soc2=482,state2=2,temp2=254,soc3=0,state3=0,temp3=0,soc4=0,state4=0,temp4=0,soc5=0,state5=0,temp5=0,soc6=0,state6=0,temp6=0';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
+
+    expect(parsed).toHaveProperty('bmsPacks');
+    const result = parsed['bmsPacks'] as VenusBMSPackInfo;
+    expect(result).toHaveProperty('packMask', 3);
+    expect(result).toHaveProperty('chargePower', 2643);
+    expect(result).toHaveProperty('dischargePower', 2643);
+    // SoC and temperature are reported in 0.1 units; VNSD scales temperatures by 10.
+    expect(result.packs?.[0]).toEqual({ soc: 42.4, state: 0, temperature: 27.8 });
+    expect(result.packs?.[1]).toEqual({ soc: 48.2, state: 2, temperature: 25.4 });
+  });
+
+  test('parses Venus cd=26 network info (colon-delimited format)', () => {
+    const message =
+      'cd=26,dev_net_info:ip:192.168.178.134,gate:192.168.178.1,mask:255.255.255.0,dns:192.168.178.1,ct_connect_ip:192.168.178.255';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
+
+    expect(parsed).toHaveProperty('network');
+    const result = parsed['network'] as VenusNetworkInfo;
+    expect(result).toHaveProperty('ipAddress', '192.168.178.134');
+    expect(result).toHaveProperty('gateway', '192.168.178.1');
+    expect(result).toHaveProperty('subnetMask', '255.255.255.0');
+    expect(result).toHaveProperty('dns', '192.168.178.1');
+    expect(result).toHaveProperty('ctConnectIp', '192.168.178.255');
   });
 
   test('scales Venus A (VNSA) BMS voltages and temperatures (issue #218)', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -403,7 +403,7 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('wifiSignalStrength', -75);
     expect(result).toHaveProperty('ctType', 4);
     expect(result).toHaveProperty('phaseType', 1);
-    expect(result).toHaveProperty('rechargeMode', 1);
+    expect(result).toHaveProperty('rechargeMode', 'threePhase');
     expect(result).toHaveProperty('deviceVersion', 134);
     expect(result).toHaveProperty('bmsVersion', 209);
     expect(result).toHaveProperty('mpptVersion', 206);

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -668,6 +668,26 @@ describe('MQTT Message Parser', () => {
     expect(result.depthOfDischarge).toBeUndefined();
   });
 
+  test('parses Venus AI working mode (wor_m=5)', () => {
+    const message =
+      'cd=1,tot_i=8848,tot_o=7097,ele_d=537,ele_m=8848,grd_d=328,grd_m=7097,inc_d=0,inc_m=0,grd_f=0,grd_o=613,grd_t=3,gct_s=1,cel_s=3,cel_p=327,cel_c=64,err_t=0,err_a=0,dev_n=158,grd_y=0,wor_m=5,tim_0=0|0|0|0|0|0|0,cts_m=0,bac_u=0,tra_a=1,tra_i=0,tra_o=0,htt_p=0,prc_c=0,prc_d=1,wif_s=33,inc_a=0,set_v=0,mcp_w=2500,mdp_w=2500,ct_t=4,phase_t=1,dchrg_t=1,bms_v=212,fc_v=202409090159,wifi_n=XXX,seq_s=0,ctrl_r=1,par=255,gen=255,ble=3,shelly_p=1010,c_ratio=90,dod=88';
+    const parsed = parseMessage(message, 'VNSE3-0', 'venus123');
+
+    expect(parsed).toHaveProperty('data');
+    const result = parsed['data'] as VenusDeviceData;
+    expect(result).toHaveProperty('workingMode', 'ai');
+  });
+
+  test('parses Jupiter AI working mode (wor_m=5)', () => {
+    const message =
+      'ele_d=349,ele_m=2193,ele_y=0,pv1_p=94,pv1_s=1,pv2_p=77,pv2_s=1,pv3_p=41,pv3_s=1,pv4_p=60,pv4_s=1,grd_o=250,grd_t=1,gct_s=1,cel_s=0,cel_p=424,cel_c=83,err_t=0,wor_m=5,tim_0=12|0|23|59|127|800|1,tim_1=0|0|12|0|127|150|1,tim_2=0|0|0|0|255|0|0,tim_3=0|0|0|0|255|0|0,tim_4=0|0|0|0|255|0|0,cts_m=0,grd_d=285,grd_m=2018,dev_n=134,dev_i=106,dev_m=206,dev_b=209,dev_t=110,wif_s=75,ala_c=0,ful_d=1,ssid=xxxx,stop_s=10,htt_p=0,ct_t=4,phase_t=1,dchrg=1,seq_s=3,ctrl_r=0,shelly_p=1010,c_ratio=100,b_lck=0,dod=88,total_b=1,online_b=1';
+    const parsed = parseMessage(message, 'JPLS-1', 'jupiter123');
+
+    expect(parsed).toHaveProperty('data');
+    const result = parsed['data'] as JupiterDeviceData;
+    expect(result).toHaveProperty('workingMode', 'ai');
+  });
+
   test('parses Venus A (VNSA) PV input power and connection status (issue #218)', () => {
     // Real runtime reading from a Venus A: pv1 connected and producing, pv2-4 idle.
     const message =

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -38,8 +38,21 @@ export function parseMessage(
 ): Record<string, BaseDeviceData> {
   const deviceDefinition = getDeviceDefinition(deviceType);
   try {
+    // The Venus cd=26 network-info response uses a non-standard colon-delimited
+    // format instead of key=value pairs, e.g.:
+    //   cd=26,dev_net_info:ip:1.2.3.4,gate:1.2.3.1,mask:255.255.255.0,dns:1.2.3.1,ct_connect_ip:1.2.3.255
+    // Normalize it to standard key=value pairs (ip=…, gate=…, …) so the generic
+    // parser below can handle it like any other message.
+    const normalizedMessage = message.startsWith('cd=26,')
+      ? message
+          .replace('dev_net_info:', '')
+          .split(',')
+          .map(pair => (pair.includes('=') ? pair : pair.replace(':', '=')))
+          .join(',')
+      : message;
+
     // Parse the comma-separated key-value pairs
-    const pairs = message.split(',');
+    const pairs = normalizedMessage.split(',');
     const values: Record<string, string> = {};
 
     // Process each key-value pair

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,7 +302,12 @@ export type VenusPhaseType = 'unknown' | 'phaseA' | 'phaseB' | 'phaseC' | 'notDe
 /**
  * Venus device recharge mode
  */
-export type VenusRechargeMode = 'singlePhase' | 'threePhase';
+const validVenusRechargeModes = ['singlePhase', 'threePhase'] as const;
+export type VenusRechargeMode = (typeof validVenusRechargeModes)[number];
+
+export function isValidVenusRechargeMode(mode: string): mode is VenusRechargeMode {
+  return validVenusRechargeModes.includes(mode as VenusRechargeMode);
+}
 
 export type WeekdaySet = `${0 | ''}${1 | ''}${2 | ''}${3 | ''}${4 | ''}${5 | ''}${6 | ''}`;
 
@@ -447,6 +452,13 @@ export function isValidJupiterWorkingMode(mode: string): mode is JupiterWorkingM
   return validJupiterWorkingModes.includes(mode as JupiterWorkingMode);
 }
 
+const validJupiterRechargeModes = ['singlePhase', 'threePhase'] as const;
+export type JupiterRechargeMode = (typeof validJupiterRechargeModes)[number];
+
+export function isValidJupiterRechargeMode(mode: string): mode is JupiterRechargeMode {
+  return validJupiterRechargeModes.includes(mode as JupiterRechargeMode);
+}
+
 export interface JupiterDeviceData extends BaseDeviceData {
   dailyChargingCapacity?: number; // ele_d
   monthlyChargingCapacity?: number; // ele_m
@@ -470,7 +482,7 @@ export interface JupiterDeviceData extends BaseDeviceData {
   wifiSignalStrength?: number; // wif_s
   ctType?: number; // ct_t
   phaseType?: number; // phase_t
-  rechargeMode?: number; // dchrg
+  rechargeMode?: JupiterRechargeMode; // dchrg
   wifiName?: string; // ssid
   deviceVersion?: number; // dev_n
   bmsVersion?: number; // dev_b

--- a/src/types.ts
+++ b/src/types.ts
@@ -480,6 +480,12 @@ export interface VenusDeviceData extends BaseDeviceData {
   localApiEnabled?: boolean;
   localApiPort?: number;
   depthOfDischarge?: number; // dod
+  ledEnabled?: boolean; // led
+  surplusFeedInEnabled?: boolean; // set via cd=43 (no status field; tracked optimistically)
+  bluetoothAdvertisingEnabled?: boolean; // set via cd=55 (tracked optimistically)
+  phaseDiagnosisStatus?: number; // seq_s
+  inverterVersion?: number; // inv_v
+  mpptVersion?: number; // mppt
 }
 
 export interface VenusBMSInfo extends BaseDeviceData {
@@ -508,6 +514,31 @@ export interface VenusBMSInfo extends BaseDeviceData {
     energyThroughput?: number;
     mosfetTemp?: number;
   };
+}
+
+/**
+ * Per-pack BMS details reported by the cd=42 response on newer Venus firmware.
+ */
+export interface VenusBMSPackInfo extends BaseDeviceData {
+  packMask?: number; // bitmask of present packs (bit 0 = pack 1, ...)
+  chargePower?: number; // allowed charge power (W)
+  dischargePower?: number; // allowed discharge power (W)
+  packs?: {
+    soc?: number; // state of charge (%)
+    state?: number; // working state (raw; meaning unconfirmed)
+    temperature?: number; // °C
+  }[];
+}
+
+/**
+ * Network configuration reported by the cd=26 response on newer Venus firmware.
+ */
+export interface VenusNetworkInfo extends BaseDeviceData {
+  ipAddress?: string;
+  gateway?: string;
+  subnetMask?: string;
+  dns?: string;
+  ctConnectIp?: string;
 }
 
 export interface JupiterTimePeriod {

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,7 +264,7 @@ export type VenusCTStatus = 'notConnected' | 'connected' | 'weakSignal';
  */
 export type VenusBatteryWorkingStatus = 'notWorking' | 'charging' | 'discharging' | 'unknown';
 
-const validVenusWorkingModes = ['automatic', 'manual', 'trading'] as const;
+const validVenusWorkingModes = ['automatic', 'manual', 'trading', 'ai'] as const;
 /**
  * Venus device working mode types
  */
@@ -440,7 +440,7 @@ export interface JupiterTimePeriod {
 
 export type JupiterBatteryWorkingStatus = 'keep' | 'charging' | 'discharging' | 'unknown';
 
-const validJupiterWorkingModes = ['automatic', 'manual'] as const;
+const validJupiterWorkingModes = ['automatic', 'manual', 'ai'] as const;
 export type JupiterWorkingMode = (typeof validJupiterWorkingModes)[number];
 
 export function isValidJupiterWorkingMode(mode: string): mode is JupiterWorkingMode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -309,6 +309,79 @@ export function isValidVenusRechargeMode(mode: string): mode is VenusRechargeMod
   return validVenusRechargeModes.includes(mode as VenusRechargeMode);
 }
 
+/**
+ * External meter type that can be configured via the SET_METER_TYPE (cd=18) command.
+ * Shared by Venus and Jupiter. The numeric command code differs from the internal
+ * key and from the reported `ct_t` value, so it is kept in a dedicated map.
+ */
+const validMeterTypes = [
+  'ct001',
+  'shellyPro3em',
+  'ct002',
+  'ct003',
+  'shellyEmGen3',
+  'shellyProEm50',
+] as const;
+export type MeterType = (typeof validMeterTypes)[number];
+
+export function isValidMeterType(type: string): type is MeterType {
+  return validMeterTypes.includes(type as MeterType);
+}
+
+/**
+ * Maps a meter type to the numeric `meter` value sent with the cd=18 command.
+ */
+export const meterTypeCommandCodes: Record<MeterType, number> = {
+  ct001: 0,
+  shellyPro3em: 1,
+  ct002: 3,
+  ct003: 4,
+  shellyEmGen3: 5,
+  shellyProEm50: 6,
+};
+
+/**
+ * Human-readable labels for each meter type, used for Home Assistant discovery.
+ */
+export const meterTypeLabels: Record<MeterType, string> = {
+  ct001: 'CT001',
+  shellyPro3em: 'Shelly Pro 3EM',
+  ct002: 'CT002',
+  ct003: 'CT003',
+  shellyEmGen3: 'Shelly EM Gen3',
+  shellyProEm50: 'Shelly Pro EM50',
+};
+
+/**
+ * Normalize a user-supplied MAC address to the 12 lowercase hex digits expected
+ * by the cd=18 command (separators such as ':' or '-' are stripped). Returns
+ * null when the input is not a valid MAC.
+ */
+export function normalizeMeterMac(input: string): string | null {
+  const cleaned = input.replace(/[\s:.-]/g, '').toLowerCase();
+  return /^[0-9a-f]{12}$/.test(cleaned) ? cleaned : null;
+}
+
+/**
+ * Determine the MAC to send for a given meter type, applying the special rules:
+ * - Shelly Pro 3EM always uses the fixed all-zero MAC.
+ * - The built-in CT001 does not need a MAC and falls back to all-zeros.
+ * - CT002/CT003/Shelly EM Gen3/Shelly Pro EM50 require an explicit MAC; when none
+ *   has been configured this returns null so the caller can abort.
+ */
+export function resolveMeterMac(meterType: MeterType, configuredMac?: string): string | null {
+  if (meterType === 'shellyPro3em') {
+    return '000000000000';
+  }
+  if (configuredMac) {
+    return configuredMac;
+  }
+  if (meterType === 'ct001') {
+    return '000000000000';
+  }
+  return null;
+}
+
 export type WeekdaySet = `${0 | ''}${1 | ''}${2 | ''}${3 | ''}${4 | ''}${5 | ''}${6 | ''}`;
 
 const venusValidVersionSets = ['800W', '2500W'] as const;
@@ -398,6 +471,8 @@ export interface VenusDeviceData extends BaseDeviceData {
   ctType?: VenusCTType;
   phaseType?: VenusPhaseType;
   rechargeMode?: VenusRechargeMode;
+  meterType?: MeterType; // last configured via cd=18
+  meterMac?: string; // MAC used when configuring the meter type
   bmsVersion?: number;
   communicationModuleVersion?: string;
   shellyPort?: number;
@@ -483,6 +558,8 @@ export interface JupiterDeviceData extends BaseDeviceData {
   ctType?: number; // ct_t
   phaseType?: number; // phase_t
   rechargeMode?: JupiterRechargeMode; // dchrg
+  meterType?: MeterType; // last configured via cd=18
+  meterMac?: string; // MAC used when configuring the meter type
   wifiName?: string; // ssid
   deviceVersion?: number; // dev_n
   bmsVersion?: number; // dev_b


### PR DESCRIPTION
## Summary

This PR adds support for several new Venus and Jupiter device features, including AI working mode, external meter configuration, and various device control commands (LED, surplus feed-in, Bluetooth advertising, phase diagnosis, etc.). It also expands the documentation with detailed command specifications for newer firmware versions.

## Key Changes

### Working Mode & Meter Configuration
- Add support for AI working mode (`wor_m=5`) on both Venus and Jupiter devices
- Add *Meter Type* select and *Meter MAC* text entities to configure external meters (CT001, Shelly Pro 3EM, CT002, CT003, Shelly EM Gen3, Shelly Pro EM50) via `cd=18,meter=…,mac=…`
- Convert recharge mode from numeric sensor to select component with proper command handling
- Implement MAC address normalization and validation for meter configuration

### Venus Device Controls
- Add *Backup Power* switch to toggle backup/EPS ("UPS") mode (`cd=11`)
- Add *Status LED* switch to control the device's status LED (`cd=59`)
- Add *Surplus Feed-in* switch to enable/disable feeding excess PV power to grid (`cd=43`)
- Add *Bluetooth Advertising* switch to control Bluetooth discoverability (`cd=55`)
- Add *Phase Diagnosis* button to trigger phase-detection routine (`cd=18,seq_check`)

### Device Information & Monitoring
- Parse and expose inverter version (`inv_v`) and MPPT module version (`mppt`) fields
- Parse and expose phase-diagnosis status (`seq_s`) field
- Add support for reading BMS pack details via `cd=42` command with per-pack SoC, state, and temperature
- Add support for reading network information via `cd=26` command (IP, gateway, DNS, etc.)
- Add support for reading power history via `cd=29` command
- Add support for pre-update check (`cd=51`) and OTA update commands (`cd=53`/`cd=54`)

### Documentation
- Expand `docs/venus.md` with detailed specifications for 10 new command types (18-27)
- Document newer firmware fields and their meanings (marked as unconfirmed where appropriate)
- Add meter type configuration table with command codes and MAC requirements
- Document OTA update sequence and network information response format

### Type System & Validation
- Add `isValidVenusRechargeMode()` and `isValidMeterType()` validation functions
- Add `meterTypeCommandCodes` and `meterTypeLabels` maps for meter type handling
- Add `normalizeMeterMac()` and `resolveMeterMac()` utility functions for MAC address handling
- Extend `VenusDeviceData` and `JupiterDeviceData` with new fields for meter config and device state
- Add `VenusBMSPackInfo` and `VenusNetworkInfo` types for new response formats

### Testing
- Add comprehensive test cases for all new commands (recharge-mode, meter-type, meter-mac, backup-enabled, led-enabled, surplus-feed-in, bluetooth-advertising, phase-diagnosis)
- Add parser tests for AI working mode on both Venus and Jupiter
- Add parser test for Venus network information response

## Implementation Details

- AI mode requires the `nl=1` flag to be sent alongside `md=5` in the working-mode command
- Meter MAC configuration uses special rules: Shelly Pro 3EM forces all-zero MAC, CT001 uses all-zero MAC, others require explicit MAC
- Surplus feed-in and Bluetooth advertising state are tracked optimistically (no status field in device info)
- BMS pack details and network info are gated behind existing feature flags (`POLL_CELL_DATA` for packs)
- Parser updated to handle non-standard colon-delimited format in `cd=26` network info response

## Validation

- `npm test -- --runInBand` passes all new and existing tests
- `npm run build` completes successfully
- All new commands properly serialize to expected MQTT payloads
- Parser correctly handles new response formats and field mappings

https://claude.ai/code/session_01XZ94FH9XveNXKGL2ifmj8X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI working mode support for Venus and Jupiter devices.
  * Made Recharge Mode user-configurable (Single Phase / Three Phase selection).
  * Added external meter configuration controls (MAC address and meter type).
  * Introduced backup power, status LED, surplus feed-in, and Bluetooth advertising controls.
  * Added phase diagnosis capability.
  * Exposed device versions and network configuration data.
  * Enabled per-pack BMS sensor monitoring.

* **Documentation**
  * Updated command documentation for MQTT topics.
  * Expanded Venus device documentation with comprehensive command and field references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->