### PR TITLE
Venus: read surplus feed-in and Bluetooth advertising state from device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,20 @@
 
 ### Added
 
-- Venus & Jupiter: Add support for the *AI* working mode (`wor_m=5`). It is now decoded as a working mode value and can be selected via the *Working Mode* entity.
-- Venus & Jupiter: Add a *Meter Type* select and *Meter MAC* text entity to configure the external meter (CT001, Shelly Pro 3EM, CT002, CT003, Shelly EM Gen3, Shelly Pro EM50) via `cd=18,meter=…,mac=…`. CT002/CT003 and the Shelly EM Gen3/Pro EM50 require the MAC to be set first; Shelly Pro 3EM uses a fixed all-zero MAC. Both entities are disabled by default.
-- Venus: Add a *Backup Power* switch to toggle the backup/EPS ("UPS") function (`cd=11`, reported as `bac_u`).
-- Venus: Add a *Status LED* switch (`cd=59`, reported as `led`) on firmware that reports the LED state.
-- Venus: Add a *Surplus Feed-in* switch (`cd=43`) on models with PV inputs (Venus A/D). The device does not report the state back, so it is tracked optimistically.
-- Venus: Add a *Bluetooth Advertising* switch (`cd=55`; `adv=1` enables advertising, `adv=0` disables it). The device does not report the state back, so it is tracked optimistically.
-- Venus: Add a *Phase Diagnosis* button (`cd=18,seq_check`) plus a *Phase Diagnosis Status* sensor (`seq_s`).
-- Venus: Expose *Inverter Version* (`inv_v`) and *MPPT Version* (`mppt`) sensors on firmware that reports them.
-- Venus: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP) parsed from the `cd=26` response. Only the IP Address is enabled by default.
-- Venus: Add per-pack BMS sensors (per-pack State of Charge, State and Temperature, plus Pack Charge/Discharge Power) parsed from the `cd=42` response. Like the detailed BMS data, these are only polled when `POLL_CELL_DATA=true` and are disabled by default.
+- Venus & Jupiter: Add support for the *AI* working mode, selectable via the *Working Mode* entity.
+- Venus & Jupiter: Add a *Meter Type* select and *Meter MAC* text entity to configure the external meter (CT001, Shelly Pro 3EM, CT002, CT003, Shelly EM Gen3, Shelly Pro EM50). CT002/CT003 and the Shelly EM Gen3/Pro EM50 require the MAC to be set first; Shelly Pro 3EM does not need a MAC. Both entities are disabled by default.
+- Venus: Add a *Backup Power* switch to toggle the backup/EPS ("UPS") function.
+- Venus: Add a *Status LED* switch on devices that support it.
+- Venus: Add a *Surplus Feed-in* switch on models with PV inputs (Venus A/D), letting you feed excess solar power into the grid.
+- Venus: Add a *Bluetooth Advertising* switch to turn Bluetooth discovery on or off (the "Bluetooth lock").
+- Venus: Add a *Phase Diagnosis* button to start grid-phase detection, plus a *Phase Diagnosis Status* sensor.
+- Venus: Add *Inverter Version* and *MPPT Version* sensors on devices that report them.
+- Venus: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP). Only the IP Address is enabled by default.
+- Venus: Add per-battery-pack sensors (State of Charge, State, Temperature and Charge/Discharge Power). These require cell-data polling to be enabled and are disabled by default.
 
 ### Changed
 
-- Venus & Jupiter: The *Recharge Mode* entity is now a settable select (Single Phase / Three Phase) instead of a read-only sensor, so the grid recharge mode can be switched from Home Assistant (`cd=18,dchrg=0|1`).
->>>>>>> 44f30bb (Add Venus/Jupiter AI mode, meter config, and device control features (#333))
+- Venus & Jupiter: The *Recharge Mode* entity is now a settable select (Single Phase / Three Phase) instead of a read-only sensor, so the grid recharge mode can be switched from Home Assistant.
 
 ## [1.8.0] - 2026-06-13
 

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -202,7 +202,7 @@ guesses based on context and cross-referencing other commands:
 | ctrl_r | *(unconfirmed)* |
 | par | Parallel-operation flag *(unconfirmed)* |
 | gen | Generator flag *(unconfirmed)* |
-| ble | Bluetooth state *(unconfirmed)* (see `cd=55`) |
+| ble | Bluetooth state bitmask; bit 2 (value `4`) is set when advertising is enabled (Bluetooth lock off), `1` when the lock is enabled (see `cd=55`) |
 | c_ratio | CT ratio (%) *(unconfirmed)* |
 | udp | UDP enabled *(unconfirmed)* |
 | api | Local API enabled (0: disabled; 1: enabled) (see `cd=30`) |
@@ -224,7 +224,7 @@ guesses based on context and cross-referencing other commands:
 | mppt | MPPT module version number *(unconfirmed)* |
 | pack | Battery pack summary `num\|mask\|idx\|?` — matches the `cd=42` BMS response (number of packs \| present-pack bitmask \| index) |
 | pv | Total PV power `value\|value` (0.1W) *(unconfirmed)* |
-| fu | *(unconfirmed)*, pipe-separated |
+| fu | Surplus feed-in state `enabled\|?` — first component is `1` when surplus feed-in is enabled, `0` when disabled (see `cd=43`) |
 | em | *(unconfirmed)* |
 
 ## 4 Set working status
@@ -565,6 +565,9 @@ You will receive a message echoing the resulting state:
 > Note: unlike most other commands (where `ret=1` means "success" and `ret=0`
 > means "failure"), here `ret` echoes the new state of the setting.
 
+The current surplus feed-in state is also reported in the first component of the
+`fu` field of the `cd=1` response (`fu=1|0` when enabled, `fu=0|0` when disabled).
+
 ## 19 Configure the local API
 
 Enables/disables the device's local API (used by tools such as the Marstek
@@ -888,5 +891,6 @@ The device echoes the resulting state:
 1. `cd=55,ret=1` - Advertising enabled (discoverable; Bluetooth lock off)
 2. `cd=55,ret=0` - Advertising disabled (Bluetooth lock on)
 
-The related Bluetooth state is also reflected in the `ble` field of the `cd=1`
-response.
+The current state is also reflected in the `ble` field of the `cd=1` response: it
+is a bitmask where bit 2 (value `4`) is set when advertising is enabled
+(Bluetooth lock off), and `1` when the lock is enabled.

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -33,6 +33,7 @@ import {
   identity,
   number,
   equalsBoolean,
+  bitBoolean,
   chain,
   inRange,
   sum,
@@ -1017,9 +1018,15 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       },
     });
 
-    // Surplus feed-in (cd=43, feeding excess PV power into the grid). Venus does
-    // not report the state back, so it is tracked optimistically based on the
-    // last command. Only advertised on models with PV inputs (Venus A/D).
+    // Surplus feed-in (cd=43, feeding excess PV power into the grid). The current
+    // state is reported in the first component of the `fu` field ("1|0" = on,
+    // "0|0" = off). The optimistic update in the command handler gives immediate
+    // feedback until the next cd=1 poll reconciles with the device.
+    field({
+      key: 'fu',
+      path: ['surplusFeedInEnabled'],
+      transform: value => value.split('|')[0] === '1',
+    });
     advertise(
       ['surplusFeedInEnabled'],
       switchComponent({
@@ -1028,7 +1035,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:transmission-tower-export',
         command: 'surplus-feed-in',
       }),
-      { enabled: state => (state.pv1Power != null ? true : undefined) },
+      { enabled: state => (state.surplusFeedInEnabled != null ? true : undefined) },
     );
     command('surplus-feed-in', {
       handler: ({ message, publishCallback, updateDeviceState }) => {
@@ -1040,8 +1047,15 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     });
 
     // Bluetooth advertising / "lock" (cd=55, adv=1 enables advertising, adv=0
-    // disables it). Venus does not report the state in cd=1, so it is tracked
-    // optimistically based on the last command.
+    // disables it). The state is reported in the `ble` field as a bitmask where
+    // bit 2 (value 4) is set when advertising is enabled (Bluetooth lock off).
+    // The optimistic update in the command handler gives immediate feedback
+    // until the next cd=1 poll reconciles with the device.
+    field({
+      key: 'ble',
+      path: ['bluetoothAdvertisingEnabled'],
+      transform: bitBoolean(2),
+    });
     advertise(
       ['bluetoothAdvertisingEnabled'],
       switchComponent({
@@ -1050,6 +1064,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:bluetooth',
         command: 'bluetooth-advertising',
       }),
+      { enabled: state => (state.bluetoothAdvertisingEnabled != null ? true : undefined) },
     );
     command('bluetooth-advertising', {
       handler: ({ message, publishCallback, updateDeviceState }) => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -783,6 +783,30 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('phaseDiagnosisStatus', 3);
   });
 
+  test('parses Venus surplus feed-in state from the fu field', () => {
+    const base =
+      'cd=1,tot_i=6,tot_o=1109,ele_d=0,ele_m=0,grd_d=27,grd_m=27,inc_d=0,inc_m=0,grd_f=0,grd_o=801,grd_t=3,gct_s=1,cel_s=2,cel_p=233,cel_c=45,err_t=800,err_a=4,dev_n=147,grd_y=0,wor_m=5,inc_a=0,pv1=2584|1,pv2=2638|1,pv3=3180|1,pv4=3080|1';
+
+    const off = parseMessage(`${base},fu=0|0,em=0`, 'VNSD-0', 'venusD123');
+    expect((off['data'] as VenusDeviceData).surplusFeedInEnabled).toBe(false);
+
+    const on = parseMessage(`${base},fu=1|0,em=0`, 'VNSD-0', 'venusD123');
+    expect((on['data'] as VenusDeviceData).surplusFeedInEnabled).toBe(true);
+  });
+
+  test('parses Venus Bluetooth advertising state from the ble field', () => {
+    const base =
+      'cd=1,tot_i=6,tot_o=1109,ele_d=0,ele_m=0,grd_d=27,grd_m=27,inc_d=0,inc_m=0,grd_f=0,grd_o=801,grd_t=3,gct_s=1,cel_s=2,cel_p=233,cel_c=45,err_t=800,err_a=4,dev_n=147,grd_y=0,wor_m=5,inc_a=0';
+
+    // ble=4 -> advertising enabled (Bluetooth lock off)
+    const on = parseMessage(`${base},ble=4`, 'VNSD-0', 'venusD123');
+    expect((on['data'] as VenusDeviceData).bluetoothAdvertisingEnabled).toBe(true);
+
+    // ble=1 -> advertising disabled (Bluetooth lock on)
+    const off = parseMessage(`${base},ble=1`, 'VNSD-0', 'venusD123');
+    expect((off['data'] as VenusDeviceData).bluetoothAdvertisingEnabled).toBe(false);
+  });
+
   test('parses Venus cd=42 per-pack BMS details', () => {
     // Real Venus D v147 response to cd=42,bms_idx=255 (two packs present).
     const message =


### PR DESCRIPTION
## What changed

Follow-up to #333. The Venus **Surplus Feed-in** and **Bluetooth Advertising** switches were previously tracked optimistically (no device feedback). They now read their actual state from the device:

- **Surplus Feed-in** — state is read from the `fu` field (first component: `1|0` = on, `0|0` = off).
- **Bluetooth Advertising** — state is read from the `ble` field (bitmask; bit 2 / value `4` set = advertising enabled / "Bluetooth lock" off, `1` = lock enabled).

Both keep an optimistic update on command for immediate UI feedback, then reconcile with the device on the next `cd=1` poll. Each switch is now advertised only when the device reports the corresponding field.

## Why

Without reading the device state, the switches could drift from reality when the setting was changed outside Home Assistant (e.g. via the Marstek app).

## How it was validated

```
npm test -- --runInBand   # 363 passed
npm run build
npm run lint
```

Added parser tests covering `fu` (on/off) and `ble` (4/1) decoding.

Docs (`docs/venus.md`) and the changelog were updated accordingly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZ94FH9XveNXKGL2ifmj8X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Venus device now properly reads and reflects actual state of Surplus Feed-in and Bluetooth Advertising features instead of optimistic-only tracking. Device availability gating improved based on confirmed feature states.

* **Documentation**
  * Refined CHANGELOG and API documentation for Venus MQTT device responses, clarifying field meanings and state representations.

* **Tests**
  * Added test coverage for state parsing of Surplus Feed-in and Bluetooth Advertising features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->