### PR TITLE
Venus: add PV energy sensors and a declarative pipe transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Venus: Add *Inverter Version* and *MPPT Version* sensors on devices that report them.
 - Venus: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP). Only the IP Address is enabled by default.
 - Venus: Add per-battery-pack sensors (State of Charge, State, Temperature and Charge/Discharge Power). These require cell-data polling to be enabled and are disabled by default.
+- Venus: Add *PV Energy Today* and *PV Energy Total* sensors on models with PV inputs (Venus A/D).
 
 ### Changed
 

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -223,7 +223,7 @@ guesses based on context and cross-referencing other commands:
 | as | *(unconfirmed)* |
 | mppt | MPPT module version number *(unconfirmed)* |
 | pack | Battery pack summary `num\|mask\|idx\|?` — matches the `cd=42` BMS response (number of packs \| present-pack bitmask \| index) |
-| pv | Total PV power `value\|value` (0.1W) *(unconfirmed)* |
+| pv | PV energy (Wh), pipe-separated — first component is today's collected PV energy, the last component is the cumulative total (the total is likely but unconfirmed; reading it as the last component leaves room for monthly/yearly values to be added in between) |
 | fu | Surplus feed-in state `enabled\|?` — first component is `1` when surplus feed-in is enabled, `0` when disabled (see `cd=43`) |
 | em | *(unconfirmed)* |
 

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -43,6 +43,7 @@ import {
   average,
   negate,
   venusPvField,
+  pipeValue,
 } from '../transforms';
 
 /**
@@ -309,6 +310,44 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         state_class: 'measurement',
       }),
       { enabled: state => (state.totalPvPower != null ? true : undefined) },
+    );
+
+    // PV energy. The `pv` field holds pipe-separated values in Wh: today's
+    // collected PV energy first and the cumulative total last. The total is read
+    // from the last component so additional values (e.g. monthly/yearly) being
+    // inserted before it would not break the mapping.
+    field({
+      key: 'pv',
+      path: ['pvEnergyToday'],
+      transform: pipeValue(0),
+    });
+    advertise(
+      ['pvEnergyToday'],
+      sensorComponent<number>({
+        id: 'pv_energy_today',
+        name: 'PV Energy Today',
+        device_class: 'energy',
+        unit_of_measurement: 'Wh',
+        state_class: 'total_increasing',
+      }),
+      { enabled: state => (state.pvEnergyToday != null ? true : undefined) },
+    );
+
+    field({
+      key: 'pv',
+      path: ['pvEnergyTotal'],
+      transform: pipeValue(-1),
+    });
+    advertise(
+      ['pvEnergyTotal'],
+      sensorComponent<number>({
+        id: 'pv_energy_total',
+        name: 'PV Energy Total',
+        device_class: 'energy',
+        unit_of_measurement: 'Wh',
+        state_class: 'total_increasing',
+      }),
+      { enabled: state => (state.pvEnergyTotal != null ? true : undefined) },
     );
 
     // Power information
@@ -1025,7 +1064,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     field({
       key: 'fu',
       path: ['surplusFeedInEnabled'],
-      transform: value => value.split('|')[0] === '1',
+      transform: chain(pipeValue(0), equalsBoolean('1')),
     });
     advertise(
       ['surplusFeedInEnabled'],

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -337,6 +337,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: 'pv',
       path: ['pvEnergyTotal'],
       transform: pipeValue(-1),
+      monotonic: true,
     });
     advertise(
       ['pvEnergyTotal'],

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -747,6 +747,28 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('totalPvPower', 525);
   });
 
+  test('parses Venus PV energy from the pv field (today|total in Wh)', () => {
+    const message =
+      'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0,pv1=1076|1,pv=41|57';
+    const parsed = parseMessage(message, 'VNSA-0', 'venusA123');
+
+    const result = parsed['data'] as VenusDeviceData;
+    expect(result).toHaveProperty('pvEnergyToday', 41);
+    expect(result).toHaveProperty('pvEnergyTotal', 57);
+  });
+
+  test('reads Venus PV total from the last pv component (future-proofing)', () => {
+    // The total is read from the last component, so extra values inserted before
+    // it (e.g. monthly/yearly) do not break the mapping.
+    const message =
+      'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0,pv1=1076|1,pv=41|120|900|57';
+    const parsed = parseMessage(message, 'VNSA-0', 'venusA123');
+
+    const result = parsed['data'] as VenusDeviceData;
+    expect(result).toHaveProperty('pvEnergyToday', 41);
+    expect(result).toHaveProperty('pvEnergyTotal', 57);
+  });
+
   test('parses Venus metering, pricing and version fields', () => {
     // Full Venus D dump exercising the CT/phase/pricing/version sensors.
     const message =

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -20,6 +20,7 @@ import {
   timePeriodField,
   mpptPvField,
   venusPvField,
+  pipeValue,
   bitMaskToWeekday,
   sum,
   min,
@@ -394,6 +395,31 @@ describe('transforms', () => {
       );
       expect(transformToJinja2(venusPvField('connected'), 'value')).toBe(
         "{% set p = value.split('|') %}{% if p | length >= 2 %}{{ p[1] == '1' }}{% else %}false{% endif %}",
+      );
+    });
+  });
+
+  describe('pipeValue transform', () => {
+    it('should extract a numeric component by index', () => {
+      expect(executeTransform(pipeValue(0), '41|57')).toBe(41);
+      expect(executeTransform(pipeValue(1), '41|57')).toBe(57);
+    });
+
+    it('should support negative indices (from the end)', () => {
+      expect(executeTransform(pipeValue(-1), '41|57')).toBe(57);
+      expect(executeTransform(pipeValue(-1), '41|120|900|57')).toBe(57);
+    });
+
+    it('should return 0 for missing components', () => {
+      expect(executeTransform(pipeValue(5), '41|57')).toBe(0);
+    });
+
+    it('should generate correct Jinja2 templates', () => {
+      expect(transformToJinja2(pipeValue(0), 'value')).toBe(
+        "{% set parts = value.split('|') %}{{ parts[0] | int(0) }}",
+      );
+      expect(transformToJinja2(pipeValue(-1), 'value')).toBe(
+        "{% set parts = value.split('|') %}{{ parts[-1] | int(0) }}",
       );
     });
   });

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -46,6 +46,7 @@ export type Transform =
   | TimePeriodFieldTransform
   | MPPTPVFieldTransform
   | VenusPvFieldTransform
+  | PipeValueTransform
   | BitMaskToWeekdayTransform
   | ChainTransform;
 
@@ -177,6 +178,16 @@ export interface MPPTPVFieldTransform {
 export interface VenusPvFieldTransform {
   type: 'venusPvField';
   field: 'power' | 'connected';
+}
+
+/**
+ * Extract a single numeric component from a pipe-separated value (e.g.
+ * "today|total"). A negative index counts from the end, so `-1` selects the
+ * last component (robust against extra components being inserted before it).
+ */
+export interface PipeValueTransform {
+  type: 'pipeValue';
+  index: number;
 }
 
 /** Convert weekday bitmask to weekday set string */
@@ -331,6 +342,8 @@ export const mpptPvField = (field: MPPTPVFieldTransform['field']): MPPTPVFieldTr
 });
 
 /** Create a Venus PV input field transform */
+export const pipeValue = (index: number): PipeValueTransform => ({ type: 'pipeValue', index });
+
 export const venusPvField = (field: VenusPvFieldTransform['field']): VenusPvFieldTransform => ({
   type: 'venusPvField',
   field,
@@ -488,6 +501,12 @@ export function executeTransform(
 
     case 'venusPvField':
       return executeVenusPvField(value, transform.field);
+
+    case 'pipeValue': {
+      const parts = value.split('|');
+      const idx = transform.index < 0 ? parts.length + transform.index : transform.index;
+      return safeParseInt(parts[idx]);
+    }
 
     case 'bitMaskToWeekday': {
       const bitmask = parseInt(value, 10);
@@ -750,6 +769,10 @@ export function transformToJinja2(
 
     case 'venusPvField':
       return generateVenusPvFieldJinja2(valueExpr, transform.field);
+
+    case 'pipeValue':
+      // Negative indices use Python-style indexing in Jinja2 (parts[-1]).
+      return `{% set parts = ${valueExpr}.split('|') %}{{ parts[${transform.index}] | int(0) }}`;
 
     case 'bitMaskToWeekday':
       // Convert bitmask to weekday set string - only mutate inside loop, output once at end

--- a/src/types.ts
+++ b/src/types.ts
@@ -433,6 +433,8 @@ export interface VenusDeviceData extends BaseDeviceData {
   pv3Connected?: boolean;
   pv4Connected?: boolean;
   totalPvPower?: number;
+  pvEnergyToday?: number;
+  pvEnergyTotal?: number;
 
   // Grid information
   offGridPower?: number;


### PR DESCRIPTION
## What changed

- Add a declarative **`pipeValue(index)`** transform that extracts a numeric component from a pipe-separated value. A negative index counts from the end (`-1` = last component).
- Add **PV Energy Today** and **PV Energy Total** sensors for Venus models with PV inputs (Venus A/D), decoded from the `pv` field. Both are `energy` / `total_increasing` sensors (Energy Dashboard-compatible) and only advertised when the device reports the field.
- Convert the surplus feed-in (`fu`) parsing from a function transform to the declarative `chain(pipeValue(0), equalsBoolean('1'))`.

## Why

- The `pv` field carries PV energy totals (previously undocumented). The **total** is read from the **last** component (`pipeValue(-1)`) so that, if firmware later inserts monthly/yearly values before it, the mapping still resolves correctly.
- Function-based transforms must not be used for new fields (they can't be introspected for Jinja2 generation/serialization) — see the deprecation note in `deviceDefinition.ts`. The new `pipeValue` transform replaces the function transforms and is wired through `executeTransform` and `transformToJinja2`.

## Notes

- The "today" value is confirmed; the "total" interpretation is likely but not 100% confirmed — flagged as such in `docs/venus.md`.

## How it was validated

```
npm test -- --runInBand   # 369 passed
npm run build
npm run lint
```

Added unit tests for `pipeValue` (positive/negative indices, Jinja2 output) and parser tests decoding `pv=41|57` and `pv=41|120|900|57` (total from the last component).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Venus A/D models with PV inputs now expose new PV Energy Today and PV Energy Total sensors, providing detailed energy measurements in watt-hours for enhanced solar monitoring.

* **Documentation**
  * Updated Venus documentation to describe new PV energy sensor availability and clarify the PV field data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->