### PR TITLE
Venus: add detailed per-pack BMS cell sensors with dynamic cd=42 polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Venus: Add *Inverter Version* and *MPPT Version* sensors on devices that report them.
 - Venus: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP). Only the IP Address is enabled by default.
 - Venus: Add per-battery-pack sensors (State of Charge, State, Temperature and Charge/Discharge Power). These require cell-data polling to be enabled and are disabled by default.
+- Venus: Add detailed per-pack cell sensors (individual cell voltages, temperature sensors, min/max cell voltage, min/max/ambient/MOSFET temperature, pack voltage and state of charge) for additional battery packs, decoded from the `cd=42,bms_idx=N` response. Each pack is only polled when it is reported as present, so absent packs add no traffic. These require cell-data polling (`POLL_CELL_DATA`) to be enabled and are disabled by default.
 - Venus: Add *PV Energy Today* and *PV Energy Total* sensors on models with PV inputs (Venus A/D).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ services:
 | `MQTT_PASSWORD` | MQTT password | -                       |
 | `MQTT_POLLING_INTERVAL` | Interval between device polls in seconds | `60`                 |
 | `MQTT_RESPONSE_TIMEOUT` | Timeout for device responses in seconds | `15`                 |
-| `POLL_CELL_DATA` | Enable cell voltage (only available on B2500 devices) | false |
+| `POLL_CELL_DATA` | Enable cell-level battery data (individual cell voltages, temperatures and, on Venus, detailed per-pack BMS data) | false |
 | `POLL_EXTRA_BATTERY_DATA` | Enable extra battery data reporting (only available on B2500 devices) | false |
 | `POLL_CALIBRATION_DATA` | Enable calibration data reporting (only available on B2500 devices) | false |
 | `DEVICE_n` | Device configuration in format `{type}:{mac}` | -                       |

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -821,14 +821,17 @@ The `num`/`mask`/`idx` values match the `pack` field in the `cd=1` response.
 Requesting a specific index (`bms_idx=N`, `N >= 1`) returns detailed data for a
 single pack, including individual cell voltages and temperature sensors.
 
-`bms_idx=N` maps to **pack `N+1`**: `bms_idx=1` is the first *slave* pack (i.e.
-"Pack 2"). `bms_idx=0` returns a master/aggregate overview without per-cell data,
-and the master pack's individual cells are instead reported by the `cd=14`
-BMS-info response. A pack only returns data when its present-pack bit is set in
-the `mask` above (`bms_idx=N` ↔ bit `N`); absent indices report all zeros.
+The Venus unit is only a controller and has no battery of its own; all packs are
+identical. `bms_idx=0` returns a whole-system aggregate (no per-cell data; it
+reports system-wide fields such as `num`/`mask`). `bms_idx=N` (`N >= 1`) returns
+the per-cell detail for one pack and maps to **pack `N+1`**: `bms_idx=1` is the
+second pack ("Pack 2"). The first pack's individual cells are reported by the
+`cd=14` BMS-info response instead. A pack only returns data when its present-pack
+bit is set in the `mask` above (`bms_idx=N` ↔ bit `N`); absent indices report all
+zeros.
 
-A Venus A supports up to 5 battery packs and a Venus D up to 6. With the master
-at `bms_idx=0`, the slave packs therefore occupy `bms_idx=1..4` (Venus A) or
+A Venus A supports up to 5 battery packs and a Venus D up to 6. Since the first
+pack is read via `cd=14`, the remaining packs occupy `bms_idx=1..4` (Venus A) or
 `bms_idx=1..5` (Venus D).
 
 Payload:

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -816,6 +816,42 @@ cd=42, BMS: num=2,mask=3,idx=2,charge_pow=2643,discharge_pow=2643,soc1=424,state
 Fields are reported for up to 6 packs (`*1` … `*6`); unused packs report zeros.
 The `num`/`mask`/`idx` values match the `pack` field in the `cd=1` response.
 
+### 24.3 Per-pack detail (`bms_idx=N`)
+
+Requesting a specific index (`bms_idx=N`, `N >= 1`) returns detailed data for a
+single pack, including individual cell voltages and temperature sensors.
+
+`bms_idx=N` maps to **pack `N+1`**: `bms_idx=1` is the first *slave* pack (i.e.
+"Pack 2"). `bms_idx=0` returns a master/aggregate overview without per-cell data,
+and the master pack's individual cells are instead reported by the `cd=14`
+BMS-info response. A pack only returns data when its present-pack bit is set in
+the `mask` above (`bms_idx=N` ↔ bit `N`); absent indices report all zeros.
+
+Payload:
+```
+cd=42,bms_idx=1
+```
+
+Receive (real Venus D v147 response):
+```
+cd=42, BMS(1): num=2,vol=5327,cur=0,soc=708,c_vol=576,c_cur=500,d_cur=500,mos=0,ver=116,max_v=3331,min_v=3329,max_t=258,min_t=254,b_err1=0,b_err2=0,b_war1=0,b_vol=3330|3330|3330|3330|-|3330|3331|3329|3330|-|3329|3329|3329|3330|-|3329|3330|3329|3329,temp=258|257|254|255|256,env=314,mos=259
+```
+
+| Key | Description |
+|-----|-------------|
+| vol | Pack voltage (centivolts; `5327` = 53.27 V) |
+| soc | Pack state of charge (0.1%; `708` = 70.8%) |
+| ver | BMS firmware version |
+| max_v / min_v | Highest / lowest cell voltage (mV) |
+| max_t / min_t | Highest / lowest temperature (0.1 °C on Venus A/D) |
+| b_vol | Individual cell voltages (mV), pipe-separated; cells are grouped in fours separated by `-` |
+| temp | Temperature sensors (0.1 °C on Venus A/D), pipe-separated |
+| env | Ambient temperature (0.1 °C on Venus A/D) |
+| mos | MOSFET temperature (0.1 °C on Venus A/D) |
+
+Other observed keys (`cur`, `c_vol`, `c_cur`, `d_cur`, `b_err*`, `b_war*`) are
+not yet decoded.
+
 ## 25 Read power history
 
 Returns recent power-curve samples. Observed on Venus D v147.

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -827,6 +827,10 @@ and the master pack's individual cells are instead reported by the `cd=14`
 BMS-info response. A pack only returns data when its present-pack bit is set in
 the `mask` above (`bms_idx=N` ↔ bit `N`); absent indices report all zeros.
 
+A Venus A supports up to 5 battery packs and a Venus D up to 6. With the master
+at `bms_idx=0`, the slave packs therefore occupy `bms_idx=1..4` (Venus A) or
+`bms_idx=1..5` (Venus D).
+
 Payload:
 ```
 cd=42,bms_idx=1

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -145,8 +145,11 @@ function extractAdditionalDeviceInfo(state: VenusDeviceData) {
   };
 }
 
-// Max number of detailed slave packs polled via cd=42,bms_idx=N (packs 2..6 at
-// bms_idx 1..5; pack 1 = master, whose cells come from cd=14).
+// Max number of detailed slave packs polled via cd=42,bms_idx=N. A Venus A
+// supports up to 5 battery packs and a Venus D up to 6; pack 1 is the master
+// (bms_idx=0, cells via cd=14), so the slaves occupy bms_idx=1..5 at most. Packs
+// whose present-pack bit is unset are never polled, so this upper bound is safe
+// for both models.
 const MAX_BMS_PACK_DETAILS = 5;
 
 const requiredRuntimeInfoKeys = [

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -145,11 +145,12 @@ function extractAdditionalDeviceInfo(state: VenusDeviceData) {
   };
 }
 
-// Max number of detailed slave packs polled via cd=42,bms_idx=N. A Venus A
-// supports up to 5 battery packs and a Venus D up to 6; pack 1 is the master
-// (bms_idx=0, cells via cd=14), so the slaves occupy bms_idx=1..5 at most. Packs
-// whose present-pack bit is unset are never polled, so this upper bound is safe
-// for both models.
+// Max number of additional packs polled via cd=42,bms_idx=N. A Venus A supports
+// up to 5 battery packs and a Venus D up to 6 (the Venus unit is only a
+// controller and has no battery of its own; all packs are identical). The first
+// pack's cells are reported by cd=14, so the remaining packs occupy bms_idx=1..5
+// at most (bms_idx=N -> pack N+1). Packs whose present-pack bit is unset are
+// never polled, so this upper bound is safe for both models.
 const MAX_BMS_PACK_DETAILS = 5;
 
 const requiredRuntimeInfoKeys = [
@@ -2198,10 +2199,10 @@ function registerBMSPackMessage(
 
 // The cd=42,bms_idx=N response (N >= 1) carries detailed per-pack BMS data,
 // including individual cell voltages and temperature sensors. bms_idx=N maps to
-// pack N+1 (bms_idx=1 is the first slave pack, i.e. "Pack 2"); the master pack's
-// cells are reported via the cd=14 BMS-info message instead. Each pack is only
-// polled when its present-pack bit is set in the cd=42 summary's packMask, so no
-// requests are wasted on absent packs.
+// pack N+1 (bms_idx=1 is the second pack, i.e. "Pack 2"); the first pack's cells
+// are reported via the cd=14 BMS-info message, and bms_idx=0 is a whole-system
+// aggregate. Each pack is only polled when its present-pack bit is set in the
+// cd=42 summary's packMask, so no requests are wasted on absent packs.
 
 // The leading "BMS(N): num" token is tokenized by the parser into the key
 // " BMS(N): num"; combined with the pipe-separated b_vol array this uniquely

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -11,6 +11,7 @@ import {
   resolveMeterMac,
   VenusBMSInfo,
   VenusBMSPackInfo,
+  VenusBMSPackDetail,
   VenusDeviceData,
   VenusNetworkInfo,
   VenusTimePeriod,
@@ -44,6 +45,7 @@ import {
   negate,
   venusPvField,
   pipeValue,
+  pipeArray,
 } from '../transforms';
 
 /**
@@ -143,6 +145,10 @@ function extractAdditionalDeviceInfo(state: VenusDeviceData) {
   };
 }
 
+// Max number of detailed slave packs polled via cd=42,bms_idx=N (packs 2..6 at
+// bms_idx 1..5; pack 1 = master, whose cells come from cd=14).
+const MAX_BMS_PACK_DETAILS = 5;
+
 const requiredRuntimeInfoKeys = [
   'cel_p',
   'cel_c',
@@ -182,6 +188,7 @@ registerDeviceDefinition(
     registerRuntimeInfoMessage(message);
     registerBMSInfoMessage(message);
     registerBMSPackMessage(message);
+    registerBMSPackDetailMessages(message);
     registerNetworkInfoMessage(message);
   },
 );
@@ -196,6 +203,7 @@ registerDeviceDefinition(
     registerRuntimeInfoMessage(message);
     registerBMSInfoMessage(message, { scaleTemperatures: true });
     registerBMSPackMessage(message, { scaleTemperatures: true });
+    registerBMSPackDetailMessages(message, { scaleTemperatures: true });
     registerNetworkInfoMessage(message);
   },
 );
@@ -2179,6 +2187,124 @@ function registerBMSPackMessage(
             enabled_by_default: false,
           }),
           { enabled: packEnabled },
+        );
+      }
+    },
+  );
+}
+
+// The cd=42,bms_idx=N response (N >= 1) carries detailed per-pack BMS data,
+// including individual cell voltages and temperature sensors. bms_idx=N maps to
+// pack N+1 (bms_idx=1 is the first slave pack, i.e. "Pack 2"); the master pack's
+// cells are reported via the cd=14 BMS-info message instead. Each pack is only
+// polled when its present-pack bit is set in the cd=42 summary's packMask, so no
+// requests are wasted on absent packs.
+
+// The leading "BMS(N): num" token is tokenized by the parser into the key
+// " BMS(N): num"; combined with the pipe-separated b_vol array this uniquely
+// identifies a detailed per-pack response.
+function isVenusBmsPackDetailMessage(bmsIdx: number) {
+  const marker = ` BMS(${bmsIdx}): num`;
+  return (values: Record<string, string>): boolean => marker in values && 'b_vol' in values;
+}
+
+function registerBMSPackDetailMessages(
+  message: BuildMessageFn,
+  { scaleTemperatures = false }: { scaleTemperatures?: boolean } = {},
+) {
+  for (let bmsIdx = 1; bmsIdx <= MAX_BMS_PACK_DETAILS; bmsIdx++) {
+    registerBMSPackDetailMessage(message, bmsIdx, { scaleTemperatures });
+  }
+}
+
+function registerBMSPackDetailMessage(
+  message: BuildMessageFn,
+  bmsIdx: number,
+  { scaleTemperatures = false }: { scaleTemperatures?: boolean } = {},
+) {
+  const packNumber = bmsIdx + 1;
+  // Temperatures are reported in 0.1 units on Venus A/D, like the other messages.
+  const tempScalar = scaleTemperatures ? divide(10) : number();
+  const tempArray = scaleTemperatures ? pipeArray(10) : pipeArray();
+
+  message<VenusBMSPackDetail>(
+    {
+      refreshDataPayload: `cd=${CommandType.GET_BMS_PACK_INFO},bms_idx=${bmsIdx}`,
+      isMessage: isVenusBmsPackDetailMessage(bmsIdx),
+      publishPath: `bmsPack${bmsIdx}`,
+      defaultState: {},
+      getAdditionalDeviceInfo: () => ({}),
+      pollInterval: 60000,
+      controlsDeviceAvailability: false,
+      // Gated behind the same flag as the other detailed BMS data.
+      enabled: process.env.POLL_CELL_DATA === 'true',
+      // Only poll this pack when its present-pack bit is set in the summary's
+      // packMask (bms_idx=N -> pack N+1 -> bit N). Avoids polling absent packs.
+      shouldPoll: state => {
+        const mask = (state as VenusBMSPackInfo).packMask;
+        return mask != null && (mask & (1 << bmsIdx)) !== 0;
+      },
+    },
+    ({ field, advertise }) => {
+      // 16 individual cell voltages (mV). The wire format groups cells in fours
+      // separated by "-", e.g. "3330|3330|3330|3330|-|3330|...".
+      field({ key: 'b_vol', path: ['cellVoltages'], transform: pipeArray() });
+      for (let i = 0; i < 16; i++) {
+        advertise(
+          ['cellVoltages', i],
+          sensorComponent<number>({
+            id: `pack_${packNumber}_cell_voltage_${i + 1}`,
+            name: `Pack ${packNumber} Cell Voltage ${i + 1}`,
+            unit_of_measurement: 'mV',
+            device_class: 'voltage',
+            state_class: 'measurement',
+            enabled_by_default: false,
+          }),
+          { enabled: state => (state.cellVoltages?.[i] != null ? true : undefined) },
+        );
+      }
+
+      // Up to 5 temperature sensors (°C).
+      field({ key: 'temp', path: ['temperatures'], transform: tempArray });
+      for (let i = 0; i < 5; i++) {
+        advertise(
+          ['temperatures', i],
+          sensorComponent<number>({
+            id: `pack_${packNumber}_temperature_${i + 1}`,
+            name: `Pack ${packNumber} Temperature ${i + 1}`,
+            unit_of_measurement: '°C',
+            device_class: 'temperature',
+            state_class: 'measurement',
+            enabled_by_default: false,
+          }),
+          { enabled: state => (state.temperatures?.[i] != null ? true : undefined) },
+        );
+      }
+
+      const scalarFields = [
+        ['vol', 'voltage', 'Voltage', 'voltage', 'V', divide(100)],
+        ['soc', 'soc', 'State of Charge', 'battery', '%', divide(10)],
+        ['max_v', 'maxCellVoltage', 'Max Cell Voltage', 'voltage', 'mV', number()],
+        ['min_v', 'minCellVoltage', 'Min Cell Voltage', 'voltage', 'mV', number()],
+        ['max_t', 'maxTemperature', 'Max Temperature', 'temperature', '°C', tempScalar],
+        ['min_t', 'minTemperature', 'Min Temperature', 'temperature', '°C', tempScalar],
+        ['env', 'ambientTemperature', 'Ambient Temperature', 'temperature', '°C', tempScalar],
+        ['mos', 'mosfetTemperature', 'MOSFET Temperature', 'temperature', '°C', tempScalar],
+      ] as const;
+
+      for (const [key, destPath, label, deviceClass, unit, transform] of scalarFields) {
+        field({ key, path: [destPath], transform });
+        advertise(
+          [destPath],
+          sensorComponent<number>({
+            id: `pack_${packNumber}_${destPath.replace(/([A-Z])/g, '_$1').toLowerCase()}`,
+            name: `Pack ${packNumber} ${label}`,
+            device_class: deviceClass,
+            unit_of_measurement: unit,
+            state_class: 'measurement',
+            enabled_by_default: false,
+          }),
+          { enabled: state => (state[destPath] != null ? true : undefined) },
         );
       }
     },

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -113,6 +113,12 @@ export interface MessageDefinition<T extends BaseDeviceData> {
   pollInterval: number;
   controlsDeviceAvailability: boolean;
   enabled?: boolean;
+  /**
+   * Optional state-aware poll predicate. When provided, the message is only
+   * polled if this returns true for the current (merged) device state. Used to
+   * dynamically poll per-pack BMS details only for packs that are present.
+   */
+  shouldPoll?: (state: BaseDeviceData) => boolean;
 }
 
 export type BaseDeviceData = {
@@ -163,6 +169,7 @@ export type BuildMessageFn = <T extends BaseDeviceData>(
     pollInterval: number;
     controlsDeviceAvailability: boolean;
     enabled?: boolean;
+    shouldPoll?: (state: BaseDeviceData) => boolean;
   },
   args: BuildMessageDefinitionFn<T>,
 ) => void;

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -129,3 +129,98 @@ describe('MqttClient discovery re-publish', () => {
     expect(publishDiscoveryConfigs).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('MqttClient shouldPoll gating', () => {
+  const topics = {
+    deviceTopicOld: 'hame_energy/VNSD-0/device/venus1/ctrl',
+    deviceTopicNew: 'marstek_energy/VNSD-0/device/venus1/ctrl',
+    publishTopic: 'homeassistant/VNSD-0/device/venus1/data',
+    deviceControlTopicOld: 'hame_energy/VNSD-0/App/venus1/ctrl',
+    deviceControlTopicNew: 'marstek_energy/VNSD-0/App/venus1/ctrl',
+    controlSubscriptionTopic: 'homeassistant/VNSD-0/control/venus1/control',
+    availabilityTopic: 'homeassistant/VNSD-0/availability/venus1',
+  };
+
+  function makeMessage(overrides: any) {
+    return {
+      isMessage: () => true,
+      getAdditionalDeviceInfo: () => ({}),
+      pollInterval: 1000,
+      controlsDeviceAvailability: false,
+      enabled: true,
+      ...overrides,
+    };
+  }
+
+  function pollPayloads(packMask: number | undefined): string[] {
+    jest.useFakeTimers();
+    try {
+      const { getDeviceDefinition } = require('./deviceDefinition');
+      (getDeviceDefinition as jest.Mock).mockReturnValue({
+        messages: [
+          makeMessage({
+            refreshDataPayload: 'cd=1',
+            publishPath: 'data',
+            controlsDeviceAvailability: true,
+          }),
+          // bms_idx=1 -> pack 2 -> present iff mask bit 1 set
+          makeMessage({
+            refreshDataPayload: 'cd=42,bms_idx=1',
+            publishPath: 'bmsPack1',
+            shouldPoll: (state: any) =>
+              state?.packMask != null && (state.packMask & (1 << 1)) !== 0,
+          }),
+          // bms_idx=2 -> pack 3 -> present iff mask bit 2 set
+          makeMessage({
+            refreshDataPayload: 'cd=42,bms_idx=2',
+            publishPath: 'bmsPack2',
+            shouldPoll: (state: any) =>
+              state?.packMask != null && (state.packMask & (1 << 2)) !== 0,
+          }),
+        ],
+      });
+
+      const mqtt = require('mqtt');
+      const client = mqtt.connect();
+      client.publish.mockClear();
+
+      const device: Device = { deviceType: 'VNSD-0', deviceId: 'venus1' };
+      const deviceManager: any = {
+        getDeviceTopics: () => topics,
+        getDeviceState: () => (packMask != null ? { packMask } : undefined),
+        getDevices: () => [],
+        getResponseTimeout: () => 5000,
+        setResponseTimeout: jest.fn(),
+        clearResponseTimeout: jest.fn(),
+      };
+      const config: any = {
+        brokerUrl: 'mqtt://localhost:1883',
+        clientId: 'test-client',
+        topicPrefix: 'homeassistant',
+        autodiscoveryTopicPrefix: 'homeassistant',
+      };
+
+      const mqttClient = new MqttClient(config, deviceManager, jest.fn());
+      mqttClient.requestDeviceData(device);
+      jest.advanceTimersByTime(1000);
+
+      return client.publish.mock.calls.map((c: any[]) => c[1]);
+    } finally {
+      jest.useRealTimers();
+    }
+  }
+
+  test('polls only present packs (mask=3 -> pack 2 present, pack 3 absent)', () => {
+    const payloads = pollPayloads(3);
+    expect(payloads).toContain('cd=1');
+    expect(payloads).toContain('cd=42,bms_idx=1');
+    expect(payloads).not.toContain('cd=42,bms_idx=2');
+  });
+
+  test('polls no pack details until the pack mask is known', () => {
+    const payloads = pollPayloads(undefined);
+    expect(payloads).toContain('cd=1');
+    expect(payloads).not.toContain('cd=42,bms_idx=1');
+    expect(payloads).not.toContain('cd=42,bms_idx=2');
+  });
+});

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -343,11 +343,18 @@ export class MqttClient {
     const controlTopicNew = topics.deviceControlTopicNew;
     const availabilityTopic = topics.availabilityTopic;
 
+    // Merged device state, used to evaluate state-aware poll predicates
+    // (e.g. only polling per-pack BMS details for packs that are present).
+    const pollState = (this.deviceManager.getDeviceState(device) ?? {}) as BaseDeviceData;
+
     // Find the first message that needs to be refreshed
     let now = Date.now();
     let needsRefresh = false;
     let shouldStartTimeout = false;
     for (const [idx, message] of deviseDefinition.messages.entries()) {
+      if (message.shouldPoll && !message.shouldPoll(pollState)) {
+        continue;
+      }
       let lastRequestTimeKey = `${device.deviceId}:${idx}`;
       const lastRequestTime = this.lastRequestTime.get(lastRequestTimeKey);
       if (lastRequestTime == null || now > lastRequestTime + message.pollInterval) {
@@ -384,6 +391,11 @@ export class MqttClient {
     for (const [idx, message] of deviseDefinition.messages.entries()) {
       // Skip polling for disabled messages
       if (!message.enabled) {
+        continue;
+      }
+
+      // Skip messages whose state-aware poll predicate is not satisfied
+      if (message.shouldPoll && !message.shouldPoll(pollState)) {
         continue;
       }
 

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -6,6 +6,7 @@ import {
   JupiterDeviceData,
   VenusBMSInfo,
   VenusBMSPackInfo,
+  VenusBMSPackDetail,
   VenusDeviceData,
   VenusNetworkInfo,
 } from './types';
@@ -843,6 +844,47 @@ describe('MQTT Message Parser', () => {
     // SoC and temperature are reported in 0.1 units; VNSD scales temperatures by 10.
     expect(result.packs?.[0]).toEqual({ soc: 42.4, state: 0, temperature: 27.8 });
     expect(result.packs?.[1]).toEqual({ soc: 48.2, state: 2, temperature: 25.4 });
+  });
+
+  test('parses Venus cd=42 detailed per-pack BMS data (bms_idx=1)', () => {
+    // Real Venus D v147 response to cd=42,bms_idx=1 (the first slave pack, "Pack 2").
+    const message =
+      'cd=42, BMS(1): num=2,vol=5327,cur=0,soc=708,c_vol=576,c_cur=500,d_cur=500,mos=0,ver=116,max_v=3331,min_v=3329,max_t=258,min_t=254,b_err1=0,b_err2=0,b_war1=0,b_vol=3330|3330|3330|3330|-|3330|3331|3329|3330|-|3329|3329|3329|3330|-|3329|3330|3329|3329,temp=258|257|254|255|256,env=314,mos=259';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
+
+    expect(parsed).toHaveProperty('bmsPack1');
+    const result = parsed['bmsPack1'] as VenusBMSPackDetail;
+
+    // 16 cell voltages (mV), with the "-" group separators dropped.
+    expect(result.cellVoltages).toEqual([
+      3330, 3330, 3330, 3330, 3330, 3331, 3329, 3330, 3329, 3329, 3329, 3330, 3329, 3330, 3329,
+      3329,
+    ]);
+    // 5 temperature sensors (deci-degrees -> °C on VNSD).
+    expect(result.temperatures).toEqual([25.8, 25.7, 25.4, 25.5, 25.6]);
+    // Scalars: pack voltage (centivolts), SoC (deci-%), cell-voltage extremes (mV),
+    // temperature extremes / ambient / MOSFET (deci-degrees on VNSD).
+    expect(result.voltage).toBeCloseTo(53.27);
+    expect(result.soc).toBeCloseTo(70.8);
+    expect(result.maxCellVoltage).toBe(3331);
+    expect(result.minCellVoltage).toBe(3329);
+    expect(result.maxTemperature).toBeCloseTo(25.8);
+    expect(result.minTemperature).toBeCloseTo(25.4);
+    expect(result.ambientTemperature).toBeCloseTo(31.4);
+    // `mos` appears twice; the later MOSFET-temperature value wins (25.9 °C).
+    expect(result.mosfetTemperature).toBeCloseTo(25.9);
+  });
+
+  test('does not parse an absent Venus pack (bms_idx=2, all zeros) as another pack', () => {
+    // bms_idx=2 maps to "Pack 3"; on a two-pack device it reports all zeros.
+    const message =
+      'cd=42, BMS(2): num=2,vol=0,cur=0,soc=0,c_vol=0,c_cur=0,d_cur=0,mos=0,ver=0,max_v=0,min_v=0,max_t=0,min_t=0,b_err1=0,b_err2=0,b_war1=0,b_vol=0|0|0|0|-|0|0|0|0|-|0|0|0|0|-|0|0|0|0,temp=0|0|0|0|0,env=0,mos=0';
+    const parsed = parseMessage(message, 'VNSD-0', 'venusD123');
+
+    // The bms_idx=2 response only matches the bmsPack2 definition, not bmsPack1.
+    expect(parsed).toHaveProperty('bmsPack2');
+    expect(parsed).not.toHaveProperty('bmsPack1');
+    expect(parsed).not.toHaveProperty('bmsPacks');
   });
 
   test('parses Venus cd=26 network info (colon-delimited format)', () => {

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -21,6 +21,7 @@ import {
   mpptPvField,
   venusPvField,
   pipeValue,
+  pipeArray,
   bitMaskToWeekday,
   sum,
   min,
@@ -420,6 +421,43 @@ describe('transforms', () => {
       );
       expect(transformToJinja2(pipeValue(-1), 'value')).toBe(
         "{% set parts = value.split('|') %}{{ parts[-1] | int(0) }}",
+      );
+    });
+  });
+
+  describe('pipeArray transform', () => {
+    it('should parse a pipe-separated list into an array', () => {
+      expect(executeTransform(pipeArray(), '41|57|12')).toEqual([41, 57, 12]);
+    });
+
+    it('should drop "-" group separators (Venus cell voltages)', () => {
+      expect(
+        executeTransform(
+          pipeArray(),
+          '3330|3330|3330|3330|-|3330|3331|3329|3330|-|3329|3329|3329|3330|-|3329|3330|3329|3329',
+        ),
+      ).toEqual([
+        3330, 3330, 3330, 3330, 3330, 3331, 3329, 3330, 3329, 3329, 3329, 3330, 3329, 3330, 3329,
+        3329,
+      ]);
+    });
+
+    it('should scale each element by the divisor (deci-degrees)', () => {
+      expect(executeTransform(pipeArray(10), '258|257|254|255|256')).toEqual([
+        25.8, 25.7, 25.4, 25.5, 25.6,
+      ]);
+    });
+
+    it('should treat non-numeric elements as 0', () => {
+      expect(executeTransform(pipeArray(), '41|foo|12')).toEqual([41, 0, 12]);
+    });
+
+    it('should generate correct Jinja2 templates', () => {
+      expect(transformToJinja2(pipeArray(), 'value')).toBe(
+        "{{ value.split('|') | reject('equalto', '-') | reject('equalto', '') | map('float', 0) | list }}",
+      );
+      expect(transformToJinja2(pipeArray(10), 'value')).toBe(
+        "{{ value.split('|') | reject('equalto', '-') | reject('equalto', '') | map('float', 0) | map('multiply', 0.1) | list }}",
       );
     });
   });

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -47,6 +47,7 @@ export type Transform =
   | MPPTPVFieldTransform
   | VenusPvFieldTransform
   | PipeValueTransform
+  | PipeArrayTransform
   | BitMaskToWeekdayTransform
   | ChainTransform;
 
@@ -188,6 +189,17 @@ export interface VenusPvFieldTransform {
 export interface PipeValueTransform {
   type: 'pipeValue';
   index: number;
+}
+
+/**
+ * Parse a pipe-separated list of numbers into an array, dropping the "-" group
+ * separators. Used for the Venus cd=42 per-pack cell-voltage / temperature
+ * arrays, e.g. "3330|3330|3330|3330|-|3330|...". An optional divisor scales each
+ * element (e.g. deci-degrees to °C).
+ */
+export interface PipeArrayTransform {
+  type: 'pipeArray';
+  divisor?: number;
 }
 
 /** Convert weekday bitmask to weekday set string */
@@ -343,6 +355,12 @@ export const mpptPvField = (field: MPPTPVFieldTransform['field']): MPPTPVFieldTr
 
 /** Create a Venus PV input field transform */
 export const pipeValue = (index: number): PipeValueTransform => ({ type: 'pipeValue', index });
+
+/**
+ * Create a transform that parses a pipe-separated list of numbers into an array,
+ * dropping the "-" group separators. An optional divisor scales each element.
+ */
+export const pipeArray = (divisor?: number): PipeArrayTransform => ({ type: 'pipeArray', divisor });
 
 export const venusPvField = (field: VenusPvFieldTransform['field']): VenusPvFieldTransform => ({
   type: 'venusPvField',
@@ -506,6 +524,17 @@ export function executeTransform(
       const parts = value.split('|');
       const idx = transform.index < 0 ? parts.length + transform.index : transform.index;
       return safeParseInt(parts[idx]);
+    }
+
+    case 'pipeArray': {
+      const divisor = transform.divisor ?? 1;
+      return value
+        .split('|')
+        .filter(part => part !== '-' && part !== '')
+        .map(part => {
+          const num = parseFloat(part);
+          return Number.isNaN(num) ? 0 : num / divisor;
+        });
     }
 
     case 'bitMaskToWeekday': {
@@ -773,6 +802,14 @@ export function transformToJinja2(
     case 'pipeValue':
       // Negative indices use Python-style indexing in Jinja2 (parts[-1]).
       return `{% set parts = ${valueExpr}.split('|') %}{{ parts[${transform.index}] | int(0) }}`;
+
+    case 'pipeArray': {
+      // Split on "|", drop the "-" group separators, parse each element.
+      const base = `${valueExpr}.split('|') | reject('equalto', '-') | reject('equalto', '') | map('float', 0)`;
+      return transform.divisor != null
+        ? `{{ ${base} | map('multiply', ${1 / transform.divisor}) | list }}`
+        : `{{ ${base} | list }}`;
+    }
 
     case 'bitMaskToWeekday':
       // Convert bitmask to weekday set string - only mutate inside loop, output once at end

--- a/src/types.ts
+++ b/src/types.ts
@@ -533,6 +533,25 @@ export interface VenusBMSPackInfo extends BaseDeviceData {
 }
 
 /**
+ * Detailed per-pack BMS data reported by the cd=42,bms_idx=N response (N >= 1)
+ * on newer Venus firmware. Each present pack reports its individual cell
+ * voltages and temperature sensors.
+ */
+export interface VenusBMSPackDetail extends BaseDeviceData {
+  voltage?: number; // vol (pack voltage, V)
+  soc?: number; // soc (%)
+  version?: number; // ver
+  maxCellVoltage?: number; // max_v (mV)
+  minCellVoltage?: number; // min_v (mV)
+  maxTemperature?: number; // max_t (°C)
+  minTemperature?: number; // min_t (°C)
+  ambientTemperature?: number; // env (°C)
+  mosfetTemperature?: number; // mos (°C)
+  cellVoltages?: number[]; // b_vol (mV per cell)
+  temperatures?: number[]; // temp (°C per sensor)
+}
+
+/**
  * Network configuration reported by the cd=26 response on newer Venus firmware.
  */
 export interface VenusNetworkInfo extends BaseDeviceData {


### PR DESCRIPTION
## What changed

- Decode the **per-pack detail** response `cd=42,bms_idx=N` (`N >= 1`), which carries each additional battery pack's **individual cell voltages**, **temperature sensors**, **min/max cell voltage**, **min/max/ambient/MOSFET temperature**, **pack voltage** and **state of charge**. New sensors are exposed per pack (`Pack 2 …`), gated behind `POLL_CELL_DATA` and **disabled by default**.
- **Dynamic ("Route B") polling.** A new state-aware `shouldPoll?(state)` predicate on the message definition lets a message opt out of a poll cycle based on current device state. The per-pack detail messages only poll `cd=42,bms_idx=N` when pack `N`'s present-pack bit is set in the `cd=42` summary's `packMask`, so **absent packs add zero traffic** — no fixed pack-count cap needed.
- New declarative **`pipeArray(divisor?)`** transform that parses the pipe-separated cell-voltage / temperature arrays, dropping the `-` group separators, with optional deci-degree scaling. Wired through `executeTransform` and `transformToJinja2` (no function transforms).

## Why

Newer Venus firmware (observed on Venus D v147) reports detailed per-pack BMS data only via `cd=42,bms_idx=N`. The master pack's cells already come from `cd=14`; this adds the remaining (slave) packs. Polling is driven off the present-pack bitmask so multi-pack systems get full visibility without wasting requests on packs that aren't installed.

## Pack-index mapping (confirmed from real dumps)

`bms_idx=N` maps to **pack `N+1`**, present iff `mask` bit `N` is set:
- `bms_idx=1` → `soc=708` and `temp` avg `~256`, matching the summary's `soc2=708` / `temp2=256` → **Pack 2**.
- `bms_idx=0` is a master/aggregate overview (no per-cell data); the master pack's cells come from `cd=14`.
- `bms_idx=2`/`3` report all zeros on a two-pack device and are correctly skipped (their `mask` bits are unset).

Documented in `docs/venus.md §24.3`. Mapping observed on Venus D v147; behind an opt-in flag and disabled by default, so it is safe if other configurations differ.

## How it was validated

```
npm test -- --runInBand   # 378 passed
npm run build
npm run lint
```

Added tests: `pipeArray` (incl. `-` separators, scaling, Jinja2); parser decoding of the real `cd=42,bms_idx=1` dump and the all-zero `bms_idx=2` case; and `shouldPoll` poll-gating (`mask=3` polls Pack 2 but not Pack 3; nothing is polled until the mask is known).

Consistency: `POLL_CELL_DATA` description corrected in `README.md` (it already gated Venus cell data), `CHANGELOG.md` `[Next]` updated, docs extended.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZ94FH9XveNXKGL2ifmj8X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detailed per-battery-pack telemetry sensors (individual cell voltages, per-cell/per-pack temperatures, min/max metrics, ambient and MOSFET temperatures, plus pack voltage and state of charge).
  * Introduced state-aware polling that skips absent packs to reduce unnecessary device traffic (cell-level polling remains disabled by default via configuration).

* **Documentation**
  * Expanded Venus BMS documentation for per-pack `bms_idx` detail requests and responses.
  * Updated configuration guidance to describe cell-level battery data for Venus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->