### PR TITLE
Fix Venus PV energy values reported 10x too low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@
 
 - Venus & Jupiter: The *Recharge Mode* entity is now a settable select (Single Phase / Three Phase) instead of a read-only sensor, so the grid recharge mode can be switched from Home Assistant.
 
-### Fixed
-
-- Venus: *PV Energy Today* and *PV Energy Total* were reported a factor of 10 too low. The device reports these values in units of 10 Wh, so they are now scaled to Wh.
-
 ## [1.8.0] - 2026-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 - Venus & Jupiter: The *Recharge Mode* entity is now a settable select (Single Phase / Three Phase) instead of a read-only sensor, so the grid recharge mode can be switched from Home Assistant.
 
+### Fixed
+
+- Venus: *PV Energy Today* and *PV Energy Total* were reported a factor of 10 too low. The device reports these values in units of 10 Wh, so they are now scaled to Wh.
+
 ## [1.8.0] - 2026-06-13
 
 ### Added

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -324,14 +324,15 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       { enabled: state => (state.totalPvPower != null ? true : undefined) },
     );
 
-    // PV energy. The `pv` field holds pipe-separated values in Wh: today's
-    // collected PV energy first and the cumulative total last. The total is read
-    // from the last component so additional values (e.g. monthly/yearly) being
-    // inserted before it would not break the mapping.
+    // PV energy. The `pv` field holds pipe-separated values in units of 10 Wh:
+    // today's collected PV energy first and the cumulative total last. Each
+    // component is scaled by 10 to convert to Wh. The total is read from the
+    // last component so additional values (e.g. monthly/yearly) being inserted
+    // before it would not break the mapping.
     field({
       key: 'pv',
       path: ['pvEnergyToday'],
-      transform: pipeValue(0),
+      transform: chain(pipeValue(0), multiply(10)),
     });
     advertise(
       ['pvEnergyToday'],
@@ -348,7 +349,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     field({
       key: 'pv',
       path: ['pvEnergyTotal'],
-      transform: pipeValue(-1),
+      transform: chain(pipeValue(-1), multiply(10)),
       monotonic: true,
     });
     advertise(

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -748,14 +748,15 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('totalPvPower', 525);
   });
 
-  test('parses Venus PV energy from the pv field (today|total in Wh)', () => {
+  test('parses Venus PV energy from the pv field (today|total in 10 Wh units)', () => {
     const message =
       'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0,pv1=1076|1,pv=41|57';
     const parsed = parseMessage(message, 'VNSA-0', 'venusA123');
 
     const result = parsed['data'] as VenusDeviceData;
-    expect(result).toHaveProperty('pvEnergyToday', 41);
-    expect(result).toHaveProperty('pvEnergyTotal', 57);
+    // Raw values are in units of 10 Wh, so they are scaled to Wh.
+    expect(result).toHaveProperty('pvEnergyToday', 410);
+    expect(result).toHaveProperty('pvEnergyTotal', 570);
   });
 
   test('reads Venus PV total from the last pv component (future-proofing)', () => {
@@ -766,8 +767,9 @@ describe('MQTT Message Parser', () => {
     const parsed = parseMessage(message, 'VNSA-0', 'venusA123');
 
     const result = parsed['data'] as VenusDeviceData;
-    expect(result).toHaveProperty('pvEnergyToday', 41);
-    expect(result).toHaveProperty('pvEnergyTotal', 57);
+    // Raw values are in units of 10 Wh, so they are scaled to Wh.
+    expect(result).toHaveProperty('pvEnergyToday', 410);
+    expect(result).toHaveProperty('pvEnergyTotal', 570);
   });
 
   test('parses Venus metering, pricing and version fields', () => {


### PR DESCRIPTION
## Summary

Fixed a scaling bug in Venus device PV energy reporting where *PV Energy Today* and *PV Energy Total* were reported a factor of 10 too low.

## Changes

- **src/device/venus.ts**: Updated PV energy field transformations to scale raw values by 10, converting from device units (10 Wh) to Wh
  - `pvEnergyToday`: Added `multiply(10)` to the transform chain
  - `pvEnergyTotal`: Added `multiply(10)` to the transform chain
  - Updated comments to clarify that raw values are in units of 10 Wh

- **src/parser.test.ts**: Updated test expectations to reflect correct scaled values
  - Test case "parses Venus PV energy from the pv field": Updated expected values from 41/57 to 410/570 Wh
  - Test case "reads Venus PV total from the last pv component": Updated expected values from 41/57 to 410/570 Wh
  - Added clarifying comments about the 10 Wh unit scaling

- **CHANGELOG.md**: Added entry under "Fixed" section documenting the bug fix

## Validation

- Unit tests updated and passing to verify correct scaling behavior
- Changes are minimal and focused on the PV energy scaling issue only
- No configuration or add-on changes required

https://claude.ai/code/session_01TWpAmDHEBTLG8FmXHXTu7P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Venus PV Energy Today and PV Energy Total values which were previously reported 10× too low. These values are now correctly reported in Watt-hours (Wh).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->