### PR TITLE
Migrate from CommonJS to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage/
 .nyc_output/
 reports/
 .env
+.claude/

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,8 +1,16 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
+  extensionsToTreatAsEsm: ['.ts'],
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/.claude/'],
+  injectGlobals: true,
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true, isolatedModules: true }],
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   collectCoverage: true,
   coverageDirectory: 'coverage',
   collectCoverageFrom: [
@@ -17,10 +25,7 @@ module.exports = {
       outputName: 'junit.xml',
     }]
   ],
-  // Add a timeout to ensure tests don't hang
   testTimeout: 10000,
-  // Force exit after tests complete
   forceExit: true,
-  // Detect open handles (like timers, sockets) that might prevent Jest from exiting
   detectOpenHandles: true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hm2mqtt",
       "version": "1.8.0",
       "dependencies": {
-        "aedes": "^0.51.3",
+        "aedes": "^1.0.2",
         "dotenv": "^17.4.2",
         "mqtt": "^5.15.1",
         "pino": "^10.3.1",
@@ -2139,30 +2139,46 @@
       }
     },
     "node_modules/aedes": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/aedes/-/aedes-0.51.3.tgz",
-      "integrity": "sha512-aQfiI9w3RbqnowNCdcGMmCtxBFXN9bhJFcuZm24U5/NU06V3MCl42jWK2GUnu8rOypR2Ahi/aEcgq3w7CMcycg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/aedes/-/aedes-1.0.2.tgz",
+      "integrity": "sha512-yVb/7ZEcUAV3MqMkMHv5aOTnyeHDLDlkHo0tD1YnBoC3+rdUcMfILTvTl7i4Y7zTaujQD5TTznXdJFOBeaUlrA==",
       "license": "MIT",
       "dependencies": {
         "aedes-packet": "^3.0.0",
-        "aedes-persistence": "^9.1.2",
-        "end-of-stream": "^1.4.4",
+        "aedes-persistence": "^10.2.2",
+        "end-of-stream": "^1.4.5",
         "fastfall": "^1.5.1",
         "fastparallel": "^2.4.1",
         "fastseries": "^2.0.0",
-        "hyperid": "^3.2.0",
-        "mqemitter": "^6.0.0",
-        "mqtt-packet": "^9.0.0",
+        "hyperid": "^3.3.0",
+        "mqemitter": "^7.1.0",
+        "mqtt-packet": "^9.0.2",
         "retimer": "^4.0.0",
-        "reusify": "^1.0.4",
-        "uuid": "^10.0.0"
+        "reusify": "^1.1.0",
+        "uuid": "^11.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/aedes"
+      },
+      "peerDependencies": {
+        "aedes-persistence-level": "^9.1.2",
+        "aedes-persistence-mongodb": "^9.3.1",
+        "aedes-persistence-redis": "^11.2.1"
+      },
+      "peerDependenciesMeta": {
+        "aedes-persistence-level": {
+          "optional": true
+        },
+        "aedes-persistence-mongodb": {
+          "optional": true
+        },
+        "aedes-persistence-redis": {
+          "optional": true
+        }
       }
     },
     "node_modules/aedes-packet": {
@@ -2238,30 +2254,29 @@
       }
     },
     "node_modules/aedes-persistence": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/aedes-persistence/-/aedes-persistence-9.1.2.tgz",
-      "integrity": "sha512-2Wlr5pwIK0eQOkiTwb8ZF6C20s8UPUlnsJ4kXYePZ3JlQl0NbBA176mzM8wY294BJ5wybpNc9P5XEQxqadRNcQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/aedes-persistence/-/aedes-persistence-10.2.2.tgz",
+      "integrity": "sha512-lbiViUGXxOyUakU01xvD758LGOLJ8T7PzpT3q2q8enMSMFSigy0dYQc0b7bgHcz96AYJjEraQSfVpXH7L546TA==",
       "license": "MIT",
       "dependencies": {
         "aedes-packet": "^3.0.0",
-        "qlobber": "^7.0.0"
+        "qlobber": "^8.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/aedes/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/ansi-escapes": {
@@ -5196,25 +5211,16 @@
       }
     },
     "node_modules/mqemitter": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/mqemitter/-/mqemitter-6.0.2.tgz",
-      "integrity": "sha512-8RGlznQx/Nb1xC3xKUFXHWov7pn7JdH++YVwlr6SLT6k3ft1h+ImGqZdVudbdKruFckIq9wheq9s4hgCivJDow==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mqemitter/-/mqemitter-7.1.0.tgz",
+      "integrity": "sha512-GnBDNz3lxmllW201ne0mrmdy5tPOTnc79jjVcsfUa2LG2pUGeyGWVeiae6ZysfC/64XrYOqCKRAQYrB7pGyBVQ==",
       "license": "ISC",
       "dependencies": {
         "fastparallel": "^2.4.1",
         "qlobber": "^8.0.1"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/mqemitter/node_modules/qlobber": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/qlobber/-/qlobber-8.0.1.tgz",
-      "integrity": "sha512-O+Wd1chXj5YE1DwmD+ae0bXiSLehmnS3czlC1R9FL/Nt/3q8uMS1bIHmg2lJfCoiimCxClWM8AAuJrF0EvNiog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
+        "node": ">=20"
       }
     },
     "node_modules/mqtt": {
@@ -5790,12 +5796,12 @@
       "license": "MIT"
     },
     "node_modules/qlobber": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/qlobber/-/qlobber-7.0.1.tgz",
-      "integrity": "sha512-FsFg9lMuMEFNKmTO9nV7tlyPhx8BmskPPjH2akWycuYVTtWaVwhW5yCHLJQ6Q+3mvw5cFX2vMfW2l9z2SiYAbg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/qlobber/-/qlobber-8.0.1.tgz",
+      "integrity": "sha512-O+Wd1chXj5YE1DwmD+ae0bXiSLehmnS3czlC1R9FL/Nt/3q8uMS1bIHmg2lJfCoiimCxClWM8AAuJrF0EvNiog==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 16"
       }
     },
     "node_modules/quick-format-unescaped": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "prettier": "^3.8.4",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.1",
-        "tsx": "^4.22.4",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vite-node": "^6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -603,6 +603,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -620,6 +621,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -637,6 +639,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -654,6 +657,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -671,6 +675,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -688,6 +693,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -705,6 +711,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -722,6 +729,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -739,6 +747,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -756,6 +765,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -773,6 +783,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -790,6 +801,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -807,6 +819,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -824,6 +837,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -841,6 +855,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -858,6 +873,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -875,6 +891,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -892,6 +909,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -909,6 +927,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -926,6 +945,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -943,6 +963,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -960,6 +981,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -977,6 +999,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -994,6 +1017,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1011,6 +1035,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1028,6 +1053,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1993,6 +2019,16 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -2022,6 +2058,270 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -3006,6 +3306,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3278,6 +3588,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3363,6 +3683,13 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -3370,6 +3697,8 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5550,6 +5879,267 @@
         "node": ">=6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5812,6 +6402,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -5890,6 +6499,20 @@
       "dependencies": {
         "debug": "^4.3.1",
         "js-sdsl": "4.3.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -6061,6 +6684,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6175,6 +6805,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prettier": {
@@ -6394,6 +7053,40 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -6506,6 +7199,16 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -6748,6 +7451,54 @@
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6890,6 +7641,8 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -7076,6 +7829,120 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-6.0.0.tgz",
+      "integrity": "sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^7.0.0",
+        "es-module-lexer": "^2.0.0",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "vite": "^8.0.0"
+      },
+      "bin": {
+        "vite-node": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/antfu"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/walker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "prettier": "^3.8.4",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.1",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3"
       }
     },
@@ -587,6 +588,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2918,6 +3361,48 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -6398,6 +6883,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "jest-util": "^30.4.1",
         "prettier": "^3.8.4",
         "ts-jest": "^29.4.11",
-        "ts-node": "^10.9.1",
         "typescript": "^6.0.3",
         "vite-node": "^6.0.0"
       }
@@ -538,6 +537,8 @@
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -551,6 +552,8 @@
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2355,28 +2358,36 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -2861,6 +2872,8 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2874,6 +2887,8 @@
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -3083,7 +3098,9 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -3520,7 +3537,9 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3614,6 +3633,8 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -7591,6 +7612,8 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7814,7 +7837,9 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -8168,6 +8193,8 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts",
+    "dev": "tsx src/index.ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
@@ -34,6 +34,7 @@
     "prettier": "^3.8.4",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.1",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "lint": "prettier --check \"src/**/*.ts\"",
     "lint:fix": "prettier --write \"src/**/*.ts\"",
-    "bump-version": "ts-node bump-version.ts",
+    "bump-version": "vite-node bump-version.ts",
     "release": "./release.sh"
   },
   "dependencies": {
@@ -33,7 +33,6 @@
     "jest-util": "^30.4.1",
     "prettier": "^3.8.4",
     "ts-jest": "^29.4.11",
-    "ts-node": "^10.9.1",
     "typescript": "^6.0.3",
     "vite-node": "^6.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "hm2mqtt",
   "version": "1.8.0",
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "test:addon": "cd ha_addon && ./test_env.sh",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
@@ -18,7 +19,7 @@
     "release": "./release.sh"
   },
   "dependencies": {
-    "aedes": "^0.51.3",
+    "aedes": "^1.0.2",
     "dotenv": "^17.4.2",
     "mqtt": "^5.15.1",
     "pino": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsx src/index.ts",
+    "dev": "vite-node src/index.ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
@@ -34,7 +34,7 @@
     "prettier": "^3.8.4",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.1",
-    "tsx": "^4.22.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite-node": "^6.0.0"
   }
 }

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -1,14 +1,16 @@
-import logger from './logger';
-import { ControlHandler } from './controlHandler';
-import { DeviceManager, DeviceStateData } from './deviceManager';
+import { jest } from '@jest/globals';
+import './device/registry.js';
+import logger from './logger.js';
+import { ControlHandler } from './controlHandler.js';
+import { DeviceManager, DeviceStateData } from './deviceManager.js';
 import {
   MqttConfig,
   Device,
   B2500V2DeviceData,
   B2500BaseDeviceData,
   B2500V1DeviceData,
-} from './types';
-import { DEFAULT_TOPIC_PREFIX } from './constants';
+} from './types.js';
+import { DEFAULT_TOPIC_PREFIX } from './constants.js';
 
 describe('ControlHandler', () => {
   let controlHandler: ControlHandler;

--- a/src/controlHandler.ts
+++ b/src/controlHandler.ts
@@ -1,9 +1,9 @@
-import { Device } from './types';
-import { DeviceManager } from './deviceManager';
-import { getDeviceDefinition, HaStatefulAdvertiseBuilder, KeyPath } from './deviceDefinition';
-import { HaComponentConfig } from './homeAssistantDiscovery';
+import { Device } from './types.js';
+import { DeviceManager } from './deviceManager.js';
+import { getDeviceDefinition, HaStatefulAdvertiseBuilder, KeyPath } from './deviceDefinition.js';
+import { HaComponentConfig } from './homeAssistantDiscovery.js';
 
-import logger from './logger';
+import logger from './logger.js';
 type RecursiveReadonly<T> = {
   readonly [P in keyof T]: RecursiveReadonly<T[P]>;
 };

--- a/src/dataHandler.ts
+++ b/src/dataHandler.ts
@@ -1,8 +1,8 @@
-import { Device } from './types';
-import { DeviceManager } from './deviceManager';
-import { parseMessage } from './parser';
+import { Device } from './types.js';
+import { DeviceManager } from './deviceManager.js';
+import { parseMessage } from './parser.js';
 
-import logger from './logger';
+import logger from './logger.js';
 /**
  * Data Handler class
  */

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -2,16 +2,21 @@ import {
   AdditionalDeviceInfo,
   BuildMessageDefinitionArgs,
   BuildMessageFn,
-} from '../deviceDefinition';
-import logger from '../logger';
-import { B2500BaseDeviceData, B2500CalibrationData, B2500CellData, CommandParams } from '../types';
+} from '../deviceDefinition.js';
+import logger from '../logger.js';
+import {
+  B2500BaseDeviceData,
+  B2500CalibrationData,
+  B2500CellData,
+  CommandParams,
+} from '../types.js';
 import {
   binarySensorComponent,
   buttonComponent,
   numberComponent,
   sensorComponent,
   switchComponent,
-} from '../homeAssistantDiscovery';
+} from '../homeAssistantDiscovery.js';
 import {
   number,
   boolean,
@@ -24,7 +29,7 @@ import {
   diff,
   average,
   divide,
-} from '../transforms';
+} from '../transforms.js';
 
 export function extractAdditionalDeviceInfo(state: B2500BaseDeviceData): AdditionalDeviceInfo {
   let firmwareVersion: string | undefined;

--- a/src/device/b2500V1.ts
+++ b/src/device/b2500V1.ts
@@ -1,5 +1,9 @@
-import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
-import { B2500V1CD16Data, B2500V1DeviceData } from '../types';
+import {
+  BuildMessageFn,
+  globalPollInterval,
+  registerDeviceDefinition,
+} from '../deviceDefinition.js';
+import { B2500V1CD16Data, B2500V1DeviceData } from '../types.js';
 import {
   CommandType,
   extractAdditionalDeviceInfo,
@@ -8,15 +12,15 @@ import {
   registerBaseMessage,
   registerCalibrationDataMessage,
   registerCellDataMessage,
-} from './b2500Base';
-import logger from '../logger';
+} from './b2500Base.js';
+import logger from '../logger.js';
 import {
   numberComponent,
   selectComponent,
   sensorComponent,
   switchComponent,
-} from '../homeAssistantDiscovery';
-import { number, bitBoolean, map } from '../transforms';
+} from '../homeAssistantDiscovery.js';
+import { number, bitBoolean, map } from '../transforms.js';
 
 registerDeviceDefinition(
   {

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -1,4 +1,4 @@
-import { ControlHandlerDefinition } from '../controlHandler';
+import { ControlHandlerDefinition } from '../controlHandler.js';
 import {
   B2500V2CD16Data,
   B2500V2DeviceData,
@@ -9,8 +9,8 @@ import {
   normalizeMeterMac,
   resolveMeterMac,
   isValidMeterType,
-} from '../types';
-import logger from '../logger';
+} from '../types.js';
+import logger from '../logger.js';
 import {
   CommandType,
   extractAdditionalDeviceInfo,
@@ -19,8 +19,12 @@ import {
   registerBaseMessage,
   registerCalibrationDataMessage,
   registerCellDataMessage,
-} from './b2500Base';
-import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
+} from './b2500Base.js';
+import {
+  BuildMessageFn,
+  globalPollInterval,
+  registerDeviceDefinition,
+} from '../deviceDefinition.js';
 import {
   binarySensorComponent,
   buttonComponent,
@@ -29,8 +33,8 @@ import {
   sensorComponent,
   switchComponent,
   textComponent,
-} from '../homeAssistantDiscovery';
-import { number, boolean, map, timeString, equalsBoolean, divide } from '../transforms';
+} from '../homeAssistantDiscovery.js';
+import { number, boolean, map, timeString, equalsBoolean, divide } from '../transforms.js';
 
 /**
  * Create a time period handler for a specific setting

--- a/src/device/ct002.ts
+++ b/src/device/ct002.ts
@@ -1,7 +1,11 @@
-import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
-import { CT002DeviceData } from '../types';
-import { sensorComponent } from '../homeAssistantDiscovery';
-import { number, identity } from '../transforms';
+import {
+  BuildMessageFn,
+  globalPollInterval,
+  registerDeviceDefinition,
+} from '../deviceDefinition.js';
+import { CT002DeviceData } from '../types.js';
+import { sensorComponent } from '../homeAssistantDiscovery.js';
+import { number, identity } from '../transforms.js';
 
 const requiredRuntimeInfoKeys = ['pwr_a', 'pwr_b', 'pwr_c', 'pwr_t'];
 

--- a/src/device/helpers.test.ts
+++ b/src/device/helpers.test.ts
@@ -1,4 +1,4 @@
-import { transformTemperature } from './helpers';
+import { transformTemperature } from './helpers.js';
 
 describe('transformTemperature()', () => {
   it('should convert positive temperatures correctly', () => {

--- a/src/device/helpers.ts
+++ b/src/device/helpers.ts
@@ -2,7 +2,7 @@
  * Legacy transform functions.
  *
  * These functions are kept for backward compatibility with existing device definitions.
- * New code should prefer using declarative transforms from '../transforms' which can be
+ * New code should prefer using declarative transforms from '../transforms.js' which can be
  * introspected and converted to Jinja2 templates for Home Assistant discovery.
  *
  * @see ../transforms.ts for the declarative transform library
@@ -15,11 +15,11 @@ import {
   bitBoolean as bitBooleanTransform,
   temperature,
   timeString,
-} from '../transforms';
+} from '../transforms.js';
 
 /**
  * Transform a time string (e.g., "0:0" to "00:00")
- * @deprecated Use `timeString()` from '../transforms' for declarative transforms
+ * @deprecated Use `timeString()` from '../transforms.js' for declarative transforms
  */
 export const transformTimeString = (value: string): string => {
   return executeTransform(timeString(), value) as string;
@@ -27,20 +27,20 @@ export const transformTimeString = (value: string): string => {
 
 /**
  * Extract a specific bit as a boolean
- * @deprecated Use `bitBoolean(bit)` from '../transforms' for declarative transforms
+ * @deprecated Use `bitBoolean(bit)` from '../transforms.js' for declarative transforms
  */
 export const transformBitBoolean = (bit: number) => (value: string) =>
   executeTransform(bitBooleanTransform(bit), value) as boolean;
 
 /**
  * Extract bit 0 as a boolean
- * @deprecated Use `boolean()` from '../transforms' for declarative transforms
+ * @deprecated Use `boolean()` from '../transforms.js' for declarative transforms
  */
 export const transformBoolean = transformBitBoolean(0);
 
 /**
  * Parse string to number with NaN fallback to 0
- * @deprecated Use `number()` from '../transforms' for declarative transforms
+ * @deprecated Use `number()` from '../transforms.js' for declarative transforms
  */
 export const transformNumber = (value: string) => {
   return executeTransform(number(), value) as number;
@@ -53,7 +53,7 @@ export const transformNumber = (value: string) => {
  *
  * @param value - The temperature coming from MQTT
  * @returns The temperature in degrees Celsius
- * @deprecated Use `temperature()` from '../transforms' for declarative transforms
+ * @deprecated Use `temperature()` from '../transforms.js' for declarative transforms
  */
 export const transformTemperature = (value: string) => {
   return executeTransform(temperature(), value) as number;

--- a/src/device/hmiInverter.ts
+++ b/src/device/hmiInverter.ts
@@ -1,13 +1,17 @@
-import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
-import { CommandParams, HmiInverterDeviceData, isValidHmiInverterMode } from '../types';
+import {
+  BuildMessageFn,
+  globalPollInterval,
+  registerDeviceDefinition,
+} from '../deviceDefinition.js';
+import { CommandParams, HmiInverterDeviceData, isValidHmiInverterMode } from '../types.js';
 import {
   sensorComponent,
   binarySensorComponent,
   numberComponent,
   selectComponent,
   switchComponent,
-} from '../homeAssistantDiscovery';
-import { number, divide, identity, equalsBoolean, map } from '../transforms';
+} from '../homeAssistantDiscovery.js';
+import { number, divide, identity, equalsBoolean, map } from '../transforms.js';
 
 /**
  * Command types supported by the HMI inverter (Marstek HMI family)

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -3,7 +3,7 @@ import {
   globalPollInterval,
   KeyPath,
   registerDeviceDefinition,
-} from '../deviceDefinition';
+} from '../deviceDefinition.js';
 import {
   CommandParams,
   JupiterBatteryWorkingStatus,
@@ -19,8 +19,8 @@ import {
   resolveMeterMac,
   WeekdaySet,
   JupiterTimePeriod,
-} from '../types';
-import logger from '../logger';
+} from '../types.js';
+import logger from '../logger.js';
 import {
   sensorComponent,
   switchComponent,
@@ -28,7 +28,7 @@ import {
   selectComponent,
   textComponent,
   numberComponent,
-} from '../homeAssistantDiscovery';
+} from '../homeAssistantDiscovery.js';
 import {
   divide,
   map,
@@ -39,7 +39,7 @@ import {
   highByte,
   lowByte,
   diff,
-} from '../transforms';
+} from '../transforms.js';
 
 /**
  * Command types supported by the Jupiter device (subset of Venus)

--- a/src/device/registry.ts
+++ b/src/device/registry.ts
@@ -1,6 +1,6 @@
-import './b2500V1';
-import './b2500V2';
-import './venus';
-import './jupiter';
-import './ct002';
-import './hmiInverter';
+import './b2500V1.js';
+import './b2500V2.js';
+import './venus.js';
+import './jupiter.js';
+import './ct002.js';
+import './hmiInverter.js';

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1,4 +1,8 @@
-import { BuildMessageFn, globalPollInterval, registerDeviceDefinition } from '../deviceDefinition';
+import {
+  BuildMessageFn,
+  globalPollInterval,
+  registerDeviceDefinition,
+} from '../deviceDefinition.js';
 import {
   CommandParams,
   isValidMeterType,
@@ -16,8 +20,8 @@ import {
   VenusNetworkInfo,
   VenusTimePeriod,
   WeekdaySet,
-} from '../types';
-import logger from '../logger';
+} from '../types.js';
+import logger from '../logger.js';
 import {
   buttonComponent,
   numberComponent,
@@ -26,7 +30,7 @@ import {
   switchComponent,
   textComponent,
   binarySensorComponent,
-} from '../homeAssistantDiscovery';
+} from '../homeAssistantDiscovery.js';
 import {
   multiply,
   divide,
@@ -46,7 +50,7 @@ import {
   venusPvField,
   pipeValue,
   pipeArray,
-} from '../transforms';
+} from '../transforms.js';
 
 /**
  * Command types supported by the Venus device

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1,7 +1,9 @@
-import { ControlHandler } from './controlHandler';
-import { DeviceManager, DeviceStateData } from './deviceManager';
-import { MqttConfig, Device } from './types';
-import { DEFAULT_TOPIC_PREFIX } from './constants';
+import { jest } from '@jest/globals';
+import './device/registry.js';
+import { ControlHandler } from './controlHandler.js';
+import { DeviceManager, DeviceStateData } from './deviceManager.js';
+import { MqttConfig, Device } from './types.js';
+import { DEFAULT_TOPIC_PREFIX } from './constants.js';
 
 /**
  * Device command test case definition

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -1,9 +1,9 @@
-import { HaComponentConfig } from './homeAssistantDiscovery';
-import { ControlHandlerDefinition } from './controlHandler';
-import { HaAdvertisement } from './generateDiscoveryConfigs';
-import { Transform, MultiKeyTransform } from './transforms';
-import { levenshteinDistance } from './utils/stringDistance';
-import logger from './logger';
+import { HaComponentConfig } from './homeAssistantDiscovery.js';
+import { ControlHandlerDefinition } from './controlHandler.js';
+import { HaAdvertisement } from './generateDiscoveryConfigs.js';
+import { Transform, MultiKeyTransform } from './transforms.js';
+import { levenshteinDistance } from './utils/stringDistance.js';
+import logger from './logger.js';
 
 export const globalPollInterval = parseInt(process.env.MQTT_POLLING_INTERVAL || '60', 10) * 1000;
 
@@ -277,5 +277,3 @@ export function getSuggestedDeviceType(baseType: string): string | undefined {
 
   return bestDistance <= threshold ? bestMatch : undefined;
 }
-
-import './device/registry';

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -1,8 +1,10 @@
-import { DeviceManager } from './deviceManager';
-import { MqttConfig } from './types';
-import { DEFAULT_TOPIC_PREFIX } from './constants';
-import { calculateNewVersionTopicId } from './utils/crypt';
-import logger from './logger';
+import { jest } from '@jest/globals';
+import './device/registry.js';
+import { DeviceManager } from './deviceManager.js';
+import { MqttConfig } from './types.js';
+import { DEFAULT_TOPIC_PREFIX } from './constants.js';
+import { calculateNewVersionTopicId } from './utils/crypt.js';
+import logger from './logger.js';
 
 describe('DeviceManager', () => {
   const mockConfig: MqttConfig = {

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -1,13 +1,13 @@
-import { Device, MqttConfig } from './types';
+import { Device, MqttConfig } from './types.js';
 import {
   getDeviceDefinition,
   extractBaseType,
   getSuggestedDeviceType,
   FieldDefinition,
   KeyPath,
-} from './deviceDefinition';
-import { calculateNewVersionTopicId, decryptNewVersionTopicId } from './utils/crypt';
-import logger from './logger';
+} from './deviceDefinition.js';
+import { calculateNewVersionTopicId, decryptNewVersionTopicId } from './utils/crypt.js';
+import logger from './logger.js';
 
 /**
  * Number of confirming readings (beyond the first drop) required before a

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -1,8 +1,10 @@
-import { generateDiscoveryConfigs } from './generateDiscoveryConfigs';
-import { Device } from './types';
-import { DeviceTopics } from './deviceManager';
-import { AdditionalDeviceInfo } from './deviceDefinition';
-import { DEFAULT_TOPIC_PREFIX } from './constants';
+import { jest } from '@jest/globals';
+import './device/registry.js';
+import { generateDiscoveryConfigs, publishDiscoveryConfigs } from './generateDiscoveryConfigs.js';
+import { Device } from './types.js';
+import { DeviceTopics } from './deviceManager.js';
+import { AdditionalDeviceInfo } from './deviceDefinition.js';
+import { DEFAULT_TOPIC_PREFIX } from './constants.js';
 
 describe('Home Assistant Discovery', () => {
   test('should generate discovery configs for a device', () => {
@@ -254,9 +256,6 @@ describe('Home Assistant Discovery', () => {
       controlSubscriptionTopic,
       publishTopic,
     };
-
-    // Import the function
-    const { publishDiscoveryConfigs } = require('./generateDiscoveryConfigs');
 
     // Call the function with the mock client
     publishDiscoveryConfigs(

--- a/src/generateDiscoveryConfigs.ts
+++ b/src/generateDiscoveryConfigs.ts
@@ -1,15 +1,15 @@
-import { DeviceTopics } from './deviceManager';
-import { HaDiscoveryConfig } from './homeAssistantDiscovery';
+import { DeviceTopics } from './deviceManager.js';
+import { HaDiscoveryConfig } from './homeAssistantDiscovery.js';
 import { MqttClient } from 'mqtt';
-import logger from './logger';
+import logger from './logger.js';
 import {
   AdditionalDeviceInfo,
   getDeviceDefinition,
   HaStatefulAdvertiseBuilder,
   KeyPath,
   TypeAtPath,
-} from './deviceDefinition';
-import { Device } from './types';
+} from './deviceDefinition.js';
+import { Device } from './types.js';
 
 const MAC_REGEX = /^[0-9a-fA-F]{12}$/;
 

--- a/src/homeAssistantDiscovery.ts
+++ b/src/homeAssistantDiscovery.ts
@@ -1,5 +1,5 @@
-import { AdvertiseBuilderArgs, HaStatefulAdvertiseBuilder } from './deviceDefinition';
-import { HaNonStatefulComponentAdvertiseBuilder } from './controlHandler';
+import { AdvertiseBuilderArgs, HaStatefulAdvertiseBuilder } from './deviceDefinition.js';
+import { HaNonStatefulComponentAdvertiseBuilder } from './controlHandler.js';
 
 export interface HaBaseComponent {
   name: string;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
-import logger from './logger';
-import { DEFAULT_TOPIC_PREFIX } from './constants';
+import { jest } from '@jest/globals';
+import logger from './logger.js';
+import { DEFAULT_TOPIC_PREFIX } from './constants.js';
 
 beforeAll(() => {
   jest.clearAllMocks();
@@ -54,9 +55,9 @@ jest.mock('mqtt', () => {
 });
 
 // Make sure the mock is reset before each test
-beforeEach(() => {
+beforeEach(async () => {
   jest.clearAllMocks();
-  const mqttMock = require('mqtt');
+  const mqttMock = (await import('mqtt')) as any;
   mqttMock.connect.mockClear();
   mqttMock.__mockClient.on.mockClear();
   mqttMock.__mockClient.publish.mockClear();
@@ -92,12 +93,12 @@ describe('MQTT Client', () => {
     process.env.MQTT_TOPIC_PREFIX = DEFAULT_TOPIC_PREFIX;
   });
 
-  test('should initialize MQTT client with correct options', () => {
+  test('should initialize MQTT client with correct options', async () => {
     // Import the module to trigger the initialization code
-    require('./index');
+    await import('./index.js');
 
     // Get the mock mqtt module
-    const mqttMock = require('mqtt');
+    const mqttMock = (await import('mqtt')) as any;
 
     // Check that mqtt.connect was called with the right options
     expect(mqttMock.connect).toHaveBeenCalledWith(
@@ -111,10 +112,10 @@ describe('MQTT Client', () => {
     );
   });
 
-  test('should subscribe to device topics on connect', () => {
+  test('should subscribe to device topics on connect', async () => {
     // Import the module
-    require('./index');
-    const mqttMock = require('mqtt');
+    await import('./index.js');
+    const mqttMock = (await import('mqtt')) as any;
     const mockClient = mqttMock.__mockClient;
 
     // Trigger connect event
@@ -127,10 +128,10 @@ describe('MQTT Client', () => {
     );
   });
 
-  test('should handle device data messages', () => {
+  test('should handle device data messages', async () => {
     // Import the module
-    require('./index');
-    const mqttMock = require('mqtt');
+    await import('./index.js');
+    const mqttMock = (await import('mqtt')) as any;
     const mockClient = mqttMock.__mockClient;
 
     // Trigger connect event
@@ -170,10 +171,10 @@ describe('MQTT Client', () => {
     }
   });
 
-  test('should handle control topic messages', () => {
+  test('should handle control topic messages', async () => {
     // Import the module
-    require('./index');
-    const mockClient = require('mqtt').__mockClient;
+    await import('./index.js');
+    const mockClient = ((await import('mqtt')) as any).__mockClient;
 
     // Trigger connect event
     mockClient.triggerEvent('connect');
@@ -195,10 +196,10 @@ describe('MQTT Client', () => {
     );
   });
 
-  test('should handle time period settings correctly', () => {
+  test('should handle time period settings correctly', async () => {
     // Import the module
-    require('./index');
-    const mockClient = require('mqtt').__mockClient;
+    await import('./index.js');
+    const mockClient = ((await import('mqtt')) as any).__mockClient;
 
     // Trigger connect event to initialize
     mockClient.triggerEvent('connect');
@@ -243,12 +244,12 @@ describe('MQTT Client', () => {
     );
   });
 
-  test('should handle periodic polling', () => {
+  test('should handle periodic polling', async () => {
     jest.useFakeTimers();
 
     // Import the module
-    const indexModule = require('./index');
-    const mqttMock = require('mqtt');
+    await import('./index.js');
+    const mqttMock = (await import('mqtt')) as any;
     const mockClient = mqttMock.__mockClient;
 
     // Reset the publish mock to clear previous calls
@@ -276,7 +277,7 @@ describe('MQTT Client', () => {
   });
 });
 
-afterAll(() => {
+afterAll(async () => {
   // Clean up any timers or event listeners
   jest.useRealTimers();
   jest.restoreAllMocks();
@@ -289,11 +290,11 @@ afterAll(() => {
 
   // If there's an index module with a cleanup method, call it
   try {
-    const indexModule = require('./index');
-    if (indexModule && typeof indexModule.cleanup === 'function') {
-      indexModule.cleanup();
+    const indexModule = await import('./index.js');
+    if (indexModule && typeof (indexModule as any).cleanup === 'function') {
+      (indexModule as any).cleanup();
     }
   } catch (e) {
-    // Ignore errors if module can't be required
+    // Ignore errors if module can't be imported
   }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,15 @@ import * as dotenv from 'dotenv';
 // Load environment variables
 dotenv.config();
 
-import { Device, MqttConfig } from './types';
-import { DEFAULT_AUTODISCOVERY_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX } from './constants';
-import { DeviceManager, DeviceStateData } from './deviceManager';
-import { MqttClient } from './mqttClient';
-import { ControlHandler } from './controlHandler';
-import logger from './logger';
-import { DataHandler } from './dataHandler';
-import { MqttProxy, MqttProxyConfig } from './mqttProxy';
+import './device/registry.js';
+import { Device, MqttConfig } from './types.js';
+import { DEFAULT_AUTODISCOVERY_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX } from './constants.js';
+import { DeviceManager, DeviceStateData } from './deviceManager.js';
+import { MqttClient } from './mqttClient.js';
+import { ControlHandler } from './controlHandler.js';
+import logger from './logger.js';
+import { DataHandler } from './dataHandler.js';
+import { MqttProxy, MqttProxyConfig } from './mqttProxy.js';
 
 // MQTT Proxy configuration
 const MQTT_PROXY_ENABLED = process.env.MQTT_PROXY_ENABLED === 'true';
@@ -313,16 +314,6 @@ async function main() {
       await mqttClient.close();
       process.exit();
     });
-
-    // Export for testing
-    if (process.env.NODE_ENV === 'test') {
-      module.exports.__test__ = {
-        deviceManager,
-        mqttClient,
-        controlHandler,
-        dataHandler,
-      };
-    }
 
     logger.debug('Application initialized successfully');
   } catch (error) {

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,5 +1,5 @@
 import pino from 'pino';
-import { consoleStyleLogMethod } from './logger';
+import { consoleStyleLogMethod } from './logger.js';
 
 // pino v10's printf-placeholder-aware typings reject console.log-style calls
 // (a trailing object/string with no matching `%s`/`%d`). consoleStyleLogMethod

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -67,7 +67,7 @@ const logger: LooseLogger = pino({
   transport: {
     targets: [
       {
-        target: require.resolve('pino-pretty'),
+        target: 'pino-pretty',
         options: {
           colorize: false,
           translateTime: 'HH:MM:ss',

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -1,40 +1,47 @@
-import { MqttClient } from './mqttClient';
-import { Device } from './types';
+import { jest } from '@jest/globals';
+import './device/registry.js';
 
-jest.mock('mqtt', () => {
-  const mockClient = {
-    on: jest.fn(),
-    publish: jest.fn(),
-    subscribe: jest.fn(),
-    end: jest.fn(),
-  };
+const mockPublish = jest.fn();
+const mockOn = jest.fn();
+const mockSubscribe = jest.fn();
+const mockEnd = jest.fn();
+const mockClient = {
+  on: mockOn,
+  publish: mockPublish,
+  subscribe: mockSubscribe,
+  end: mockEnd,
+};
 
-  return {
-    connect: jest.fn(() => mockClient),
-  };
-});
-
-jest.mock('./generateDiscoveryConfigs', () => ({
-  publishDiscoveryConfigs: jest.fn(),
+jest.unstable_mockModule('mqtt', () => ({
+  connect: jest.fn(() => mockClient),
 }));
 
-jest.mock('./deviceDefinition', () => ({
-  getDeviceDefinition: jest.fn(() => ({
-    messages: [
-      {
-        refreshDataPayload: 'cd=1',
-        publishPath: 'data',
-        getAdditionalDeviceInfo: (state: any) => ({
-          firmwareVersion: state?.fw,
-        }),
-      },
-    ],
-  })),
+const mockPublishDiscoveryConfigs = jest.fn();
+jest.unstable_mockModule('./generateDiscoveryConfigs.js', () => ({
+  publishDiscoveryConfigs: mockPublishDiscoveryConfigs,
 }));
+
+const mockGetDeviceDefinition = jest.fn(() => ({
+  messages: [
+    {
+      refreshDataPayload: 'cd=1',
+      publishPath: 'data',
+      getAdditionalDeviceInfo: (state: any) => ({
+        firmwareVersion: state?.fw,
+      }),
+    },
+  ],
+}));
+jest.unstable_mockModule('./deviceDefinition.js', () => ({
+  getDeviceDefinition: mockGetDeviceDefinition,
+}));
+
+const { MqttClient } = await import('./mqttClient.js');
+import type { Device } from './types.js';
 
 describe('MqttClient discovery re-publish', () => {
   test('re-publishes discovery when additional device info changes after first data on same path (regression #235)', () => {
-    const { publishDiscoveryConfigs } = require('./generateDiscoveryConfigs');
+    mockPublishDiscoveryConfigs.mockClear();
 
     const device: Device = { deviceType: 'HMJ-2', deviceId: 'abc123' };
     const topics = {
@@ -71,10 +78,10 @@ describe('MqttClient discovery re-publish', () => {
     mqttClient.onDeviceDataReceived(device, 'data');
 
     // We expect discovery to be re-published again so newly enabled entities appear
-    expect(publishDiscoveryConfigs).toHaveBeenCalledTimes(2);
+    expect(mockPublishDiscoveryConfigs).toHaveBeenCalledTimes(2);
 
     // Verify the second publish carries firmware info
-    expect(publishDiscoveryConfigs).toHaveBeenNthCalledWith(
+    expect(mockPublishDiscoveryConfigs).toHaveBeenNthCalledWith(
       2,
       expect.anything(),
       device,
@@ -87,8 +94,7 @@ describe('MqttClient discovery re-publish', () => {
   });
 
   test('only publishes discovery after a cd=1 response, not on non-cd=1 paths', () => {
-    const { publishDiscoveryConfigs } = require('./generateDiscoveryConfigs');
-    publishDiscoveryConfigs.mockClear();
+    mockPublishDiscoveryConfigs.mockClear();
 
     const device: Device = { deviceType: 'HMJ-2', deviceId: 'abc123' };
     const topics = {
@@ -118,15 +124,15 @@ describe('MqttClient discovery re-publish', () => {
 
     // A response on a non-cd=1 path (e.g. BMS data) must not announce discovery
     mqttClient.onDeviceDataReceived(device, 'bms');
-    expect(publishDiscoveryConfigs).not.toHaveBeenCalled();
+    expect(mockPublishDiscoveryConfigs).not.toHaveBeenCalled();
 
     // The first cd=1 response unlocks discovery
     mqttClient.onDeviceDataReceived(device, 'data');
-    expect(publishDiscoveryConfigs).toHaveBeenCalledTimes(1);
+    expect(mockPublishDiscoveryConfigs).toHaveBeenCalledTimes(1);
 
     // The previously-seen non-cd=1 path still gets its normal first-data publish
     mqttClient.onDeviceDataReceived(device, 'bms');
-    expect(publishDiscoveryConfigs).toHaveBeenCalledTimes(2);
+    expect(mockPublishDiscoveryConfigs).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -155,8 +161,7 @@ describe('MqttClient shouldPoll gating', () => {
   function pollPayloads(packMask: number | undefined): string[] {
     jest.useFakeTimers();
     try {
-      const { getDeviceDefinition } = require('./deviceDefinition');
-      (getDeviceDefinition as jest.Mock).mockReturnValue({
+      mockGetDeviceDefinition.mockReturnValue({
         messages: [
           makeMessage({
             refreshDataPayload: 'cd=1',
@@ -178,11 +183,9 @@ describe('MqttClient shouldPoll gating', () => {
               state?.packMask != null && (state.packMask & (1 << 2)) !== 0,
           }),
         ],
-      });
+      } as any);
 
-      const mqtt = require('mqtt');
-      const client = mqtt.connect();
-      client.publish.mockClear();
+      mockPublish.mockClear();
 
       const device: Device = { deviceType: 'VNSD-0', deviceId: 'venus1' };
       const deviceManager: any = {
@@ -204,7 +207,7 @@ describe('MqttClient shouldPoll gating', () => {
       mqttClient.requestDeviceData(device);
       jest.advanceTimersByTime(1000);
 
-      return client.publish.mock.calls.map((c: any[]) => c[1]);
+      return mockPublish.mock.calls.map((c: any[]) => c[1]);
     } finally {
       jest.useRealTimers();
     }

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -1,9 +1,9 @@
 import * as mqtt from 'mqtt';
-import { Device, MqttConfig } from './types';
-import { DeviceManager } from './deviceManager';
-import { publishDiscoveryConfigs } from './generateDiscoveryConfigs';
-import { AdditionalDeviceInfo, BaseDeviceData, getDeviceDefinition } from './deviceDefinition';
-import logger from './logger';
+import { Device, MqttConfig } from './types.js';
+import { DeviceManager } from './deviceManager.js';
+import { publishDiscoveryConfigs } from './generateDiscoveryConfigs.js';
+import { AdditionalDeviceInfo, BaseDeviceData, getDeviceDefinition } from './deviceDefinition.js';
+import logger from './logger.js';
 
 export class MqttClient {
   private client: mqtt.MqttClient;

--- a/src/mqttProxy.test.ts
+++ b/src/mqttProxy.test.ts
@@ -1,0 +1,237 @@
+/**
+ * E2E integration tests for MqttProxy.
+ *
+ * Topology:
+ *
+ *   [main broker (Aedes)]  <-->  [MqttProxy]  <-->  [proxy client(s) (mqtt.js)]
+ *        port MAIN_PORT                port PROXY_PORT
+ *
+ * Tests verify:
+ *   1. Proxy starts and accepts connections
+ *   2. Client tracking (connect / disconnect)
+ *   3. Proxy client → main broker message forwarding
+ *   4. Main broker → proxy client message forwarding
+ *   5. Client ID conflict resolution renames duplicate IDs
+ *   6. Multiple clients with same original ID all forward data
+ *   7. Proxy stops cleanly
+ */
+
+import { Aedes } from 'aedes';
+import * as net from 'net';
+import * as mqtt from 'mqtt';
+import { MqttProxy } from './mqttProxy.js';
+
+const MAIN_PORT = 19801;
+const PROXY_PORT = 19802;
+
+const CTRL_TOPIC = 'hame_energy/HMA-1/App/test/ctrl';
+const DATA_TOPIC = 'hame_energy/HMA-1/device/test/ctrl';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function startMainBroker(): Promise<{ broker: Aedes; server: net.Server }> {
+  const broker = await Aedes.createBroker();
+  const server = net.createServer(broker.handle.bind(broker));
+  await new Promise<void>((resolve, reject) =>
+    server.listen(MAIN_PORT, (err?: Error) => (err ? reject(err) : resolve())),
+  );
+  return { broker, server };
+}
+
+async function stopMainBroker(broker: Aedes, server: net.Server): Promise<void> {
+  await new Promise<void>(resolve => broker.close(() => resolve()));
+  await new Promise<void>(resolve => server.close(() => resolve()));
+}
+
+function connectClient(port: number, clientId: string): Promise<mqtt.MqttClient> {
+  return new Promise((resolve, reject) => {
+    const client = mqtt.connect(`mqtt://localhost:${port}`, {
+      clientId,
+      clean: true,
+      reconnectPeriod: 0, // no auto-reconnect in tests
+    });
+    client.once('connect', () => resolve(client));
+    client.once('error', reject);
+  });
+}
+
+function disconnectClient(client: mqtt.MqttClient): Promise<void> {
+  return new Promise(resolve => client.end(true, {}, () => resolve()));
+}
+
+function subscribe(client: mqtt.MqttClient, topic: string): Promise<void> {
+  return new Promise((resolve, reject) =>
+    client.subscribe(topic, err => (err ? reject(err) : resolve())),
+  );
+}
+
+function waitForMessage(
+  client: mqtt.MqttClient,
+  topic: string,
+  timeoutMs = 3000,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Timeout waiting for message on "${topic}"`)),
+      timeoutMs,
+    );
+    client.on('message', (t: string, payload: Buffer) => {
+      if (t === topic) {
+        clearTimeout(timer);
+        resolve(payload.toString());
+      }
+    });
+  });
+}
+
+/** DeviceManager mock that exposes CTRL_TOPIC for subscription */
+const deviceManager: any = {
+  getDevices: () => [{ deviceType: 'HMA-1', deviceId: 'test' }],
+  getDeviceTopics: () => ({
+    deviceControlTopicOld: CTRL_TOPIC,
+    deviceControlTopicNew: CTRL_TOPIC,
+  }),
+};
+
+describe('MqttProxy E2E', () => {
+  let mainBroker: Aedes;
+  let mainServer: net.Server;
+  let proxy: MqttProxy;
+
+  beforeEach(async () => {
+    ({ broker: mainBroker, server: mainServer } = await startMainBroker());
+    proxy = new MqttProxy(
+      {
+        port: PROXY_PORT,
+        mainBrokerUrl: `mqtt://localhost:${MAIN_PORT}`,
+        proxyClientId: 'test-proxy',
+        autoResolveClientIdConflicts: true,
+      },
+      deviceManager,
+    );
+    await proxy.start();
+    await sleep(100); // let proxy connect to main broker
+  }, 10000);
+
+  afterEach(async () => {
+    if (proxy.isProxyRunning()) await proxy.stop();
+    await stopMainBroker(mainBroker, mainServer);
+  }, 10000);
+
+  test('proxy starts and reports running', () => {
+    expect(proxy.isProxyRunning()).toBe(true);
+  });
+
+  test('proxy client connects and is tracked', async () => {
+    const client = await connectClient(PROXY_PORT, 'device-1');
+    await sleep(100);
+
+    expect(proxy.getConnectedClientCount()).toBe(1);
+    expect(proxy.getConnectedClients()).toContain('device-1');
+
+    await disconnectClient(client);
+    await sleep(100);
+    expect(proxy.getConnectedClientCount()).toBe(0);
+  });
+
+  test('message from proxy client is forwarded to main broker', async () => {
+    const payload = 'pe=75,kn=500';
+
+    const mainClient = await connectClient(MAIN_PORT, 'main-subscriber');
+    await subscribe(mainClient, DATA_TOPIC);
+
+    const proxyClient = await connectClient(PROXY_PORT, 'device-1');
+    const received = waitForMessage(mainClient, DATA_TOPIC);
+    proxyClient.publish(DATA_TOPIC, payload);
+
+    expect(await received).toBe(payload);
+
+    await disconnectClient(proxyClient);
+    await disconnectClient(mainClient);
+  });
+
+  test('message from main broker is forwarded to proxy client', async () => {
+    const payload = 'cd=1';
+
+    const proxyClient = await connectClient(PROXY_PORT, 'device-1');
+    await subscribe(proxyClient, CTRL_TOPIC);
+    await sleep(100); // let subscription propagate
+
+    const mainClient = await connectClient(MAIN_PORT, 'main-publisher');
+    const received = waitForMessage(proxyClient, CTRL_TOPIC);
+    mainClient.publish(CTRL_TOPIC, payload);
+
+    expect(await received).toBe(payload);
+
+    await disconnectClient(proxyClient);
+    await disconnectClient(mainClient);
+  });
+
+  test('duplicate client IDs are renamed so both stay connected', async () => {
+    const client1 = await connectClient(PROXY_PORT, 'same-id');
+    await sleep(100);
+    expect(proxy.getConnectedClients()).toContain('same-id');
+
+    const client2 = await connectClient(PROXY_PORT, 'same-id');
+    await sleep(100);
+
+    const connected = proxy.getConnectedClients();
+    expect(connected).toHaveLength(2);
+
+    const renamed = connected.filter(id => id !== 'same-id');
+    expect(renamed).toHaveLength(1);
+    expect(renamed[0]).toMatch(/^same-id_/);
+
+    await disconnectClient(client1);
+    await disconnectClient(client2);
+  });
+
+  test('multiple clients with same ID all forward their data to main broker', async () => {
+    const mainClient = await connectClient(MAIN_PORT, 'main-subscriber');
+    await subscribe(mainClient, DATA_TOPIC);
+
+    // Connect three "devices" that all identify as the same client ID
+    const [c1, c2, c3] = await Promise.all([
+      connectClient(PROXY_PORT, 'b2500'),
+      connectClient(PROXY_PORT, 'b2500'),
+      connectClient(PROXY_PORT, 'b2500'),
+    ]);
+    await sleep(150);
+    expect(proxy.getConnectedClientCount()).toBe(3);
+
+    // Collect all messages arriving on the main broker
+    const received: string[] = [];
+    mainClient.on('message', (_t: string, payload: Buffer) => {
+      received.push(payload.toString());
+    });
+
+    c1.publish(DATA_TOPIC, 'from-c1');
+    c2.publish(DATA_TOPIC, 'from-c2');
+    c3.publish(DATA_TOPIC, 'from-c3');
+
+    // Give messages time to arrive
+    await sleep(300);
+
+    expect(received).toHaveLength(3);
+    expect(received).toContain('from-c1');
+    expect(received).toContain('from-c2');
+    expect(received).toContain('from-c3');
+
+    await disconnectClient(c1);
+    await disconnectClient(c2);
+    await disconnectClient(c3);
+    await disconnectClient(mainClient);
+  });
+
+  test('proxy stops cleanly', async () => {
+    const client = await connectClient(PROXY_PORT, 'device-1');
+    await sleep(100);
+
+    await proxy.stop();
+    expect(proxy.isProxyRunning()).toBe(false);
+
+    await disconnectClient(client);
+  });
+});

--- a/src/mqttProxy.test.ts
+++ b/src/mqttProxy.test.ts
@@ -67,11 +67,7 @@ function subscribe(client: mqtt.MqttClient, topic: string): Promise<void> {
   );
 }
 
-function waitForMessage(
-  client: mqtt.MqttClient,
-  topic: string,
-  timeoutMs = 3000,
-): Promise<string> {
+function waitForMessage(client: mqtt.MqttClient, topic: string, timeoutMs = 3000): Promise<string> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(
       () => reject(new Error(`Timeout waiting for message on "${topic}"`)),

--- a/src/mqttProxy.ts
+++ b/src/mqttProxy.ts
@@ -1,8 +1,8 @@
 import * as mqtt from 'mqtt';
-import Aedes from 'aedes';
+import { Aedes, Client as AedesClient, ConnectPacket } from 'aedes';
 import * as net from 'net';
-import { DeviceManager } from './deviceManager';
-import logger from './logger';
+import { DeviceManager } from './deviceManager.js';
+import logger from './logger.js';
 
 export interface MqttProxyConfig {
   /** Port for the proxy MQTT server */
@@ -28,8 +28,8 @@ export interface MqttProxyConfig {
  * 3. Forwards messages from proxy clients to the main broker
  */
 export class MqttProxy {
-  private aedesServer: Aedes;
-  private tcpServer: net.Server;
+  private aedesServer!: Aedes;
+  private tcpServer!: net.Server;
   private mainBrokerClient: mqtt.MqttClient;
   private isRunning: boolean = false;
   private connectedClients: Set<string> = new Set();
@@ -39,17 +39,22 @@ export class MqttProxy {
     private config: MqttProxyConfig,
     private deviceManager: DeviceManager,
   ) {
-    this.aedesServer = new Aedes({
-      // Handle client ID conflicts by ensuring unique client IDs
-      preConnect: (client, packet, callback) => {
+    this.mainBrokerClient = this.setupMainBrokerConnection();
+  }
+
+  private async initAedes(): Promise<void> {
+    this.aedesServer = await Aedes.createBroker({
+      preConnect: (
+        client: AedesClient,
+        packet: ConnectPacket,
+        callback: (error: Error | null, success: boolean) => void,
+      ) => {
         const originalClientId = packet.clientId || '';
 
-        // If auto-resolve is enabled and the client ID is already in use
         if (
           this.config.autoResolveClientIdConflicts !== false &&
           this.usedClientIds.has(originalClientId)
         ) {
-          // Generate unique client ID by appending timestamp and random suffix
           let uniqueId: string;
           let attempts = 0;
           const maxAttempts = 10;
@@ -73,13 +78,11 @@ export class MqttProxy {
           );
         }
 
-        // Add the client ID to our tracking set
         this.usedClientIds.add(packet.clientId);
         callback(null, true);
       },
     });
-    this.tcpServer = net.createServer(this.aedesServer.handle);
-    this.mainBrokerClient = this.setupMainBrokerConnection();
+    this.tcpServer = net.createServer(this.aedesServer.handle.bind(this.aedesServer));
     this.setupAedesEventHandlers();
   }
 
@@ -242,6 +245,8 @@ export class MqttProxy {
       logger.warn('MQTT Proxy is already running');
       return;
     }
+
+    await this.initAedes();
 
     return new Promise((resolve, reject) => {
       this.tcpServer.listen(this.config.port, (err?: Error) => {

--- a/src/mqttProxy.ts
+++ b/src/mqttProxy.ts
@@ -30,7 +30,7 @@ export interface MqttProxyConfig {
 export class MqttProxy {
   private aedesServer!: Aedes;
   private tcpServer!: net.Server;
-  private mainBrokerClient: mqtt.MqttClient;
+  private mainBrokerClient!: mqtt.MqttClient;
   private isRunning: boolean = false;
   private connectedClients: Set<string> = new Set();
   private usedClientIds: Set<string> = new Set();
@@ -38,9 +38,7 @@ export class MqttProxy {
   constructor(
     private config: MqttProxyConfig,
     private deviceManager: DeviceManager,
-  ) {
-    this.mainBrokerClient = this.setupMainBrokerConnection();
-  }
+  ) {}
 
   private async initAedes(): Promise<void> {
     this.aedesServer = await Aedes.createBroker({
@@ -247,6 +245,7 @@ export class MqttProxy {
     }
 
     await this.initAedes();
+    this.mainBrokerClient = this.setupMainBrokerConnection();
 
     return new Promise((resolve, reject) => {
       this.tcpServer.listen(this.config.port, (err?: Error) => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,4 +1,5 @@
-import { parseMessage } from './parser';
+import './device/registry.js';
+import { parseMessage } from './parser.js';
 import {
   B2500V2DeviceData,
   HmiInverterDeviceData,
@@ -9,7 +10,7 @@ import {
   VenusBMSPackDetail,
   VenusDeviceData,
   VenusNetworkInfo,
-} from './types';
+} from './types.js';
 
 describe('MQTT Message Parser', () => {
   test('should parse comma-separated key-value pairs correctly', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,20 +1,20 @@
-import { B2500V2DeviceData } from './types';
+import { B2500V2DeviceData } from './types.js';
 import {
   KeyPath,
   BaseDeviceData,
   getDeviceDefinition,
   FieldDefinition,
   TypeAtPath,
-} from './deviceDefinition';
-import { transformNumber } from './device/helpers';
-import logger from './logger';
+} from './deviceDefinition.js';
+import { transformNumber } from './device/helpers.js';
+import logger from './logger.js';
 import {
   Transform,
   MultiKeyTransform,
   isMultiKeyTransform,
   executeTransform,
   executeMultiKeyTransform,
-} from './transforms';
+} from './transforms.js';
 
 /**
  * Check if a transform spec is a declarative Transform object

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -38,7 +38,7 @@ import {
   isMultiKeyTransform,
   toTransformFunction,
   toMultiKeyTransformFunction,
-} from './transforms';
+} from './transforms.js';
 
 describe('transforms', () => {
   describe('number transform', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { BaseDeviceData } from './deviceDefinition';
+import { BaseDeviceData } from './deviceDefinition.js';
 
 type BatteryStatus = {
   // Host battery sign position (bit3:undervoltage, bit2:dod, bit1:charge, bit0:discharge)

--- a/src/utils/crypt.test.ts
+++ b/src/utils/crypt.test.ts
@@ -1,4 +1,4 @@
-import { calculateNewVersionTopicId, decryptNewVersionTopicId } from './crypt';
+import { calculateNewVersionTopicId, decryptNewVersionTopicId } from './crypt.js';
 
 describe('crypt', () => {
   it.each`

--- a/src/utils/stringDistance.test.ts
+++ b/src/utils/stringDistance.test.ts
@@ -1,4 +1,4 @@
-import { levenshteinDistance } from './stringDistance';
+import { levenshteinDistance } from './stringDistance.js';
 
 describe('levenshteinDistance', () => {
   it('should return 0 for identical strings', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## What changed

Migrates the entire codebase from CommonJS to native ESM (`"type": "module"`), and upgrades `aedes` to 1.0.2 (which is now pure ESM and requires an async `createBroker()` constructor).

### Key changes

- **`package.json`**: Added `"type": "module"`, bumped `aedes` to `^1.0.2`, updated test script to `NODE_OPTIONS=--experimental-vm-modules jest`
- **`tsconfig.json`**: Changed `module`/`moduleResolution` to `NodeNext`
- **`jest.config.js` → `jest.config.cjs`**: Renamed (CJS config file required when package is ESM); added `extensionsToTreatAsEsm`, `useESM` ts-jest transform, and `moduleNameMapper` to strip `.js` suffixes so Jest finds `.ts` source files
- **All `src/**/*.ts`**: Added `.js` extensions to every relative import (required by NodeNext resolution)
- **`src/logger.ts`**: Replaced `require.resolve('pino-pretty')` with a plain string (no `require` in ESM)
- **`src/mqttProxy.ts`**: Updated aedes 1.0 API — named import `{ Aedes }`, async `Aedes.createBroker()` init pattern
- **`src/index.ts`**: Moved device registry side-effect import here (from `deviceDefinition.ts`) to break an ESM circular-dependency TDZ; removed CJS-only `module.exports.__test__` block
- **Test files**: Added `import { jest } from '@jest/globals'` everywhere; added `import './device/registry.js'` to tests that need device definitions; converted `jest.mock()` to `jest.unstable_mockModule()` in `mqttClient.test.ts` for proper ESM interception

## Why

`aedes` 1.0.0 dropped its CommonJS build (pure ESM only). Rather than adding a CJS shim hack in `__mocks__/`, migrating the whole project to ESM is the correct long-term fix. It also unblocks future dependency upgrades that follow the ESM-only trend.

## How it was validated

```
npm test -- --runInBand   # 387 tests, all pass
npm run build             # tsc exits clean
npm run lint              # prettier reports no issues
```

---
_Generated by [Claude Code](https://claude.ai/code/session_011LA5ivNRg8AZh3XdvHvFoX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the project to ECMAScript Modules (ESM) by default, updating runtime and test execution to work smoothly in modern Node.js environments.
  * Updated Jest/TypeScript configuration and related test imports for ESM compatibility.
* **Dependencies**
  * Upgraded the embedded MQTT broker component to v1.0.2.
* **Refactor**
  * Improved MQTT proxy startup ordering by initializing asynchronously before the main forwarding/subscription workflow begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->