### PR TITLE
docs: Add Marstek Venus A/D and HMI micro inverters to supported devices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Device Model
       description: |
-        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter
+        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Venus A, Marstek Venus D, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter, Marstek HMI micro inverters (MI800, HMI-2000)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Device Model (optional)
       description: |
-        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter
+        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Venus A, Marstek Venus D, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter, Marstek HMI micro inverters (MI800, HMI-2000)
     validations:
       required: false
   - type: input

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -20,7 +20,7 @@ body:
     attributes:
       label: Device Model (optional)
       description: |
-        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter
+        Supported models: B2500 HMA/HMB/HMJ, Marstek Venus C, Marstek Venus E, Marstek Venus A, Marstek Venus D, Marstek Jupiter C, Marstek Jupiter E, Marstek Jupiter Plus, Marstek CT002 Smart Meter, Marstek HMI micro inverters (MI800, HMI-2000)
     validations:
       required: false
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Changed
 
 - Venus & Jupiter: The *Recharge Mode* entity is now a settable select (Single Phase / Three Phase) instead of a read-only sensor, so the grid recharge mode can be switched from Home Assistant.
-- Docs: List Marstek Venus A and Venus D (and the HMI micro inverters) in the supported device lists in the README and the GitHub issue templates.
+- Docs: List Marstek Venus A, Venus D, the HMF-X B2500 v2 device type, and the HMI micro inverters in the supported device lists in the README and the GitHub issue templates.
 
 ## [1.8.0] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changed
 
 - Venus & Jupiter: The *Recharge Mode* entity is now a settable select (Single Phase / Three Phase) instead of a read-only sensor, so the grid recharge mode can be switched from Home Assistant.
+- Docs: List Marstek Venus A and Venus D (and the HMI micro inverters) in the supported device lists in the README and the GitHub issue templates.
 
 ## [1.8.0] - 2026-06-13
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ hm2mqtt is a bridge application that connects Hame energy storage devices (like 
   - Second and third generation with timer support
 - Marstek Venus C
 - Marstek Venus E
+- Marstek Venus A
+- Marstek Venus D
 - Marstek Jupiter C
 - Marstek Jupiter E
 - Marstek Jupiter Plus
@@ -475,6 +477,7 @@ This is typically stale MQTT Discovery state in Home Assistant.
 The device type can be one of the following:
 - **HMB-X**: (e.g. HMB-1, HMB-2, ...) B2500 storage v1
 - **HMA-X**: (e.g. HMA-1, HMA-2, ...) B2500 storage v2
+- **HMF-X**: (e.g. HMF-1, ...) B2500 storage v2
 - **HMJ-X**: (e.g. HMJ-2, ...) B2500 storage v2
 - **HMK-X**: (e.g. HMK-1, HMK-2, ...) Greensolar storage v3
 - **HMG-X**: (e.g. HMG-50) Marstek Venus


### PR DESCRIPTION
## Summary
Updated documentation and GitHub issue templates to reflect support for additional Marstek device models and micro inverters that were previously missing from the supported device lists.

## Changes
- **README.md**: Added Marstek Venus A and Venus D to the supported devices list, and added HMF-X device type documentation (B2500 storage v2)
- **GitHub issue templates** (bug_report.yml, feature_request.yml, question.yml): Updated supported models list to include Venus A, Venus D, and Marstek HMI micro inverters (MI800, HMI-2000)
- **CHANGELOG.md**: Added entry documenting the documentation updates

## Notes
These are documentation-only changes reflecting devices that appear to already be supported by the codebase. No runtime code modifications were made.

https://claude.ai/code/session_01135x6hwmwa7VAmhnz9rG8v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded supported devices list in README to include Marstek Venus A, Marstek Venus D, and added the HMF-X (B2500 storage v2) device type.
  * Updated GitHub issue templates to show an expanded “Supported models” list for bug reports, feature requests, and questions.
  * Added a changelog entry in the “Next” section documenting the newly included supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->