### PR TITLE
docs: Restructure and expand B2500 MQTT protocol documentation

### DIFF
--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -720,6 +720,8 @@ The response contains multiple entries concatenated. `code=255` marks the end of
 
 The `data` field carries context-specific values (e.g. cell voltage in mV for over/under-voltage events, or Ah/Wh measurements for learning events).
 
+> **Note:** The descriptions below are reproduced verbatim from the device firmware's (machine-translated) error strings. Some read awkwardly as a result — e.g. code 92 "Operator 309 MOS" — and their precise intent is not always clear.
+
 ##### Error codes — V1 (HMB, firmware ≥ 138)
 
 | Code | Description | Typical data |

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -1,390 +1,596 @@
-Here's the markdown conversion of the document:
+# B2500 MQTT Protocol
 
-# Menu
+This document describes the MQTT protocol spoken by the Marstek/Hame B2500 battery system.
 
-1. [How to read the device information](#1-how-to-read-the-device-information)
-2. [Charging mode setting(Flash storage)](#2-charging-mode-settingflash-storage)
-3. [Discharge mode setting(Flash storage)](#3-discharge-mode-settingflash-storage)
-4. [Discharge depth setting(Flash storage)](#4-discharge-depth-settingflash-storage)
-5. [Start battery output threshold](#5-start-battery-output-threshold)
-6. [Timed and fixed power discharge settings(Flash storage)](#6-timed-and-fixed-power-discharge-settingsflash-storage)
-7. [Synchronization time setting](#7-synchronization-time-setting)
-8. [Time zone setting(Flash storage)](#8-time-zone-settingflash-storage)
-9. [Software restart](#9-software-restart)
-10. [Restore factory settings](#10-restore-factory-settings)
-11. [Charging mode setting(No flash storage)](#11-charging-mode-settingno-flash-storage)
-12. [Discharge mode setting(No flash storage)](#12-discharge-mode-settingno-flash-storage)
-13. [Discharge depth setting(No flash storage)](#13-discharge-depth-settingno-flash-storage)
-14. [Timed and fixed power discharge settings(No flash storage)](#14-timed-and-fixed-power-discharge-settingsno-flash-storage)
+## Device Variants
 
-## 1. How to read the device information
+| Model prefix | Generation | Notes |
+|---|---|---|
+| `HMB` | V1 | First generation. Separate output switches (OUT1/OUT2). |
+| `HMA`, `HMF`, `HMK`, `HMJ` | V2 | Second generation. Adaptive mode, time periods (up to 5), CT/smart-meter support, surplus feed-in. |
 
-### 1.1 Subscribe
+---
 
-**Topic:**
+## Raw Device Protocol
+
+The B2500 is unique among Marstek devices in that it supports connecting to a user-configured local MQTT broker in addition to the Marstek cloud broker. Other devices (Venus, Jupiter, etc.) only connect to the Marstek cloud.
+
+### Topic structure — custom/local broker
+
+When configured to use a custom broker, the B2500 always uses:
+
+| Direction | Topic |
+|---|---|
+| Device → App (status) | `hame_energy/{type}/device/{mac}/ctrl` |
+| App → Device (command) | `hame_energy/{type}/App/{mac}/ctrl` |
+
+`{type}` is the model prefix (e.g. `HMB`, `HMA`). `{mac}` is the device's plain MAC address.
+
+**Exception — firmware bug in 226.5 (HMA/HMF/HMK) and 108.7 (HMJ):** these versions accidentally used the cloud broker topic format even on a custom broker (see below), publishing to `marstek_energy/` with an encrypted device ID instead of the plain MAC. This bug was fixed in later firmware.
+
+### Topic structure — Marstek cloud broker
+
+Marstek runs two separate cloud broker infrastructures:
+
+**hame-2024** (older firmware):
+
+| Direction | Topic |
+|---|---|
+| Device → App (status) | `hame_energy/{type}/device/{uid}/ctrl` |
+| App → Device (command) | `hame_energy/{type}/App/{uid}/ctrl` |
+
+`{uid}` is a long unencrypted device identifier assigned by the cloud.
+
+**hame-2025** (firmware ≥ 226 for HMA/HMF/HMK, ≥ 108 for HMJ):
+
+| Direction | Topic |
+|---|---|
+| Device → App (status) | `marstek_energy/{type}/device/{deviceIdNew}/ctrl` |
+| App → Device (command) | `marstek_energy/{type}/App/{deviceIdNew}/ctrl` |
+
+`{deviceIdNew}` is computed differently depending on firmware version. Two schemes exist:
+
+**Scheme 1 — AES-128-CBC** (firmware 226 for HMA/HMF/HMK; firmware 108 for HMJ):
+
+The MAC address is AES-128-CBC encrypted (zero IV) using a broker-provisioned key, then hex-encoded. The key (`!@#$%^&*()_+{}[]`) is distributed with the hame-2025 broker certificate bundle. This is also the scheme that leaked onto the local broker in those exact firmware versions (the bug described above).
+
+**Scheme 2 — VID/salt-based `cq`** (firmware ≥ 230 for HMA/HMF/HMK; firmware ≥ 116 for HMJ):
+
+A more complex 24-character ID derived from a per-device salt (fetched from the Marstek cloud API), the MAC address, and a vendor ID (VID). The algorithm chains three steps:
+1. `HexUtil.textForRand(salt, vid_mac)` — RC4-like byte permutation
+2. `StreamUtil.e(vid+mac, sub_mac_vid)` — XOR stream cipher (LCG key stream)
+3. `CodeUtil.e(combined)[0:24]` — SHA-256 + custom base-62 encoding, truncated to 24 chars
+
+This scheme requires the cloud-issued salt and is not reproducible from the MAC alone.
+
+### Message encoding
+
+All messages (in both directions) are plain text with comma-separated `key=value` pairs:
+
 ```
-hame_energy/{type}/device/{uid or mac}/ctrl/#
-```
-
-**Payload:**
-```
-p1=0,p2=0,w1=0,w2=0,pe-99,vv=160,cs=1,cd=0,am=0,o1=1,02=1,do=2,1v=200,cj=1,kn=4412,g1=96,g2=99,b1=1,b2=0,md=0,d1=1,e1=0:0,f1=24:0,h1=200,d2=0,e2=0:0,2=0:0,h2=0,d3=0,e3=0:0f3=0:0,h3=0,sg=0,sp=100,st=0,t1=26,th=28,tc=0,t=0,c=202303012046
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| p1 | Solar input status 1 |
-| p2 | Solar input status 2 |
-| w1 | Solar 1 input power |
-| w2 | Solar 2 input power |
-| pe | Battery percentage |
-| vv | Device version number |
-| cs | Charging settings |
-| cd | Discharge settings |
-| am | AM |
-| o1 | Output State 1 |
-| o2 | Output State 2 |
-| do | dod discharge depth |
-| lv | Battery output threshold |
-| cj | Scene |
-| kn | Battery capacity |
-| g1 | Output power 1 |
-| g2 | Output power 2 |
-| b1 | Is power pack 1 connected |
-| b2 | Is power pack 2 connected |
-| md | Discharge setting mode |
-| d1 | Time1 enable status |
-| e1 | Time1 start time |
-| f1 | Time1 end time |
-| h1 | Time1 output value |
-| d2 | Time2 enable status |
-| e2 | Time2 start time |
-| f2 | Time2 end time |
-| h2 | Time2 output value |
-| d3 | Time3 enable status |
-| e3 | Time3 start time |
-| f3 | Time3 end time |
-| h3 | Time3 output value |
-| d4* | Time4 enable status |
-| e4* | Time4 start time |
-| f4* | Time4 end time |
-| h4* | Time4 output value |
-| d5* | Time5 enable status |
-| e5* | Time5 start time |
-| f5* | Time5 end time |
-| h5* | Time5 output value |
-| sg | Is the sensor connected |
-| sp | Automatic power size of the monitor |
-| st | The power transmitted by the monitor |
-| tl | Minimum temperature of battery cells |
-| th | Maximum temperature of battery cells |
-| tc | Charging temperature alarm |
-| tf | Discharge temperature alarm |
-| ts | Signal WiFi signal detection |
-| fc | Chip fc4 version number |
-| id** | Device ID |
-| a0** | Host battery capacity |
-| a1** | Extra 1 battery capacity |
-| a2** | Extra 2 battery capacity |
-| l0** | Host battery sign position (bit3:undervoltage,bit2:dod,bit1:charge,bit0:discharge) |
-| l1** | Extra 1 and extra 2 battery sign position |
-| bc*** | Daily total battery charging power |
-| bs*** | Daily total power of battery discharge |
-| pt*** | Daily total photovoltaic charging power |
-| it*** | Daily micro reverse output total power |
-| c0**** | The channel currently connected to CTCH |
-| c1**** | The current status of the host CT |
-| m0**** | The power collected by the first acquisition clip of CT001 |
-| m1**** | The power collected by the second acquisition clip of CT001 |
-| m2**** | The power collected by the third acquisition clip of CT001 |
-| m3**** | Micro Inverter current real-time power |
-| lmo1***** | Rated output power of device output channel 1 |
-| lmo2***** | Rated output power of device output channel 2 |
-| lmi1***** | Rated input power of device input channel 1 |
-| lmi2***** | Rated input power of device input channel 2 |
-| lmf***** | Is the device limited (including input and output restrictions) |
-
-_* 218.2 and later versions_  
-_** 212.17 and later versions_  
-_*** 218 and later versions_  
-_**** 218.2 and later versions_  
-_***** 220.1 and later versions_
-
-### 1.2 Public
-
-**Topic:**
-```
-hame_energy/{type}/App/{uid or mac}/ctrl
+key1=value1,key2=value2,key3=value3
 ```
 
-**Payload:**
+There is no JSON, no QoS guarantee, and no retained flag convention at the device level.
+
+---
+
+## Status Messages (Device → App)
+
+The device publishes different payloads depending on the request. Each response type is identified by the set of keys it contains.
+
+### Runtime info (`cd=01` request)
+
+Triggered by sending `cd=01` to the command topic. The device responds with the full runtime state.
+
+#### Example payload
+
+```
+p1=0,p2=0,w1=0,w2=0,pe=99,vv=160,cs=1,cd=0,am=0,o1=1,o2=1,do=2,lv=200,cj=1,kn=4412,
+g1=96,g2=99,b1=1,b2=0,md=0,d1=1,e1=0:0,f1=24:0,h1=200,d2=0,e2=0:0,f2=0:0,h2=0,
+d3=0,e3=0:0,f3=0:0,h3=0,sg=0,sp=100,st=0,tl=26,th=28,tc=0,tf=0,c0=0,c1=0,
+m0=0,m1=0,m2=0,m3=0,lmo=800,lmi=800,lmf=0
+```
+
+#### Field reference
+
+**Solar input**
+
+| Key | Description | Unit |
+|---|---|---|
+| `p1` | Input 1 status flags (bit 0 = charging, bit 1 = pass-through) | bitmask |
+| `p2` | Input 2 status flags (bit 0 = charging, bit 1 = pass-through) | bitmask |
+| `w1` | Input 1 power | W |
+| `w2` | Input 2 power | W |
+
+**Battery**
+
+| Key | Description | Unit |
+|---|---|---|
+| `pe` | State of charge (all packs combined) | % |
+| `kn` | Total battery capacity | Wh |
+| `do` | Discharge depth (DoD) setting | % |
+| `lv` | Battery output threshold (minimum load before output activates) | W |
+| `b1` | Extra battery pack 1 connected (`0`/`1`) | boolean |
+| `b2` | Extra battery pack 2 connected (`0`/`1`) | boolean |
+| `a0` ¹ | Host battery SoC | % |
+| `a1` ¹ | Extra battery 1 SoC | % |
+| `a2` ¹ | Extra battery 2 SoC | % |
+| `l0` ¹ | Host battery status flags (bit 0=discharging, bit 1=charging, bit 2=DoD reached, bit 3=undervoltage) | bitmask |
+| `l1` ¹ | Extra battery status flags (bits 0-3 = extra2, bits 4-7 = extra1; same bit layout as `l0`) | bitmask |
+
+**Output**
+
+| Key | Description | Unit |
+|---|---|---|
+| `o1` | Output 1 active (`0`/`1`) | boolean |
+| `o2` | Output 2 active (`0`/`1`) | boolean |
+| `g1` | Output 1 power | W |
+| `g2` | Output 2 power | W |
+| `cd` | Discharge mode (V1: bitmask bit 0=OUT1, bit 1=OUT2) | bitmask |
+
+**Device info**
+
+| Key | Description |
+|---|---|
+| `vv` | Firmware version (major) |
+| `sv` | Firmware subversion |
+| `fc` | FC4.2D chip version string |
+| `id` ¹ | Device ID number |
+| `uv` | Bootloader version |
+| `am` | Unknown |
+| `fktc` ³ | Unknown |
+| `ws` | Wi-Fi signal strength |
+| `tc_dis` | Surplus feed-in disabled (`0`=enabled, `1`=disabled) — V2 |
+| `sm` | Unknown |
+| `bn` | Unknown |
+
+**Temperature**
+
+| Key | Description | Unit |
+|---|---|---|
+| `tl` | Minimum cell temperature | °C |
+| `th` | Maximum cell temperature | °C |
+| `tc` | Charging temperature alarm (`0`/`1`) | boolean |
+| `tf` | Discharge temperature alarm (`0`/`1`) | boolean |
+
+**Scene / time-of-day**
+
+| Key | Description | Values |
+|---|---|---|
+| `cj` | Scene | `0`=day, `1`=night, `2`=dusk/dawn |
+
+**Charging/discharge mode (V2)**
+
+| Key | Description | Values |
+|---|---|---|
+| `cs` | Charging mode | `0`=simultaneous charge+discharge, `1`=charge then discharge |
+| `md` | Adaptive mode enabled (`0`/`1`) | boolean |
+
+**Time periods (V2, up to 5)**
+
+| Key | Description |
+|---|---|
+| `d1`–`d5` | Time period N enabled (`0`/`1`) |
+| `e1`–`e5` | Time period N start time (`H:M`, no leading zeros) |
+| `f1`–`f5` | Time period N end time (`H:M`, no leading zeros) |
+| `h1`–`h5` | Time period N output power (W, 0–800) |
+
+> **Note:** Periods 4 and 5 (`d4`/`e4`/`f4`/`h4`, `d5`/`e5`/`f5`/`h5`) require firmware ≥ 218.2.
+
+**Daily energy statistics (V2, firmware ≥ 218)**
+
+| Key | Description | Unit |
+|---|---|---|
+| `bc` | Daily battery charging energy | Wh |
+| `bs` | Daily battery discharge energy | Wh |
+| `pt` | Daily PV charging energy | Wh |
+| `it` | Daily micro-inverter output energy | Wh |
+
+**CT / smart meter (V2, firmware ≥ 218.2)**
+
+| Key | Description | Unit |
+|---|---|---|
+| `sg` | CT sensor connected (`0`/`1`) | boolean |
+| `sp` | CT automatic power target | W |
+| `st` | CT measured/transmitted power | W |
+| `c0` | CT connected phase (`0`=phase 1, `1`=phase 2, `2`=phase 3, `3`=searching, `255`=none) | |
+| `c1` | CT status (see table below) | |
+| `m0` | CT clip 1 measured power | W |
+| `m1` | CT clip 2 measured power | W |
+| `m2` | CT clip 3 measured power | W |
+| `m3` | Micro-inverter real-time power | W |
+
+CT status values (`c1`):
+
+| Value | Meaning |
+|---|---|
+| 5 | Preparing to diagnose CT001 (step 1) |
+| 6 | Preparing to diagnose CT001 (step 2) |
+| 7 | Diagnosing CT001 equipment |
+| 8 | Diagnosing CT001 channel |
+| 9 | Diagnosis timeout |
+| 10 | Charging in progress |
+| 11 | Unable to find channel |
+| other | Not in diagnosis |
+
+**Rated power (V2, firmware ≥ 220.1)**
+
+| Key | Description | Unit |
+|---|---|---|
+| `lmo` | Rated output power | W |
+| `lmi` | Rated input power | W |
+| `lmf` | Power currently limited (`0`/`1`) | boolean |
+
+¹ Available from firmware 212.17 and later.  
+³ Available from firmware 114.x and later.
+
+---
+
+### Cell voltage data (`cd=13` request)
+
+Triggered by sending `cd=13`. Returns individual cell voltages for all connected battery packs.
+
+**Field naming:** `{pack}{cell}` where pack is `a` (host), `b` (extra1), `c` (extra2) and cell is a hex digit.
+
+| Key pattern | Description | Unit |
+|---|---|---|
+| `a0`–`ad` | Host battery cell voltages (14 cells) | mV |
+| `b0`–`bd` | Extra battery 1 cell voltages (14 cells) | mV |
+| `c0`–`cd` | Extra battery 2 cell voltages (14 cells) | mV |
+
+---
+
+### Extra battery data (`cd=16` request)
+
+Triggered by sending `cd=16`. Returns detailed electrical measurements for inputs, outputs, and each battery pack.
+
+#### V1 payload
+
+| Key | Description | Unit |
+|---|---|---|
+| `m1`, `m2` | Input 1/2 voltage | V (raw) |
+| `w1`, `w2` | Input 1/2 power | W |
+| `g1`, `g2` | Output 1/2 power | W |
+
+#### V2 payload
+
+| Key | Description | Unit (raw) |
+|---|---|---|
+| `m1`, `m2` | Input 1/2 voltage | mV (÷1000 → V) |
+| `c1`, `c2` | Input 1/2 current | mA (÷1000 → A) |
+| `w1`, `w2` | Input 1/2 power | W |
+| `i1`, `i2` | Output 1/2 voltage | mV (÷1000 → V) |
+| `c3`, `c4` | Output 1/2 current | mA (÷1000 → A) |
+| `g1`, `g2` | Output 1/2 power | W |
+| `bb` | Host battery power | W |
+| `bv` | Host battery voltage | mV (÷1000 → V) |
+| `bc` | Host battery current | mA (÷1000 → A) |
+| `sb` | Extra battery 1 power | W |
+| `sv` | Extra battery 1 voltage | mV (÷1000 → V) |
+| `sc` | Extra battery 1 current | mA (÷1000 → A) |
+| `lb` | Extra battery 2 power | W |
+| `lv` | Extra battery 2 voltage | mV (÷1000 → V) |
+| `lc` | Extra battery 2 current | mA (÷1000 → A) |
+
+---
+
+### Split status part 1 (`cd=15` request)
+
+Triggered by sending `cd=15`. Returns the non-power subset of the runtime state — battery info, timer periods, temperatures, device info, and daily energy stats. Equivalent to the fields in `cd=01` that are not electrical measurements. Useful on firmware versions that split the full status across two responses (`cd=15` + `cd=16`) to stay within MQTT payload limits.
+
+---
+
+### Unknown data (`cd=14` request)
+
+Triggered by sending `cd=14`. Returns a set of fields whose meanings are mostly undocumented:
+
+| Key | Description |
+|---|---|
+| `ds` | Unknown |
+| `ps` | Unknown |
+| `ch` | Unknown |
+| `as` | Unknown |
+| `e0` | Unknown |
+| `e1` | Unknown |
+| `op` | Unknown |
+| `cp` | Unknown |
+| `cr` | Unknown |
+| `c0` | Unknown |
+| `c1` | Unknown |
+| `c2` | Unknown |
+| `g1` | Unknown |
+| `g2` | Unknown |
+
+---
+
+### Micro-inverter interface data (`cd=24` request)
+
+Triggered by sending `cd=24`. Returns information about the connected micro-inverter:
+
+| Key | Description |
+|---|---|
+| `id` | Micro-inverter code / identifier |
+| `s` | Start time |
+| `c` | Capacitor discharge time |
+| `i` | Compatibility mode |
+| `p` | Rated power |
+
+---
+
+### Calibration data (`cd=21` request)
+
+Triggered by sending `cd=21`. Returns two fields:
+
+| Key | Description | Unit |
+|---|---|---|
+| `cf` | Charge calibration value | mAh |
+| `df` | Discharge calibration value | mAh |
+
+---
+
+## Commands (App → Device)
+
+All commands are sent as a `key=value` string to the App command topic. The first field is always `cd=<code>`.
+
+### Flash vs. no-flash commands
+
+Some settings can be written to flash (persisted across reboots) or applied transiently (lost on reboot). Flash writes wear the flash memory; for frequently-changing values, prefer the no-flash variant.
+
+| Command | Flash `cd` | No-flash `cd` | Min firmware |
+|---|---|---|---|
+| Read device info | 1 | 1 | — |
+| Charging mode | 3 | 17 | 214.1 |
+| Discharge mode (V1) / Adaptive mode (V2) | 4 | 18 | 214.1 |
+| Discharge depth | 5 | 19 | 214.1 |
+| Timed discharge | 7 | 20 | 214.1 |
+| Battery output threshold | 6 | 6 | — |
+| Time zone | 9 | 9 | — |
+| Sync time | 8 | 8 | — |
+| Set CT phase | 22 | 22 | — |
+| Set smart meter type | 27 | 27 | — |
+| Surplus feed-in | 31 | 31 | 226 (HMJ: 108) |
+| Software restart | 10 | 10 | — |
+| Factory reset | 11 | 11 | — |
+| Set micro-inverter | 23 | 23 | — |
+| Query smart meter | 28 | 28 | — |
+| Multi-device mode | 29 | 29 | — |
+| Query error codes | 30 | 30 | — |
+| Query network info | 34 | 34 | — |
+
+---
+
+### Command payloads
+
+#### Read device info
+
 ```
 cd=01
 ```
 
-## 2. Charging mode setting(Flash storage)
+Triggers a full runtime info response.
 
-### 2.1 Public
+---
 
-**Topic:**
+#### Charging mode (V2)
+
 ```
-hame_energy/{type}/App/{uid or mac}/ctrl
-```
-
-**Payload:**
-1. `cd=03,md=0` - Charging and discharging simultaneously
-2. `cd=03,md=1` - Fully charged and then discharged
-
-*Note: It will be saved to flash*
-
-## 3. Discharge mode setting(Flash storage)
-
-### 3.1 Public
-
-**Topic:**
-```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=03,md=0    ← simultaneous charge + discharge (flash)
+cd=03,md=1    ← fully charge then discharge (flash)
+cd=17,md=0    ← same, no-flash
+cd=17,md=1
 ```
 
-**Payload:**
-1. `cd=04,md=0` - Disable OUT1&OUT2
-2. `cd=04,md=1` - Enable OUT1
-3. `cd=04,md=2` - Enable OUT2
-4. `cd=04,md=3` - Enable OUT1&OUT2
+#### Charging mode (V1)
 
-*Notes:*
-1. *Only suitable for B2500 first generation, product is HMB-*
-2. *It will be saved to flash*
-
-## 4. Discharge depth setting(Flash storage)
-
-### 4.1 Public
-
-**Topic:**
 ```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=03,md=0    ← PV2 pass-through
+cd=03,md=1    ← fully charge then discharge
 ```
 
-**Payload:**
+---
+
+#### Discharge mode / output control (V1 only)
+
+Controls which output ports are enabled. The `md` value is a bitmask: bit 0 = OUT1, bit 1 = OUT2.
+
 ```
-cd=05,md=0
-```
-md=0-100, For example, setting 95: cd=05, md=95
-
-*Note: It will be saved to flash*
-
-## 5. Start battery output threshold
-
-### 5.1 Public
-
-**Topic:**
-```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=04,md=0    ← both off (flash)
+cd=04,md=1    ← OUT1 only
+cd=04,md=2    ← OUT2 only
+cd=04,md=3    ← OUT1 + OUT2
+cd=18,md=...  ← same, no-flash
 ```
 
-**Payload:**
-```
-cd=06,md=0
-```
-md=0-500, For example, setting 300: cd=06, md=300
+---
 
-## 6. Timed and fixed power discharge settings(Flash storage)
+#### Adaptive mode (V2 only)
 
-### 6.1 Public
-
-**Topic:**
 ```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=04,md=1    ← enable adaptive mode (flash)
+cd=04,md=0    ← disable
+cd=18,md=...  ← same, no-flash
 ```
 
-**Payload:**
+---
 
-1. `cd=07,md=0` - Set discharge for three periods of time
-   - First time period:
-     ```
-     cd=07,md=0,a1=1,b1=0:30,e1=6:30,v1=260,a2=0,b2=12:30,e2=20:30,v2=123,a3=0,b3=12:30,e3=20:30,v3=123
-     ```
-   - Second time period:
-     ```
-     cd=07,md=0,a1=0,b1=0:30,e1=6:30,v1=260,a2=1,b2=12:30,e2=20:30,v2=340,a3=0,b3=12:30,e3=20:30,v3=123
-     ```
-   - Third time period:
-     ```
-     cd=07,md=0,a1=0,b1=0:30,e1=6:30,v1=260,a2=0,b2=12:30,e2=20:30,v2=123,a3=1,b3=21:30,e3=23:30,v3=250
-     ```
+#### Discharge depth
 
-2. `cd=07,md=1` - Automatically recognize based on the monitor
-
-| Parameter | Description |
-|-----------|-------------|
-| a1 | First time period energy state (0=off, 1=on) |
-| b1 | First time period start time |
-| e1 | First time period end time |
-| v1 | First time period output port value [80,800] |
-| a2 | Second time period energy state (0=off, 1=on) |
-| b2 | Second time period start time |
-| e2 | Second time period end time |
-| v2 | Second time period output port value [80,800] |
-| a3 | Third time period energy state (0=off, 1=on) |
-| b3 | Third time period start time |
-| e3 | Third time period end time |
-| v3 | Third time period output port value [80,800] |
-
-*Notes:*
-1. *Suitable for the second generation B2500, products are HMA -, HMF -, HMK-*
-2. *It will be saved to flash*
-
-## 7. Synchronization time setting
-
-### 7.1 Public
-
-**Topic:**
 ```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=05,md=80   ← set DoD to 80 % (flash)
+cd=19,md=80   ← same, no-flash
 ```
 
-**Payload:**
+Range: 0–100 (%).
+
+---
+
+#### Battery output threshold
+
 ```
-cd=08,wy=480,yy=123,mm=1,rr=2,hh=23,mn=56,ss=56
+cd=06,md=300
+```
+
+Range: 0–800 (W). The device only begins discharging when the load exceeds this value. No flash/no-flash distinction; always persisted.
+
+---
+
+#### Timed discharge (V2 only)
+
+Up to 5 time periods. Each period has: enable flag (`a`), start time (`b`), end time (`e`), output power (`v`).
+
+Time format: `H:M` without leading zeros (e.g. `0:30`, `8:1`, `21:30`).
+
+```
+cd=07,md=0,a1=1,b1=0:30,e1=6:30,v1=260,a2=0,b2=12:30,e2=20:30,v2=123,a3=0,b3=12:30,e3=20:30,v3=123
+```
+
+```
+cd=20,md=0,...    ← same, no-flash
+```
+
+`md=0` = fixed power periods. `md=1` = automatically track the smart meter (CT).
+
+Output power range: 0–800 W per period.
+
+---
+
+#### Sync time
+
+```
+cd=08,wy=60,yy=124,mm=0,rr=15,hh=10,mn=30,ss=0
 ```
 
 | Parameter | Description |
-|-----------|-------------|
-| wy | Time offset (local timezone offset in minutes) |
-| yy | Year (actual year minus 1900) |
-| mm | Month (0-11, 0=January) |
-| rr | Date (1-31) |
-| hh | Hour (0-23) |
-| mn | Minute (0-59) |
-| ss | Second (0-59) |
+|---|---|
+| `wy` | Timezone offset from UTC in minutes (e.g. `60` = UTC+1, `-300` = UTC-5) |
+| `yy` | Year minus 1900 (e.g. `124` for 2024) |
+| `mm` | Month, 0-indexed (0 = January, 11 = December) |
+| `rr` | Day of month (1–31) |
+| `hh` | Hour, UTC (0–23) |
+| `mn` | Minute (0–59) |
+| `ss` | Second (0–59) |
 
-## 8. Time zone setting(Flash storage)
+---
 
-### 8.1 Public
+#### Time zone (flash)
 
-**Topic:**
 ```
-hame_energy/{type}/App/{uid or mac}/ctrl
-```
-
-**Payload:**
-```
-cd=09,wy=480
+cd=09,wy=60
 ```
 
-*Note: It will be saved to flash*
+`wy` is the timezone offset in minutes. Written to flash.
 
-## 9. Software restart
+---
 
-### 9.1 Public
+#### Set CT connected phase (V2 only)
 
-**Topic:**
 ```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=22,md=0    ← phase 1
+cd=22,md=1    ← phase 2
+cd=22,md=2    ← phase 3
+cd=22,md=255  ← none / automatic
 ```
 
-**Payload:**
+---
+
+#### Set smart meter type (V2 only)
+
+```
+cd=27,meter=<code>,mac=<address>
+```
+
+Supported meter types and their command codes:
+
+| Meter type | `meter` code | MAC required |
+|---|---|---|
+| CT001 (built-in) | 0 | No (send `mac=0`) |
+| CT002 | 1 | Yes |
+| CT003 | 2 | Yes |
+| Shelly Pro 3EM | 3 | Yes |
+| Shelly EM Gen3 | 4 | Yes |
+| Shelly Pro EM-50 | 5 | Yes |
+
+MAC format: 12 hex digits, no separators (e.g. `AABBCCDDEEFF`).
+
+---
+
+#### Surplus feed-in (V2 only, firmware ≥ 226; HMJ: ≥ 108)
+
+Controls whether excess energy is fed back to the grid.
+
+```
+cd=31,touchuan_disa=0    ← enable surplus feed-in
+cd=31,touchuan_disa=1    ← disable
+```
+
+---
+
+#### Software restart
+
 ```
 cd=10
 ```
 
-## 10. Restore factory settings
+---
 
-### 10.1 Public
+#### Factory reset
 
-**Topic:**
-```
-hame_energy/{type}/App/{uid or mac}/ctrl
-```
-
-**Payload:**
 ```
 cd=11
 ```
 
-## 11. Charging mode setting(No flash storage)
+---
 
-### 11.1 Public
+#### Set micro-inverter (V2 only)
 
-**Topic:**
 ```
-hame_energy/{type}/App/{uid or mac}/ctrl
-```
-
-**Payload:**
-1. `cd=17,md=0` - Charging and discharging simultaneously
-2. `cd=17,md=1` - Fully charged and then discharged
-
-*Notes:*
-1. *Effective version: 214.1 and later versions*
-2. *Do not save to flash*
-
-## 12. Discharge mode setting(No flash storage)
-
-### 12.1 Public
-
-**Topic:**
-```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=23,...
 ```
 
-**Payload:**
-1. `cd=18,md=0` - Disable OUT1&OUT2
-2. `cd=18,md=1` - Enable OUT1
-3. `cd=18,md=2` - Enable OUT2
-4. `cd=18,md=3` - Enable OUT1&OUT2
+Parameters undocumented.
 
-*Notes:*
-1. *Only suitable for B2500 first generation, product is HMB-*
-2. *Effective version: 214.1 and later versions*
-3. *Do not save to flash*
+---
 
-## 13. Discharge depth setting(No flash storage)
+#### Query smart meter (V2 only)
 
-### 13.1 Public
-
-**Topic:**
 ```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=28
 ```
 
-**Payload:**
+Triggers a smart meter data response. Response format undocumented.
+
+---
+
+#### Multi-device mode (V2 only)
+
 ```
-cd=19,md=0
-```
-md=0-100, For example, setting 95: cd=05, md=95
-
-*Notes:*
-1. *Effective version: 214.1 and later versions*
-2. *Do not save to flash*
-
-## 14. Timed and fixed power discharge settings(No flash storage)
-
-### 14.1 Public
-
-**Topic:**
-```
-hame_energy/{type}/App/{uid or mac}/ctrl
+cd=29,single_mode=0,b2500_num=5001
 ```
 
-**Payload:**
-1. `cd=20,md=0` - Set discharge for three periods of time
-   - First time period:
-     ```
-     cd=20,md=0,a1=1,b1=0:30,e1=6:30,v1=260,a2=0,b2=12:30,e2=20:30,v2=123,a3=0,b3=12:30,e3=20:30,v3=123
-     ```
-   - Second time period:
-     ```
-     cd=20,md=0,a1=0,b1=0:30,e1=6:30,v1=260,a2=1,b2=12:30,e2=20:30,v2=340,a3=0,b3=12:30,e3=20:30,v3=123
-     ```
-   - Third time period:
-     ```
-     cd=20,md=0,a1=0,b1=0:30,e1=6:30,v1=260,a2=0,b2=12:30,e2=20:30,v2=123,a3=1,b3=21:30,e3=23:30,v3=250
-     ```
+| Parameter | Description |
+|---|---|
+| `single_mode` | `0` = multi-device, `1` = single device |
+| `b2500_num` | Device slot number (range 5000–5499) |
 
-2. `cd=20,md=1` - Automatically recognize based on the monitor
+Purpose and exact behaviour not fully documented.
 
-*Notes:*
-1. *The parameter settings are the same as cd=07*
-2. *Effective version: 214.1 and later versions*
-3. *Do not save to flash*
+---
+
+#### Query error codes
+
+```
+cd=30
+```
+
+Triggers an error code response. Response format not documented here; see device error code reference.
+
+---
+
+#### Query network info
+
+```
+cd=34
+```
+
+Triggers a network information response. Response format undocumented.

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -134,20 +134,20 @@ Marstek runs two separate cloud broker infrastructures:
 
 The MAC address is AES-128-CBC encrypted (zero IV) using a broker-provisioned key, then hex-encoded. The key (`!@#$%^&*()_+{}[]`) is distributed with the hame-2025 broker certificate bundle. This is also the scheme that leaked onto the local broker in those exact firmware versions (the bug described above).
 
-**Scheme 2 — VID/salt-based `cq`** (firmware ≥ 230 for HMA/HMF/HMK; firmware ≥ 116 for HMJ):
+**Scheme 2 — salt-based `cq`** (firmware ≥ 230 for HMA/HMF/HMK; firmware ≥ 116 for HMJ):
 
-A 24-character ID derived from a per-device salt (fetched from the Marstek cloud API), the MAC address, and a vendor ID (VID). This scheme requires the cloud-issued salt and is not reproducible from the MAC alone.
+A 24-character ID derived from a per-device salt (fetched from the Marstek cloud API), the MAC address, and the device type string (e.g. `HMA`, `HMF`). This scheme requires the cloud-issued salt and is not reproducible from the MAC alone.
 
-Given inputs `salt`, `mac`, `vid`, the algorithm is `cq(salt, mac, vid)`:
+Given inputs `salt`, `mac`, `type` (device type string), the algorithm is `cq(salt, mac, type)`:
 
 ```
-var1 = vid + "_" + mac[0..-5]        // vid + underscore + mac without last 4 chars
-var2 = mac[1..-3] + "_" + vid        // mac without first char and last 2 chars + underscore + vid
+var1 = type + "_" + mac[0..-5]        // type + underscore + mac without last 4 chars
+var2 = mac[1..-3] + "_" + type        // mac without first char and last 2 chars + underscore + type
 
-h1   = permute(salt, var1)           // RC4-KSA permutation of salt bytes, keyed by var1
-h2   = lcg_xor(vid + mac, var2)      // LCG stream cipher XOR of vid+mac, keyed by var2
+h1   = permute(salt, var1)            // RC4-KSA permutation of salt bytes, keyed by var1
+h2   = lcg_xor(type + mac, var2)      // LCG stream cipher XOR of type+mac, keyed by var2
 
-return sha256_encode(h1 + h2)[0:24]  // SHA-256, custom encoding, truncated to 24 chars
+return sha256_encode(h1 + h2)[0:24]   // SHA-256, custom encoding, truncated to 24 chars
 ```
 
 **Step 1 — `permute(content, key)`:**

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -177,8 +177,9 @@ return sha256_encode(h1 + h2)[0:24]   // SHA-256, custom encoding, truncated to 
 
 1. SHA-256 hash the input string (UTF-8)
 2. Interpret the 32-byte digest as 8 big-endian uint32 words
-3. Extract 12 bytes in column-major order: `bytes[i] = words[i % 8] >> ((i / 8) * 8) & 0xFF` for i in 0..11  
-   (bytes 3 of each word are discarded; 8 bytes of the hash are never used)
+3. Extract 12 bytes: `bytes[i] = words[i % 8] >> ((i / 8) * 8) & 0xFF` for i in 0..11  
+   Words 0–7 each contribute their LSB (byte 0); words 0–3 additionally contribute byte 1.  
+   Bytes 2–3 of words 0–3, and bytes 1–3 of words 4–7, are discarded — 20 of 32 hash bytes go unused.
 4. Encode each byte as 2 characters: `CHARSET[b % 62]` + `(b is odd ? 'V' : '0')`  
    where `CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"`
 5. Return the 24-character result
@@ -508,11 +509,15 @@ cd=03,md=0    ← PV2 pass-through
 cd=03,md=1    ← fully charge then discharge
 ```
 
+> **Warning:** `md=0` has different meanings on V1 vs V2. On V1 it enables PV2 pass-through; on V2 it enables simultaneous charge + discharge. `md=1` (charge then discharge) is the same on both generations.
+
 ---
 
 #### Discharge mode / output control (V1 only)
 
-Controls which output ports are enabled. The `md` value is a bitmask: bit 0 = OUT1, bit 1 = OUT2.
+> **Warning:** `cd=04` has completely different semantics on V1 vs V2. On V1 it controls output port enable/disable via a bitmask; on V2 it toggles adaptive mode with a boolean. Do not send V2-style values to a V1 device or vice versa.
+
+On V1, `md` is a bitmask: bit 0 = OUT1, bit 1 = OUT2.
 
 ```
 cd=04,md=0    ← both off (flash)
@@ -525,6 +530,8 @@ cd=18,md=...  ← same, no-flash
 ---
 
 #### Adaptive mode (V2 only)
+
+On V2, `md` is a boolean (0=disabled, 1=enabled). See warning above about `cd=04` command code reuse.
 
 ```
 cd=04,md=1    ← enable adaptive mode (flash)

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -137,7 +137,7 @@ The MAC address is AES-128-CBC encrypted (zero IV) using a broker-provisioned ke
 **Scheme 2 — VID/salt-based `cq`** (firmware ≥ 230 for HMA/HMF/HMK; firmware ≥ 116 for HMJ):
 
 A more complex 24-character ID derived from a per-device salt (fetched from the Marstek cloud API), the MAC address, and a vendor ID (VID). The algorithm chains three steps:
-1. `HexUtil.textForRand(salt, vid_mac)` — RC4-like byte permutation
+1. `HexUtil.textForRand(salt, vid_mac)` — key-derived byte permutation (reorders bytes by a permutation table built from the key; applied N times where N is derived from the input)
 2. `StreamUtil.e(vid+mac, sub_mac_vid)` — XOR stream cipher (LCG key stream)
 3. `CodeUtil.e(combined)[0:24]` — SHA-256 + custom base-62 encoding, truncated to 24 chars
 

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -136,12 +136,52 @@ The MAC address is AES-128-CBC encrypted (zero IV) using a broker-provisioned ke
 
 **Scheme 2 — VID/salt-based `cq`** (firmware ≥ 230 for HMA/HMF/HMK; firmware ≥ 116 for HMJ):
 
-A more complex 24-character ID derived from a per-device salt (fetched from the Marstek cloud API), the MAC address, and a vendor ID (VID). The algorithm chains three steps:
-1. `HexUtil.textForRand(salt, vid_mac)` — key-derived byte permutation (reorders bytes by a permutation table built from the key; applied N times where N is derived from the input)
-2. `StreamUtil.e(vid+mac, sub_mac_vid)` — XOR stream cipher (LCG key stream)
-3. `CodeUtil.e(combined)[0:24]` — SHA-256 + custom base-62 encoding, truncated to 24 chars
+A 24-character ID derived from a per-device salt (fetched from the Marstek cloud API), the MAC address, and a vendor ID (VID). This scheme requires the cloud-issued salt and is not reproducible from the MAC alone.
 
-This scheme requires the cloud-issued salt and is not reproducible from the MAC alone.
+Given inputs `salt`, `mac`, `vid`, the algorithm is `cq(salt, mac, vid)`:
+
+```
+var1 = vid + "_" + mac[0..-5]        // vid + underscore + mac without last 4 chars
+var2 = mac[1..-3] + "_" + vid        // mac without first char and last 2 chars + underscore + vid
+
+h1   = permute(salt, var1)           // RC4-KSA permutation of salt bytes, keyed by var1
+h2   = lcg_xor(vid + mac, var2)      // LCG stream cipher XOR of vid+mac, keyed by var2
+
+return sha256_encode(h1 + h2)[0:24]  // SHA-256, custom encoding, truncated to 24 chars
+```
+
+**Step 1 — `permute(content, key)`:**
+
+1. Hex-encode `content` as UTF-8 bytes → `hexContent`
+2. `N = (last byte of hexContent) % 5`, or 1 if zero
+3. Build a permutation array of size `len(hexContent_bytes)` using RC4's KSA:
+   ```
+   p = [0, 1, ..., n-1]
+   j = 0
+   for i in 0..n-1:
+     j = (j + p[i] + keyBytes[i % keyLen]) % n
+     swap(p[i], p[j])
+   ```
+4. Apply `result[i] = data[p[i]]` to reorder the bytes
+5. Repeat steps 3–4 N times total
+6. Return as hex string
+
+**Step 2 — `lcg_xor(data, key)`:**
+
+1. Seed an LCG from `key`: `seed = 0; for each byte b in key: seed = (seed * 31 + b) % 2147483647`
+2. Generate keystream: `state = seed; for each output byte: state = (state * 1664525 + 1013904223) % 2^32; byte = (state XOR (state >> 16)) & 0xFF`
+3. XOR UTF-8 bytes of `data` against the keystream
+4. Return as hex string
+
+**Step 3 — `sha256_encode(input)`:**
+
+1. SHA-256 hash the input string (UTF-8)
+2. Interpret the 32-byte digest as 8 big-endian uint32 words
+3. Extract 12 bytes in column-major order: `bytes[i] = words[i % 8] >> ((i / 8) * 8) & 0xFF` for i in 0..11  
+   (bytes 3 of each word are discarded; 8 bytes of the hash are never used)
+4. Encode each byte as 2 characters: `CHARSET[b % 62]` + `(b is odd ? 'V' : '0')`  
+   where `CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"`
+5. Return the 24-character result
 
 ### Message encoding
 

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -11,6 +11,86 @@ This document describes the MQTT protocol spoken by the Marstek/Hame B2500 batte
 
 ---
 
+## BLE Configuration
+
+The B2500 exposes a Bluetooth Low Energy interface for device configuration, including setting a custom MQTT broker.
+
+### BLE services and characteristics
+
+**B2500 (firmware 200-series):**
+
+| Role | UUID |
+|---|---|
+| Service | `0000ff00-0000-1000-8000-00805f9b34fb` |
+| Command (write) | `0000ff01-0000-1000-8000-00805f9b34fb` |
+| Status (notify) | `0000ff02-0000-1000-8000-00805f9b34fb` |
+
+**Tronic variant (firmware 100-series, experimental):**
+
+| Role | UUID |
+|---|---|
+| Service | `000000ff-0000-1000-8000-00805f9b34fb` |
+| Command (write) | `0000ff03-0000-1000-8000-00805f9b34fb` |
+| Status (notify) | `0000ff01-0000-1000-8000-00805f9b34fb` |
+
+### BLE message frame
+
+All BLE messages share a common frame:
+
+```
+[0x73] [length] [0x23] [command] [payload...] [xor_checksum]
+```
+
+- `0x73` — fixed start byte
+- `length` — number of bytes that follow (excluding start byte itself)
+- `0x23` — fixed identifier byte
+- `command` — command type byte (see below)
+- `payload` — variable-length, command-specific
+- `xor_checksum` — XOR of all bytes from `length` through the last payload byte
+
+Commands are written to the command characteristic. Responses arrive as notifications on the status characteristic. To improve delivery reliability, commands should be sent twice.
+
+### BLE command types
+
+| Command | Byte |
+|---|---|
+| Get runtime info | `0x03` |
+| Get device info | `0x04` |
+| Get cell info | `0x0f` |
+| Set Wi-Fi | `0x05` |
+| Set MQTT broker | `0x20` |
+| Reset MQTT broker | `0x21` |
+
+### Setting a custom MQTT broker
+
+Command byte: `0x20`
+
+Payload format (UTF-8 string, fields separated by `<.,.>`):
+
+```
+{ssl}<.,.>{host}<.,.>{port}<.,.>{username}<.,.>{password}<.,.>
+```
+
+| Field | Description |
+|---|---|
+| `ssl` | `1` = TLS enabled, `0` = plain |
+| `host` | Broker hostname or IP address |
+| `port` | Broker port number |
+| `username` | MQTT username (empty string if none) |
+| `password` | MQTT password (empty string if none) |
+
+Example payload string for a local broker without authentication:
+
+```
+0<.,.>192.168.1.100<.,.>1883<.,.><.,.><.,.>
+```
+
+### Resetting to the default (Marstek cloud) broker
+
+Command byte: `0x21`, no payload.
+
+---
+
 ## Raw Device Protocol
 
 The B2500 is unique among Marstek devices in that it supports connecting to a user-configured local MQTT broker in addition to the Marstek cloud broker. Other devices (Venus, Jupiter, etc.) only connect to the Marstek cloud.

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -703,7 +703,80 @@ Purpose and exact behaviour not fully documented.
 cd=30
 ```
 
-Triggers an error code response. Response format not documented here; see device error code reference.
+The device responds with a log of recent events. Each entry is 9 bytes:
+
+```
+[code: 1 byte] [timestamp: 4 bytes, big-endian Unix epoch] [data: 4 bytes]
+```
+
+The response contains multiple entries concatenated. `code=255` marks the end of the list.
+
+The `data` field carries context-specific values (e.g. cell voltage in mV for over/under-voltage events, or Ah/Wh measurements for learning events).
+
+##### Error codes — V1 (HMB, firmware ≥ 138)
+
+| Code | Description | Typical data |
+|---|---|---|
+| 0 | Device startup | 0 |
+| 12 | Battery overvoltage | mV per cell |
+| 25 | Watchdog reset | 255 |
+| 33 | Lithium short circuit protection | 32 |
+| 35 | Single battery overvoltage | mV per cell |
+| 36 | Single section undervoltage | mV per cell |
+| 42 | Register notification undervoltage | 2 |
+| 43 | Undervoltage enters sleep mode | mV (battery pack) |
+| 51 | BMS charging low-temperature protection | |
+| 55 | Start discharge learning | 0 |
+| 56 | Start charging and learning | 0 |
+| 57 | Interrupted discharge learning | ~Ah/Wh |
+| 60 | Discharge learning completed | ~Ah/Wh |
+| 61 | Charging learning completed | ~Ah/Wh |
+| 62 | Invalid learning data | ~Ah/Wh |
+| 63 | Discharge opens, exits charging learning | ~Ah/Wh |
+| 64 | Enter warehouse transportation mode | |
+| 65 | Wake up in warehouse transportation mode | 0 |
+| 74 | MQTT open failed | -1 |
+| 75 | MQTT connection disconnected | 0–3 |
+| 76 | MQTT reconnect | 0–2 |
+| 77 | DOD stops discharging | 0, 5, 10 |
+| 78 | MQTT connection successful | 1 |
+| 79 | MQTT connection error | 1 |
+| 80 | MQTT re-upload | 1 |
+| 81 | MQTT certificate deletion | 1 |
+| 82 | MQTT upload successful | 0 |
+| 84 | HTTP GET error | 0 |
+| 85 | Output 2 abnormal | 3 |
+| 86 | HTTP POST error | 0 |
+| 87 | Battery pack DOD parking | 2 |
+| 88 | Battery pack switching | |
+| 89 | Abnormal battery pack switching | |
+| 90 | Battery pack communication abnormality | 10 |
+| 91 | Device restart | 0 |
+| 92 | Operator 309 MOS | |
+| 93 | Battery pack switching | |
+| 94 | Abnormal low-power output | |
+| 95 | Abnormal battery pack switching | |
+| 100 | Risk of backflow | |
+| 255 | End of list | |
+
+##### Error codes — V2 (HMA/HMF/HMK/HMJ, firmware ≥ 216)
+
+Shares most codes with V1. Differences:
+
+| Code | V1 | V2 |
+|---|---|---|
+| 79 | MQTT connection error | Bind monitor IP |
+| 84 | HTTP GET error | HTTP GET error *(same)* |
+| 85 | Output 2 abnormal | Output 2 abnormal *(same)* |
+| 86 | HTTP POST error | MQTT re-upload |
+| 87 | Battery pack DOD parking | MQTT delete certificate |
+| 88 | Battery pack switching | MQTT upload successful |
+| 89 | Abnormal battery pack switching | Output 1 channel abnormal |
+| 90 | Battery pack communication abnormality | Output 2 channels abnormal |
+| 91 | Device restart | HTTP POST error |
+| 92 | Operator 309 MOS | Battery pack DOD parking |
+
+> Some codes are assigned different meanings between V1 and V2 firmware. When logging or displaying error codes, apply the correct table for the device generation.
 
 ---
 


### PR DESCRIPTION
## Summary

Completely restructured and significantly expanded the B2500 MQTT protocol documentation (`docs/b2500.md`) to provide comprehensive, well-organized reference material for developers integrating with the device.

## Key Changes

- **Reorganized structure**: Replaced flat numbered list with hierarchical sections covering device variants, raw protocol, status messages, and commands
- **Added device variant table**: Documents differences between V1 (HMB) and V2 (HMA/HMF/HMK/HMJ) models
- **Expanded broker/topic documentation**: 
  - Clarified custom vs. Marstek cloud broker topic formats
  - Documented firmware bug in versions 226.5 (HMA/HMF/HMK) and 108.7 (HMJ)
  - Detailed two encryption schemes for `deviceIdNew` (AES-128-CBC and VID/salt-based `cq`)
- **Comprehensive status message reference**:
  - Organized fields by category (solar input, battery, output, device info, temperature, etc.)
  - Added detailed field descriptions with units and value ranges
  - Documented all request types (`cd=01`, `cd=13`, `cd=14`, `cd=15`, `cd=16`, `cd=21`, `cd=24`)
  - Included CT status value table and firmware version requirements
- **Complete command reference**:
  - Created flash vs. no-flash command comparison table
  - Documented all 16+ command types with payload examples
  - Added parameter descriptions, ranges, and version requirements
  - Clarified V1-only vs. V2-only commands
- **Improved formatting**: Used tables, code blocks, and consistent markdown conventions throughout
- **Added version annotations**: Marked firmware version requirements and generation-specific features

## Validation

Documentation-only change; no runtime code modifications. Content verified against existing protocol implementation patterns and device behavior documentation.

https://claude.ai/code/session_01Fecb1JJFsCXEhJauTsxMge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the B2500 battery system guide into a comprehensive protocol reference.
  * Added detailed BLE configuration, message framing, and supported device variants.
  * Documented MQTT and cloud topic structures, including custom/local broker behavior and topic-ID computation.
  * Expanded runtime/status specifications with field references, payload examples, and additional status types.
  * Clarified app-to-device command formats, including flash/no-flash behavior, payload ranges, and firmware-specific error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->