### PR TITLE
Venus: Fix spurious warnings for partial PV power aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Next]
 
+### Fixed
+
+- Venus: Stop logging `Some values are missing for field totalPvPower` on every poll for devices that report fewer than four PV strings (or none, e.g. Venus E). The *Total PV Power* value is now aggregated from whichever `pv1`–`pv4` inputs are present and is simply omitted when none are reported, instead of warning (fixes #360)
 
 
 ## [1.8.1] - 2026-06-20

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -315,6 +315,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       key: ['pv1', 'pv2', 'pv3', 'pv4'],
       path: ['totalPvPower'],
       transform: sum(10),
+      // Not every Venus reports all four PV strings (some report fewer or none),
+      // so aggregate over whatever is present instead of warning about the rest.
+      allowPartial: true,
     });
     advertise(
       ['totalPvPower'],

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -88,6 +88,15 @@ export type FieldDefinition<
    * Home Assistant `total_increasing` sensors from transient corrupt readings.
    */
   monotonic?: boolean;
+  /**
+   * Only meaningful for multi-key (aggregate) fields. When set, the field is
+   * computed from whichever keys are present instead of requiring all of them:
+   * if none of the keys are present the field is skipped silently, and a partial
+   * set no longer logs a "Some values are missing" warning. Use for optional
+   * aggregates such as total PV power on devices that report a variable number
+   * of PV strings.
+   */
+  allowPartial?: boolean;
 } & (TypeAtPath<T, KP> extends number | undefined
   ? {}
   : {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,5 +1,7 @@
+import { jest } from '@jest/globals';
 import './device/registry.js';
 import { parseMessage } from './parser.js';
+import logger from './logger.js';
 import {
   B2500V2DeviceData,
   HmiInverterDeviceData,
@@ -729,6 +731,42 @@ describe('MQTT Message Parser', () => {
     const result = parsed['data'] as VenusDeviceData;
     expect(result).not.toHaveProperty('pv1Power');
     expect(result).not.toHaveProperty('totalPvPower');
+  });
+
+  test('does not warn about total PV power when the payload omits the pv fields (issue #360)', () => {
+    const warnSpy = jest.spyOn(logger, 'warn');
+    try {
+      const message =
+        'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0';
+      const parsed = parseMessage(message, 'VNSE3-0', 'venus123');
+
+      const result = parsed['data'] as VenusDeviceData;
+      expect(result).not.toHaveProperty('totalPvPower');
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Some values are missing for field totalPvPower'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('aggregates total PV power from a partial set of pv fields without warning (issue #360)', () => {
+    const warnSpy = jest.spyOn(logger, 'warn');
+    try {
+      // Only pv1 and pv2 are reported; pv3/pv4 are absent.
+      const message =
+        'cd=1,tot_i=0,tot_o=0,ele_d=0,ele_m=0,grd_d=0,grd_m=0,inc_d=0,inc_m=0,grd_f=0,grd_o=0,grd_t=1,gct_s=1,cel_s=1,cel_p=40,cel_c=7,err_t=0,err_a=0,dev_n=148,grd_y=0,wor_m=0,inc_a=0,pv1=1076|1,pv2=1000|1';
+      const parsed = parseMessage(message, 'VNSE3-0', 'venus123');
+
+      const result = parsed['data'] as VenusDeviceData;
+      // 1076 + 1000 -> 2076 deciwatts -> 207.6 W
+      expect(result).toHaveProperty('totalPvPower', 207.6);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Some values are missing for field totalPvPower'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   test('parses Venus D (VNSD) PV input power and connection status', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -120,9 +120,18 @@ function applyMessageDefinition<T extends BaseDeviceData>(
     } else if (field.transform != null) {
       // Multi-key field
       let entries = key.map(key => [key, values[key]] as const);
-      if (entries.every(([, value]) => value !== undefined)) {
+      const presentEntries = entries.filter(([, value]) => value !== undefined);
+      // For aggregate fields flagged as partial-friendly, compute from whatever
+      // keys are present and skip silently when none are (e.g. total PV power on
+      // devices that report a variable number of PV strings). Otherwise require
+      // all keys and warn when only some are present.
+      if (
+        field.allowPartial ? presentEntries.length > 0 : presentEntries.length === entries.length
+      ) {
         const transform = field.transform;
-        const valuesObj = Object.fromEntries(entries) as Record<string, string>;
+        const valuesObj = Object.fromEntries(
+          field.allowPartial ? presentEntries : entries,
+        ) as Record<string, string>;
         let transformedValue: unknown;
 
         if (isDeclarativeTransform(transform)) {
@@ -134,7 +143,7 @@ function applyMessageDefinition<T extends BaseDeviceData>(
         }
 
         setValueAtPath(parsedData, field.path, transformedValue);
-      } else {
+      } else if (!field.allowPartial) {
         logger.warn(`Some values are missing for field ${field.path.join('.')}`);
       }
     } else {


### PR DESCRIPTION
## Summary

Fixes issue #360 by allowing the `totalPvPower` field to be aggregated from a partial set of PV inputs instead of requiring all four `pv1`–`pv4` keys to be present. This eliminates spurious "Some values are missing" warnings on every poll for Venus devices that report fewer than four PV strings (or none at all, like Venus E).

## Changes

- **src/deviceDefinition.ts**: Added `allowPartial?: boolean` field option for multi-key aggregate fields. When set, the field is computed from whichever keys are present; if none are present, the field is silently omitted instead of logging a warning.

- **src/parser.ts**: Updated multi-key field processing logic to:
  - Filter to only present entries when `allowPartial` is true
  - Compute the aggregate from whatever keys are available
  - Skip the warning when `allowPartial` is true and no keys are present

- **src/device/venus.ts**: Marked the `totalPvPower` field with `allowPartial: true` to handle devices reporting a variable number of PV strings.

- **src/parser.test.ts**: Added two test cases:
  - Verifies no warning is logged when all PV fields are omitted
  - Verifies partial PV fields (e.g., only `pv1` and `pv2`) are correctly aggregated without warning

- **CHANGELOG.md**: Documented the fix under `[Next]` / `Fixed` section.

## Validation

- `npm test -- --runInBand` passes all tests including new cases
- `npm run build` completes successfully
- No configuration changes required

https://claude.ai/code/session_01SWuuHiybs7XaYVNXvvzbX9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Venus devices no longer warn when some or all PV string values are missing.
  - *Total PV Power* is now calculated from whichever PV inputs are available.
  - The value is omitted quietly when no PV inputs are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->