### PR TITLE
Add configurable cell data polling interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 ## [Next]
 
+### Added
 
+- B2500: Add a configurable cell-voltage polling interval via `POLL_CELL_DATA_INTERVAL` and the Home Assistant app option `cellDataPollingInterval` (default: 15 seconds, minimum: 1 second).
 
 ## [1.8.1] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ docker run -d --name hm2mqtt \
   -e MQTT_USERNAME=your-username \
   -e MQTT_PASSWORD=your-password \
   -e POLL_CELL_DATA=false \
+  -e POLL_CELL_DATA_INTERVAL=15 \
   -e POLL_EXTRA_BATTERY_DATA=false \
   -e POLL_CALIBRATION_DATA=false \
   -e DEVICE_0=HMA-1:your-device-mac \
@@ -193,6 +194,7 @@ services:
       - MQTT_PROXY_ENABLED=true  # Enable proxy for multiple B2500s
       - MQTT_PROXY_PORT=1890
       - POLL_CELL_DATA=true
+      - POLL_CELL_DATA_INTERVAL=15
       - POLL_EXTRA_BATTERY_DATA=true
       - POLL_CALIBRATION_DATA=true
       - DEVICE_0=HMA-1:0019aa0d4dcb  # First B2500 device
@@ -214,6 +216,7 @@ services:
       - MQTT_USERNAME=''
       - MQTT_PASSWORD=''
       - POLL_CELL_DATA=true
+      - POLL_CELL_DATA_INTERVAL=15
       - POLL_EXTRA_BATTERY_DATA=true
       - POLL_CALIBRATION_DATA=true
       - DEVICE_0=HMA-1:0019aa0d4dcb  # 12-character MAC address
@@ -245,6 +248,7 @@ services:
    MQTT_POLLING_INTERVAL=60
    MQTT_RESPONSE_TIMEOUT=30
    POLL_CELL_DATA=false
+   POLL_CELL_DATA_INTERVAL=15
    POLL_EXTRA_BATTERY_DATA=false
    POLL_CALIBRATION_DATA=false
    DEVICE_0=HMA-1:001a2b3c4d5e  # 12-character MAC address
@@ -270,6 +274,7 @@ services:
 | `MQTT_POLLING_INTERVAL` | Interval between device polls in seconds | `60`                 |
 | `MQTT_RESPONSE_TIMEOUT` | Timeout for device responses in seconds | `15`                 |
 | `POLL_CELL_DATA` | Enable cell-level battery data (individual cell voltages, temperatures and, on Venus, detailed per-pack BMS data) | false |
+| `POLL_CELL_DATA_INTERVAL` | Interval between B2500 cell-voltage polls in seconds (minimum: `1`) | `15` |
 | `POLL_EXTRA_BATTERY_DATA` | Enable extra battery data reporting (only available on B2500 devices) | false |
 | `POLL_CALIBRATION_DATA` | Enable calibration data reporting (only available on B2500 devices) | false |
 | `DEVICE_n` | Device configuration in format `{type}:{mac}` | -                       |
@@ -282,6 +287,8 @@ services:
 ```yaml
 pollingInterval: 60  # Interval between device polls in seconds
 responseTimeout: 30  # Timeout for device responses in seconds
+enableCellData: false  # Enable detailed cell data polling
+cellDataPollingInterval: 15  # B2500 cell voltage polling interval in seconds (minimum: 1)
 allowedConsecutiveTimeouts: 3  # Number of consecutive timeouts before a device is marked offline
 topicPrefix: hm2mqtt  # Base MQTT topic prefix for published data
 autodiscoveryTopicPrefix: homeassistant  # Base MQTT topic prefix for HA auto discovery

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -21,6 +21,7 @@ options:
   pollingInterval: 60
   responseTimeout: 30
   enableCellData: false
+  cellDataPollingInterval: 15
   enableCalibrationData: false
   enableExtraBatteryData: false
   allowedConsecutiveTimeouts: 3
@@ -35,6 +36,7 @@ schema:
   pollingInterval: int?
   responseTimeout: int?
   enableCellData: bool
+  cellDataPollingInterval: "int(1,)"
   enableCalibrationData: bool
   enableExtraBatteryData: bool
   allowedConsecutiveTimeouts: int?

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -109,6 +109,7 @@ export MQTT_CLIENT_ID="hm2mqtt-ha-addon"
 export MQTT_POLLING_INTERVAL=$(bashio::config 'pollingInterval' "60")
 export MQTT_RESPONSE_TIMEOUT=$(bashio::config 'responseTimeout' "30")
 export POLL_CELL_DATA=$(bashio::config 'enableCellData' "false")
+export POLL_CELL_DATA_INTERVAL=$(bashio::config 'cellDataPollingInterval' "15")
 export POLL_CALIBRATION_DATA=$(bashio::config 'enableCalibrationData' "false")
 export POLL_EXTRA_BATTERY_DATA=$(bashio::config 'enableExtraBatteryData' "false")
 export DEBUG=$(bashio::config 'debug' "false")
@@ -120,6 +121,7 @@ bashio::log.info "MQTT allowed consecutive timeouts: ${MQTT_ALLOWED_CONSECUTIVE_
 bashio::log.info "MQTT proxy enabled: ${MQTT_PROXY_ENABLED}"
 bashio::log.info "MQTT polling interval: ${MQTT_POLLING_INTERVAL} seconds"
 bashio::log.info "MQTT response timeout: ${MQTT_RESPONSE_TIMEOUT} seconds"
+bashio::log.info "Cell data polling interval: ${POLL_CELL_DATA_INTERVAL} seconds"
 bashio::log.info "MQTT topic prefix: ${MQTT_TOPIC_PREFIX}"
 bashio::log.info "MQTT autodiscovery topic prefix: ${AUTODISCOVERY_TOPIC_PREFIX}"
 

--- a/ha_addon/test_env.sh
+++ b/ha_addon/test_env.sh
@@ -123,6 +123,7 @@ run_test "Additional configuration options" \
         "pollingInterval": 30,
         "responseTimeout": 15,
         "enableCellData": true,
+        "cellDataPollingInterval": 7,
         "enableCalibrationData": true,
         "enableExtraBatteryData": true,
         "topicPrefix": "custom",
@@ -139,6 +140,7 @@ MQTT_TOPIC_PREFIX=custom
 MQTT_POLLING_INTERVAL=30
 MQTT_RESPONSE_TIMEOUT=15
 POLL_CELL_DATA=true
+POLL_CELL_DATA_INTERVAL=7
 POLL_EXTRA_BATTERY_DATA=true
 POLL_CALIBRATION_DATA=true
 LOG_LEVEL=debug

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -8,6 +8,9 @@ configuration:
   enableCellData:
     name: "Zellspannung"
     description: "Aktiviere Abruf der Zellenspannung (nur verfügbar für B2500)"
+  cellDataPollingInterval:
+    name: "Abfrageintervall der Zellspannung"
+    description: "Intervall in Sekunden zwischen den Zellspannungsabfragen (Standard: 15, Minimum: 1)"
   enableCalibrationData:
     name: "Kalibrierungsdaten"
     description: "Aktiviere Abruf der Kalibrierungsdaten (nur verfügbar für B2500)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -8,6 +8,9 @@ configuration:
   enableCellData:
     name: Enable Cell Data
     description: "Enable cell voltage (only available on B2500 devices)"
+  cellDataPollingInterval:
+    name: Cell Data Polling Interval
+    description: "Interval in seconds between B2500 cell voltage polls (default: 15, minimum: 1)"
   enableCalibrationData:
     name: Enable Calibration Data
     description: "Enable calibration data reporting (only available on B2500 devices)"

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,0 +1,25 @@
+import {
+  DEFAULT_CELL_DATA_POLLING_INTERVAL_SECONDS,
+  parseCellDataPollingInterval,
+} from './constants.js';
+
+describe('parseCellDataPollingInterval', () => {
+  it('uses the 15 second default when no value is configured', () => {
+    expect(parseCellDataPollingInterval(undefined)).toBe(
+      DEFAULT_CELL_DATA_POLLING_INTERVAL_SECONDS * 1000,
+    );
+  });
+
+  it('uses a configured interval in seconds', () => {
+    expect(parseCellDataPollingInterval('7')).toBe(7000);
+  });
+
+  it('enforces the one second minimum', () => {
+    expect(parseCellDataPollingInterval('0')).toBe(1000);
+    expect(parseCellDataPollingInterval('-5')).toBe(1000);
+  });
+
+  it('falls back to the default for invalid values', () => {
+    expect(parseCellDataPollingInterval('invalid')).toBe(15000);
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,3 +10,21 @@ export const DEFAULT_TOPIC_PREFIX = 'hm2mqtt';
  * `AUTODISCOVERY_TOPIC_PREFIX` is not provided.
  */
 export const DEFAULT_AUTODISCOVERY_TOPIC_PREFIX = 'homeassistant';
+
+/** Default interval for polling detailed cell data, in seconds. */
+export const DEFAULT_CELL_DATA_POLLING_INTERVAL_SECONDS = 15;
+
+/** Smallest supported interval for polling detailed cell data, in seconds. */
+export const MIN_CELL_DATA_POLLING_INTERVAL_SECONDS = 1;
+
+/** Parse the cell-data polling interval from its seconds-based environment value. */
+export function parseCellDataPollingInterval(value: string | undefined): number {
+  const configuredSeconds = Number.parseInt(
+    value || `${DEFAULT_CELL_DATA_POLLING_INTERVAL_SECONDS}`,
+    10,
+  );
+  const seconds = Number.isNaN(configuredSeconds)
+    ? DEFAULT_CELL_DATA_POLLING_INTERVAL_SECONDS
+    : Math.max(configuredSeconds, MIN_CELL_DATA_POLLING_INTERVAL_SECONDS);
+  return seconds * 1000;
+}

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -39,6 +39,7 @@ describe('ControlHandler', () => {
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [testDeviceV1, testDeviceV2],
       responseTimeout: 15000,
     };

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -709,6 +709,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
     getAdditionalDeviceInfo: () => ({}),
     publishPath: 'cells',
     pollInterval: 60000,
+    pollIntervalConfig: 'cellDataPollingInterval',
     controlsDeviceAvailability: false,
     enabled: process.env.POLL_CELL_DATA === 'true',
   } as const;

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1541,6 +1541,7 @@ describe('Device Commands', () => {
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [device],
       responseTimeout: 15000,
     };

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -111,6 +111,8 @@ export interface MessageDefinition<T extends BaseDeviceData> {
   fields: FieldDefinition<T, KeyPath<T>>[];
   publishPath: string;
   pollInterval: number;
+  /** Optional MqttConfig property that overrides pollInterval. */
+  pollIntervalConfig?: 'cellDataPollingInterval';
   controlsDeviceAvailability: boolean;
   enabled?: boolean;
   /**
@@ -167,6 +169,7 @@ export type BuildMessageFn = <T extends BaseDeviceData>(
     defaultState: Omit<T, keyof BaseDeviceData>;
     getAdditionalDeviceInfo: (state: T) => AdditionalDeviceInfo;
     pollInterval: number;
+    pollIntervalConfig?: 'cellDataPollingInterval';
     controlsDeviceAvailability: boolean;
     enabled?: boolean;
     shouldPoll?: (state: BaseDeviceData) => boolean;

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -3,6 +3,7 @@ import './device/registry.js';
 import { DeviceManager } from './deviceManager.js';
 import { MqttConfig } from './types.js';
 import { DEFAULT_TOPIC_PREFIX } from './constants.js';
+import { getDeviceDefinition } from './deviceDefinition.js';
 import { calculateNewVersionTopicId } from './utils/crypt.js';
 import logger from './logger.js';
 
@@ -12,6 +13,7 @@ describe('DeviceManager', () => {
     clientId: 'test-client',
     topicPrefix: DEFAULT_TOPIC_PREFIX,
     autodiscoveryTopicPrefix: 'homeassistant',
+    cellDataPollingInterval: 15000,
     devices: [
       {
         deviceType: 'HMA-1',
@@ -58,12 +60,23 @@ describe('DeviceManager', () => {
     expect(topics?.availabilityTopic).toBe('customPrefix/HMA-1/availability/test123');
   });
 
+  it('should use the configured interval for B2500 cell data', () => {
+    const cellMessage = getDeviceDefinition('HMA-1')?.messages.find(
+      message => message.refreshDataPayload === 'cd=13',
+    );
+
+    expect(cellMessage).toBeDefined();
+    expect(cellMessage?.pollIntervalConfig).toBe('cellDataPollingInterval');
+    expect(deviceManager.getMessagePollingInterval(cellMessage!)).toBe(15000);
+  });
+
   it('should handle invalid device types gracefully', () => {
     const invalidConfig: MqttConfig = {
       brokerUrl: 'mqtt://localhost',
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [
         {
           deviceType: 'INVALID-TYPE',
@@ -84,6 +97,7 @@ describe('DeviceManager', () => {
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [
         {
           deviceType: 'INVALID-TYPE',
@@ -117,6 +131,7 @@ describe('DeviceManager', () => {
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [
         { deviceType: 'HWJ-2', deviceId: 'typo123' },
         { deviceType: 'HMA-1', deviceId: 'valid123' },
@@ -137,6 +152,7 @@ describe('DeviceManager', () => {
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [
         { deviceType: 'ZZZZZ-1', deviceId: 'bad123' },
         { deviceType: 'HMA-1', deviceId: 'valid123' },
@@ -154,6 +170,7 @@ describe('DeviceManager', () => {
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [{ deviceType: 'hma-1', deviceId: 'case123' }],
     };
 
@@ -168,6 +185,7 @@ describe('DeviceManager', () => {
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [
         {
           deviceType: 'HMB-1',
@@ -189,6 +207,7 @@ describe('DeviceManager', () => {
       clientId: 'test-client',
       topicPrefix: DEFAULT_TOPIC_PREFIX,
       autodiscoveryTopicPrefix: 'homeassistant',
+      cellDataPollingInterval: 15000,
       devices: [{ deviceType: 'VNSE3-0', deviceId: 'venus123' }],
     };
 

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -3,8 +3,10 @@ import {
   getDeviceDefinition,
   extractBaseType,
   getSuggestedDeviceType,
+  BaseDeviceData,
   FieldDefinition,
   KeyPath,
+  MessageDefinition,
 } from './deviceDefinition.js';
 import { calculateNewVersionTopicId, decryptNewVersionTopicId } from './utils/crypt.js';
 import logger from './logger.js';
@@ -352,8 +354,9 @@ export class DeviceManager {
     const allPollingIntervals = this.getDevices().flatMap(device => {
       return (
         getDeviceDefinition(device.deviceType)
-          ?.messages.map(message => {
-            return message.pollInterval;
+          ?.messages.filter(message => message.enabled)
+          .map(message => {
+            return this.getMessagePollingInterval(message);
           })
           ?.filter(n => n != null) ?? []
       );
@@ -372,6 +375,16 @@ export class DeviceManager {
     }
 
     return allPollingIntervals.reduce(gcd2, allPollingIntervals[0]);
+  }
+
+  /** Resolve a message's configured polling interval in milliseconds. */
+  getMessagePollingInterval(
+    message: Pick<MessageDefinition<BaseDeviceData>, 'pollInterval' | 'pollIntervalConfig'>,
+  ): number {
+    if (message.pollIntervalConfig === 'cellDataPollingInterval') {
+      return this.config.cellDataPollingInterval;
+    }
+    return message.pollInterval;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,11 @@ dotenv.config();
 
 import './device/registry.js';
 import { Device, MqttConfig } from './types.js';
-import { DEFAULT_AUTODISCOVERY_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX } from './constants.js';
+import {
+  DEFAULT_AUTODISCOVERY_TOPIC_PREFIX,
+  DEFAULT_TOPIC_PREFIX,
+  parseCellDataPollingInterval,
+} from './constants.js';
 import { DeviceManager, DeviceStateData } from './deviceManager.js';
 import { MqttClient } from './mqttClient.js';
 import { ControlHandler } from './controlHandler.js';
@@ -114,6 +118,7 @@ function createMqttConfig(devices: Device[]): MqttConfig {
     topicPrefix: process.env.MQTT_TOPIC_PREFIX || DEFAULT_TOPIC_PREFIX,
     autodiscoveryTopicPrefix:
       process.env.AUTODISCOVERY_TOPIC_PREFIX || DEFAULT_AUTODISCOVERY_TOPIC_PREFIX,
+    cellDataPollingInterval: parseCellDataPollingInterval(process.env.POLL_CELL_DATA_INTERVAL),
     devices,
     responseTimeout: parseInt(process.env.MQTT_RESPONSE_TIMEOUT || '15', 10) * 1000,
     allowedConsecutiveTimeouts: parseInt(process.env.MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS || '3', 10),

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -192,6 +192,7 @@ describe('MqttClient shouldPoll gating', () => {
         getDeviceTopics: () => topics,
         getDeviceState: () => (packMask != null ? { packMask } : undefined),
         getDevices: () => [],
+        getMessagePollingInterval: (message: any) => message.pollInterval,
         getResponseTimeout: () => 5000,
         setResponseTimeout: jest.fn(),
         clearResponseTimeout: jest.fn(),
@@ -225,5 +226,47 @@ describe('MqttClient shouldPoll gating', () => {
     expect(payloads).toContain('cd=1');
     expect(payloads).not.toContain('cd=42,bms_idx=1');
     expect(payloads).not.toContain('cd=42,bms_idx=2');
+  });
+
+  test('polls again as soon as the configured interval has elapsed', () => {
+    jest.useFakeTimers({ now: 0 });
+    try {
+      mockGetDeviceDefinition.mockReturnValue({
+        messages: [makeMessage({ refreshDataPayload: 'cd=13', publishPath: 'cells' })],
+      } as any);
+
+      const device: Device = { deviceType: 'HMA-1', deviceId: 'b2500' };
+      const deviceManager: any = {
+        getDeviceTopics: () => topics,
+        getDeviceState: () => ({}),
+        getMessagePollingInterval: () => 1000,
+        getResponseTimeout: () => 5000,
+        setResponseTimeout: jest.fn(),
+        clearResponseTimeout: jest.fn(),
+      };
+      const config: any = {
+        brokerUrl: 'mqtt://localhost:1883',
+        clientId: 'test-client',
+        topicPrefix: 'homeassistant',
+        autodiscoveryTopicPrefix: 'homeassistant',
+      };
+      const mqttClient = new MqttClient(config, deviceManager, jest.fn());
+
+      mqttClient.requestDeviceData(device);
+      jest.advanceTimersByTime(0);
+      mockPublish.mockClear();
+
+      jest.advanceTimersByTime(999);
+      mqttClient.requestDeviceData(device);
+      jest.advanceTimersByTime(0);
+      expect(mockPublish).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      mqttClient.requestDeviceData(device);
+      jest.advanceTimersByTime(0);
+      expect(mockPublish).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -357,7 +357,8 @@ export class MqttClient {
       }
       let lastRequestTimeKey = `${device.deviceId}:${idx}`;
       const lastRequestTime = this.lastRequestTime.get(lastRequestTimeKey);
-      if (lastRequestTime == null || now > lastRequestTime + message.pollInterval) {
+      const pollInterval = this.deviceManager.getMessagePollingInterval(message);
+      if (lastRequestTime == null || now >= lastRequestTime + pollInterval) {
         needsRefresh = true;
         shouldStartTimeout = shouldStartTimeout || message.controlsDeviceAvailability;
       }
@@ -401,7 +402,8 @@ export class MqttClient {
 
       let lastRequestTimeKey = `${device.deviceId}:${idx}`;
       const lastRequestTime = this.lastRequestTime.get(lastRequestTimeKey);
-      if (lastRequestTime == null || now > lastRequestTime + message.pollInterval) {
+      const pollInterval = this.deviceManager.getMessagePollingInterval(message);
+      if (lastRequestTime == null || now >= lastRequestTime + pollInterval) {
         this.lastRequestTime.set(lastRequestTimeKey, now);
         const payload = message.refreshDataPayload;
         setTimeout(

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,8 @@ export interface MqttConfig {
    * (default: 'homeassistant')
    */
   autodiscoveryTopicPrefix: string;
+  /** Interval for polling detailed cell data, in milliseconds. */
+  cellDataPollingInterval: number;
   useFlashCommands?: boolean;
   responseTimeout?: number; // Timeout for device responses in milliseconds
   /**


### PR DESCRIPTION
## What changed

- add a Home Assistant app input for the B2500 cell-voltage polling interval
- add `POLL_CELL_DATA_INTERVAL` for Docker and `.env` deployments
- default the interval to 15 seconds and enforce a minimum of 1 second
- use the configured interval for B2500 `cd=13` cell-data requests
- update translations, documentation, add-on mapping, changelog, and configuration fixtures

## Why

The B2500 cell-voltage polling interval was fixed at 60 seconds. Users can now choose how frequently detailed cell voltages are refreshed without changing the general device polling interval.

## Validation

- `npm run build`
- Jest: 400 tests passed
- `npm run format:check`
- `git diff --check`
- parsed `ha_addon/config.yaml` and both translation YAML files

The Docker-based add-on test could not be run locally because Docker/WSL is unavailable in the development environment.
