### PR TITLE
docs: add Marstek ecosystem overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Reads Hame energy storage MQTT data, parses it and exposes it as JSON.
 
+<!-- marstek-family:start -->
+**🔋 The Marstek ecosystem.** This repo is part of a family of open-source tools for Marstek batteries (B2500, Venus, Jupiter, …):
+
+| Project | What it does |
+|---|---|
+| **hm2mqtt** (this repo) | Brings your battery into your smart home, turning its raw data into readable sensors and controls (e.g. in Home Assistant) |
+| [hame-relay](https://github.com/tomquist/hame-relay) | Connects the official Marstek cloud/app and your local smart home so both work together, forwarding data whichever way your battery is set up |
+| [marsrelay](https://github.com/tomquist/marsrelay) | Runs your battery completely offline, with no internet or Marstek cloud, while still sending all its data to your smart home |
+| [AstraMeter](https://github.com/tomquist/astrameter) | Tells your battery your live grid usage (read from your existing meter) so it charges and discharges to avoid buying or selling power |
+| [hmjs](https://github.com/tomquist/hmjs) | Sets up and configures B2500 batteries over Bluetooth, right from your web browser, with no app or account needed |
+| [esphome-b2500](https://github.com/tomquist/esphome-b2500) | Continuously monitors and controls a B2500 over Bluetooth using a small ESP32 board |
+<!-- marstek-family:end -->
+
 ## Overview
 
 hm2mqtt is a bridge application that connects Hame energy storage devices (like the B2500 series) to Home Assistant (or other home automation systems) through MQTT. It provides real-time monitoring and control of your energy storage system directly from your Home Assistant dashboard.


### PR DESCRIPTION
## Summary

Added a new "Marstek ecosystem" section to the README that documents the family of open-source tools available for Marstek batteries, positioning `hm2mqtt` within the broader ecosystem and linking to related projects.

## Changes

- Added a new ecosystem overview section with a table listing related projects:
  - `hame-relay` – cloud/app integration bridge
  - `marsrelay` – offline-only battery operation
  - `AstraMeter` – grid usage awareness
  - `hmjs` – web-based battery setup
  - `esphome-b2500` – ESP32-based Bluetooth monitoring
- Placed the section prominently after the intro, before the existing "Overview" section
- Used HTML comments (`<!-- marstek-family:start/end -->`) to mark the section for potential future automation or synchronization across related repos

## Validation

- README structure and links verified
- No code or configuration changes; documentation-only update

https://claude.ai/code/session_014X7oipnV3LXbrsLYoii4yq