### PR TITLE
Fix spurious subscription error for devices without controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Venus: Stop logging `Some values are missing for field totalPvPower` on every poll for devices that report fewer than four PV strings (or none, e.g. Venus E). The *Total PV Power* value is now aggregated from whichever `pv1`–`pv4` inputs are present and is simply omitted when none are reported, instead of warning (fixes #360)
+- CT002: Stop logging a spurious `Invalid topic empty_topic_list` subscription error on startup for devices without any controls (fixes #371)
 
 
 ## [1.8.1] - 2026-06-20

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -136,6 +136,33 @@ describe('MqttClient discovery re-publish', () => {
   });
 });
 
+describe('MqttClient subscribe', () => {
+  test('skips subscribing when the topic list is empty (regression #371)', () => {
+    mockSubscribe.mockClear();
+
+    const deviceManager: any = {
+      getDevices: jest.fn(() => []),
+    };
+    const config: any = {
+      brokerUrl: 'mqtt://localhost:1883',
+      clientId: 'test-client',
+      topicPrefix: 'homeassistant',
+      autodiscoveryTopicPrefix: 'homeassistant',
+    };
+
+    const mqttClient = new MqttClient(config, deviceManager, jest.fn());
+
+    mqttClient.subscribe([]);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+
+    mqttClient.subscribe(['homeassistant/HME-4/control/ct002/control/refresh']);
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      ['homeassistant/HME-4/control/ct002/control/refresh'],
+      expect.any(Function),
+    );
+  });
+});
+
 describe('MqttClient shouldPoll gating', () => {
   const topics = {
     deviceTopicOld: 'hame_energy/VNSD-0/device/venus1/ctrl',

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -150,6 +150,9 @@ export class MqttClient {
    * @param topic - The topic to subscribe to
    */
   subscribe(topic: string | string[]): void {
+    if (Array.isArray(topic) && topic.length === 0) {
+      return;
+    }
     this.client.subscribe(topic, err => {
       if (err) {
         logger.error(`Subscription error for ${topic}:`, err);


### PR DESCRIPTION
## Summary

Fixes a spurious `Invalid topic empty_topic_list` subscription error that was logged on startup for CT002 devices without any controls.

## Changes

- **src/mqttClient.ts**: Added an early return in the `subscribe()` method to skip calling the underlying MQTT client when the topic list is empty
- **src/mqttClient.test.ts**: Added regression test to verify that `subscribe()` skips the underlying subscription call when given an empty topic array, and still works correctly with non-empty topics
- **CHANGELOG.md**: Documented the fix under the Fixed section

## Implementation Details

The fix is minimal and surgical: when `subscribe()` is called with an empty array, it now returns early without invoking `this.client.subscribe()`. This prevents the MQTT client from attempting to subscribe to an empty topic list, which was causing the spurious error log.

The regression test ensures this behavior is maintained and verifies that normal subscription still works as expected.

## Validation

- Unit test added and passing
- Change is backward compatible
- Closes #371

https://claude.ai/code/session_01XLKip61P1NxE32EB5JCvm7