### PR TITLE
Venus: Add peak shaving, parallel mode, and battery/grid power sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 - CT002 & CT003: Add a *Slave Count* sensor, disabled by default.
 - CT002: Add *Phase 1/2/3 Charge* and *Phase 1/2/3 Discharge* counters, disabled by default. The meter does not say what unit these are in, so they are published as reported, without a unit — if you can match them against your meter's own readings, please report what you find.
 - Docs: Add [docs/meters.md](docs/meters.md), documenting the MQTT protocol of the CT002 and CT003 meters.
+- Venus: Add *Peak Shaving* switch and *Peak Shaving Power* number entities, capping how much power the device draws from the grid (`cd=63`). Supported from control firmware v150 on the Venus D and Venus E; the entities appear once the device reports the `peak_status`/`peak_power` fields.
+- Venus: Add *Battery Power* and *Grid Power* sensors, read from the `bp` and `gp` fields reported by newer firmware, plus a *Battery Power (Calculated)* sensor for the `rp` field (disabled by default). The Marstek app shows either `bp` or `rp` depending on a per-model flag that could not be recovered from the app, so both are published.
+- Venus: Add a *Parallel Mode* select for running several units in parallel (`cd=23`), along with the `par` status field it reports (*Turned Off*, *Wiring Check*, *Turned On*). Disabled by default: parallel operation is a wiring-level change that also makes the backup/EPS function unavailable, so it has to be switched on deliberately. See [the README](README.md#parallel-mode) for what it does and the order the wiring steps have to happen in.
 
 ### Fixed
 
+- Venus: Fix the *Version Set* entity reporting the wrong rated power. The `set_v` field is a power-version *code*, not a wattage, and the previous mapping had it backwards: devices reporting `set_v=0` (the 2500W version) were shown as *800W Version* and every other code as *2500W Version*. The full code table from the Marstek app is now used, so the 600W, 1200W, 1500W, 2000W, 2200W, 2300W, 3000W and 3600W versions are reported correctly too, and unknown codes are left unset instead of being reported as 2500W. The *Version Set* select offers the same list; the command it sends is unchanged (`cd=15,vs=<watts>`)
 - Venus: Stop logging `Some values are missing for field totalPvPower` on every poll for devices that report fewer than four PV strings (or none, e.g. Venus E). The *Total PV Power* value is now aggregated from whichever `pv1`–`pv4` inputs are present and is simply omitted when none are reported, instead of warning (fixes #360)
 - CT002: Stop logging a spurious `Invalid topic empty_topic_list` subscription error on startup for devices without any controls (fixes #371)
 

--- a/README.md
+++ b/README.md
@@ -646,6 +646,32 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `surplus-feed-in`: Toggles surplus feed-in into the grid (`on` or `off`). Only available on Venus models with PV inputs (Venus A/D).
 - `bluetooth-advertising`: Toggles Bluetooth advertising (`on` enables advertising, `off` disables it / "Bluetooth lock")
 - `phase-diagnosis`: Starts the grid-phase detection routine
+- `peak-shaving`: Toggles peak shaving, which caps the power drawn from the grid (`on` or `off`). Only available on firmware that reports the peak-shaving state (control v150 and up on Venus D/E).
+- `peak-shaving-power`: Sets the peak-shaving power cap in watts. Only takes effect on the device while peak shaving is enabled; while it is off the value is stored and applied the next time you enable it.
+- `parallel-mode`: Controls parallel operation (`off`, `wiringCheck` or `on`), which links several units into one group for a higher combined output. **Disabled by default, and best left that way unless you know you need it** — see the warning below.
+
+#### Parallel mode
+
+Parallel operation is a wiring-level change, not a software setting: the units
+have to be physically cabled together, and the command only tells them to run in
+that configuration. The Marstek app puts it behind a "⚠️ Parallel Connection
+Safety Notice" warning that it involves high-voltage output, that improper
+operation may damage the devices, that you must not operate under load, and that
+it should not be attempted unless you are a qualified professional.
+
+Two things are worth knowing before you touch it:
+
+- **The order differs between on and off.** Enabling comes first and the rewiring
+  second (power off, then reconnect). Disabling is the reverse: power off every
+  device in the group and remove the wiring *first*, then turn parallel mode off.
+- **Parallel mode disables backup power.** While a group runs in off-grid
+  parallel mode the backup/EPS function is unavailable, so the *Backup Power*
+  switch will not work.
+
+The `wiringCheck` value is the app's own verification step — it runs that before
+enabling. The matching *Parallel Mode* entity reports the current state (*Turned
+Off*, *Wiring Check*, *Turned On*, or *Unknown* on units that do not support
+parallel operation).
 
 ### Jupiter Device Commands
 

--- a/docs/venus.md
+++ b/docs/venus.md
@@ -32,8 +32,6 @@
     1. [Public](#121-public)
     2. [Receive](#122-receive)
 13. [Set maximum discharge power](#13-set-maximum-discharge-power)
-    1. [Public](#131-public)
-    2. [Receive](#132-receive)
 14. [Set the meter type and supplementary power type](#14-set-the-meter-type-and-supplementary-power-type)
     1. [Public](#141-public)
 15. [Obtain CT power](#15-obtain-ct-power)
@@ -72,6 +70,12 @@
 27. [Configure Bluetooth advertising](#27-configure-bluetooth-advertising)
     1. [Public](#271-public)
     2. [Receive](#272-receive)
+28. [Configure peak shaving](#28-configure-peak-shaving)
+    1. [Public](#281-public)
+    2. [Receive](#282-receive)
+29. [Configure parallel operation](#29-configure-parallel-operation)
+    1. [Public](#291-public)
+    2. [Receive](#292-receive)
 
 ## 1 MQTT Core Concepts
 
@@ -176,7 +180,7 @@ Description of the above parameters:
 | prc_d | Obtain regional discharge prices |
 | wif_s | WIFI signal strength (Less than 50: Good signal; 50-70: The signal is average; 70-80: Poor signal; Greater than 80: The signal is very weak) |
 | inc_a | Total cumulative income (Unit: 0.001 euros) |
-| set_v | Version set (0: 2500W version; 1: 800W version) |
+| set_v | Power version — a *code* for the device's rated output power, not a wattage (see [Set version](#11-set-version)). The resulting power is reported back as `mdp_w`. |
 | mcp_w | Maximum charging power (Not exceeding 2500W) |
 | mdp_w | Maximum discharge power (Not exceeding 2500W) |
 | ct_t | CT type (0: No meter detected; 1: CT1; 2: CT2; 3: CT3; 4: Shelly pro; 5: p1 meter) |
@@ -200,7 +204,7 @@ guesses based on context and cross-referencing other commands:
 |-----|-------------|
 | seq_s | Phase-diagnosis status *(unconfirmed)* — changes after running `cd=18,seq_check` |
 | ctrl_r | *(unconfirmed)* |
-| par | Parallel-operation flag *(unconfirmed)* |
+| par | Parallel operation status (0: turned off; 1: wiring check; 2: turned on). Units that do not support parallel operation report `255`. See [Configure parallel operation](#29-configure-parallel-operation) |
 | gen | Generator flag *(unconfirmed)* |
 | ble | Bluetooth state bitmask; bit 2 (value `4`) is set when advertising is enabled (Bluetooth lock off), `1` when the lock is enabled (see `cd=55`) |
 | c_ratio | CT ratio (%) *(unconfirmed)* |
@@ -211,11 +215,11 @@ guesses based on context and cross-referencing other commands:
 | inv_v | Inverter / micro module version number (matches the `micro` OTA image version) |
 | id | *(unconfirmed)*, pipe-separated list |
 | lk | Lock flag *(unconfirmed)* |
-| bp | Battery power (W) *(unconfirmed)* |
+| bp | Battery power (W) |
 | ei | *(unconfirmed)* |
 | eb | *(unconfirmed)* |
-| rp | *(unconfirmed)* power (W) |
-| gp | Grid power (W) *(unconfirmed)* |
+| rp | Battery power (W), calculated. The app overwrites the `bp` reading with this one when its per-model "use calculated power" flag is set (see the note below) |
+| gp | Grid power (W). Only used by the app when the same flag is set; otherwise grid power comes from `grd_o` |
 | vp | *(unconfirmed)* power (W) |
 | bl | *(unconfirmed)* |
 | bl_p | *(unconfirmed)* |
@@ -226,6 +230,16 @@ guesses based on context and cross-referencing other commands:
 | pv | PV energy (Wh), pipe-separated — first component is today's collected PV energy, the last component is the cumulative total (the total is likely but unconfirmed; reading it as the last component leaves room for monthly/yearly values to be added in between) |
 | fu | Surplus feed-in state `enabled\|?` — first component is `1` when surplus feed-in is enabled, `0` when disabled (see `cd=43`) |
 | em | *(unconfirmed)* |
+| peak_status | Peak shaving enabled (0: off; 1: on) (see [Configure peak shaving](#28-configure-peak-shaving)) |
+| peak_power | Peak shaving power cap (W) (see [Configure peak shaving](#28-configure-peak-shaving)) |
+
+> **Note on `bp`, `rp` and `gp`.** The Marstek app shows a single battery-power
+> value and a single grid-power value. Battery power normally comes from `bp`
+> and grid power from `grd_o`, but on some models a "calculated" reading is used
+> instead: `rp` for battery power and `gp` for grid power. Which models those are
+> is not something the payload reveals. On the devices observed so far `gp`
+> matched `grd_o` exactly, while `bp` and `rp` differed slightly (e.g. `bp=291`
+> vs `rp=347`), and all three only appear on models with PV inputs (Venus A/D).
 
 ## 4 Set working status
 
@@ -381,6 +395,8 @@ You will receive a message with a ret value:
 
 ## 11 Set version
 
+Selects the device's rated output power ("power version").
+
 ### 11.1 Public
 
 Topic:
@@ -392,11 +408,38 @@ Payload:
 1. `cd=15,vs=800` - Set up 800W version
 2. `cd=15,vs=2500` - Set up 2500W version
 
+The `vs` parameter is the rated power **in watts**. These are the values the
+Marstek app sends; which of them a given unit accepts depends on its model and
+region:
+
+`600`, `800`, `1200`, `1500`, `2000`, `2200`, `2300`, `2400`, `2500`, `3000`, `3600`
+
 ### 11.2 Receive
 
 You will receive a message with a ret value:
 1. `ret=0` - Setting failed
 2. `ret=1` - Setting successful
+
+The current setting is reported in the `cd=1` response as the `set_v` **code**
+(not the wattage), and the resulting power as `mdp_w`. The codes map to the
+rated powers as follows:
+
+| `set_v` | Rated power |
+|-----|-------------|
+| 0 | Device default: 2500 W on a Venus C/D/E with recent firmware; 800 W on older firmware or on a Venus A below control v148 / inverter v118, 1500 W on a Venus A at or above those versions, and 600 W on the Swiss (`…CH-0`) variants |
+| 1 | 800 W |
+| 2 | 600 W |
+| 3 | 2200 W |
+| 4 | 1200 W |
+| 5 | 1500 W |
+| 6 | 2300 W |
+| 7 | 2000 W |
+| 8 | 3000 W |
+| 9 | 3600 W |
+
+Note that code `0` is **not** the 800 W version — observed device dumps report
+`set_v=0` alongside `mcp_w=2500,mdp_w=2500`, `set_v=1` alongside `mdp_w=800`,
+and `set_v=4` alongside `mdp_w=1200`.
 
 ## 12 Set maximum charging power
 
@@ -420,22 +463,11 @@ You will receive a message with a ret value:
 
 ## 13 Set maximum discharge power
 
-### 13.1 Public
-
-Topic:
-```
-hame_energy/{type}/App/{uid or mac}/ctrl
-```
-
-Payload:
-1. `cd=15,vs=800` - Set up 800W version
-2. `cd=15,vs=2500` - Set up 2500W version
-
-### 13.2 Receive
-
-You will receive a message with a ret value:
-1. `ret=0` - Setting failed
-2. `ret=1` - Setting successful
+The maximum discharge power is not a separate setting: it follows the power
+version, so it is changed with the same `cd=15,vs=<watts>` command as
+[Set version](#11-set-version) and read back as `mdp_w`. (Only the maximum
+*charging* power, `mcp_w`, is independently adjustable — see
+[Set maximum charging power](#12-set-maximum-charging-power).)
 
 ## 14 Set the meter type and supplementary power type
 
@@ -937,3 +969,101 @@ The device echoes the resulting state:
 The current state is also reflected in the `ble` field of the `cd=1` response: it
 is a bitmask where bit 2 (value `4`) is set when advertising is enabled
 (Bluetooth lock off), and `1` when the lock is enabled.
+
+## 28 Configure peak shaving
+
+Peak shaving caps how much power the device draws from the grid, for regions
+that limit the grid connection. Supported from control firmware v150 on the
+Venus D and Venus E (`VNSD`/`VNSE3`); older firmware neither accepts the command
+nor reports the two status fields.
+
+### 28.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+1. `cd=63,as=1,vv=2000` - Enable peak shaving and cap grid draw at 2000 W
+2. `cd=63,as=0` - Disable peak shaving
+
+Description of the above parameters:
+
+| Key | Description |
+|-----|-------------|
+| cd | Instruction identification |
+| as | Enable (0: disable; 1: enable) |
+| vv | Peak power cap in watts. Only sent when enabling; the Marstek app defaults it to 2000 W and does not enforce an upper bound of its own |
+
+### 28.2 Receive
+
+You will receive a message with a ret value:
+1. `ret=0` - Setting failed
+2. `ret=1` - Setting successful
+
+The current state is reported in the `cd=1` response as `peak_status` (0/1) and
+`peak_power` (the cap, in watts).
+
+## 29 Configure parallel operation
+
+Links several units into one group so they operate in parallel, for a higher
+combined output than a single unit can deliver.
+
+This is a wiring-level change, not a software setting: the units have to be
+physically cabled together, and the command only tells them to run in that
+configuration. The Marstek app exposes it under *Parallel Mode Control*, behind
+a "⚠️ Parallel Connection Safety Notice", and the warnings it shows are worth
+repeating verbatim:
+
+> - This function involves high-voltage output. Please ensure correct wiring.
+> - Check all device wiring before operation.
+> - Improper operation may cause device damage. Please proceed with caution.
+> - For all devices in the group, please follow the app instructions carefully.
+> - In parallel mode, the Backup Power function will be unavailable.
+> - For your safety, do not operate under load!
+> - Do not operate unless you are a qualified professional!
+
+The order of operations matters, and differs between enabling and disabling:
+
+- **Enabling**: enable parallel mode first, then power off and reconnect all the
+  wiring ("After enabling parallel mode, power off before reconnecting all
+  wiring. Do not operate under load!").
+- **Disabling**: power off every device in the group and remove the wiring
+  *first*, then disable parallel mode ("Before disabling parallel mode, power
+  off all devices in the group and disconnect wiring. Do not operate under load!
+  After removing all wiring, use the app to turn off parallel mode.").
+
+While a group is in off-grid parallel mode the backup/EPS function is refused
+with "This device is currently in off-grid parallel mode. This function is
+unavailable." — so parallel operation and [the backup function](#10-enable-eps-function)
+are mutually exclusive.
+
+### 29.1 Public
+
+Topic:
+```
+hame_energy/{type}/App/{uid or mac}/ctrl
+```
+
+Payload:
+1. `cd=23,pm=0` - Turn parallel mode off
+2. `cd=23,pm=1` - Run the wiring check
+3. `cd=23,pm=2` - Turn parallel mode on
+
+The app's own flow is to run the wiring check (`pm=1`) first and only send
+`pm=2` once it passes.
+
+### 29.2 Receive
+
+You will receive a message with a ret value:
+1. `ret=0` - Setting failed
+2. `ret=1` - Setting successful
+
+The current state is reported in the `cd=1` response as the `par` field, using
+the same values (0: turned off; 1: wiring check; 2: turned on). Units that do
+not support parallel operation report `255`.
+
+The `pm=1` "wiring check" is the app's own verification step, shown as *Wiring
+Check* in the status line; the app runs it and asks the user to follow the
+on-screen instructions before it sends `pm=2`.

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -6,6 +6,7 @@ import {
 import {
   CommandParams,
   isValidMeterType,
+  isValidVenusParallelMode,
   isValidVenusRechargeMode,
   isValidVenusVersionSet,
   isValidVenusWorkingMode,
@@ -19,6 +20,7 @@ import {
   VenusDeviceData,
   VenusNetworkInfo,
   VenusTimePeriod,
+  VenusVersionSet,
   WeekdaySet,
 } from '../types.js';
 import logger from '../logger.js';
@@ -65,12 +67,14 @@ enum CommandType {
   GET_FC41D_INFO = 10, // -> wifi_v=202409090159
   ENABLE_BACKUP = 11,
   GET_BMS_INFO = 14, // -> b_ver=212,b_chv=571,b_rci=1000,b_rdi=1000,b_soc=65,b_soh=100,b_cap=5120,b_vol=5223,b_cur=-94,b_tem=250,b_chf=192,b_slf=0,b_cpc=332,b_err=0,b_war=0,b_ret=102482070,b_ent=0,b_mot=23,b_tp1=18,b_tp2=19,b_tp3=18,b_tp4=19,b_vo1=3265,b_vo2=3265,b_vo3=3265,b_vo4=3265,b_vo5=3264,b_vo6=3264,b_vo7=3265,b_vo8=3265,b_vo9=3264,b_vo10=3265,b_vo11=3264,b_vo12=3265,b_vo13=3265,b_vo14=3265,b_vo15=3264,b_vo16=3262
+  // `cd=15,vs=<watts>` selects the rated output power ("power version"). The
+  // resulting power is reported back as `mdp_w`, and its code as `set_v`.
   SET_DISCHARGE_POWER = 15,
   SET_MAX_CHARGING_POWER = 16,
-  SET_MAX_DISCHARGE_POWER = 17,
   SET_METER_TYPE = 18, // also used for phase diagnosis via `cd=18,seq_check`
   GET_CT_POWER = 19,
   UPGRADE_FC4_MODULE = 20,
+  SET_PARALLEL_MODE = 23,
   GET_NETWORK_INFO = 26,
   SET_LOCAL_API = 30,
   GET_BMS_PACK_INFO = 42,
@@ -78,12 +82,53 @@ enum CommandType {
   BLUETOOTH_ADVERTISING = 55,
   DEPTH_OF_DISCHARGE = 56,
   SET_LED = 59,
+  SET_PEAK_SHAVING = 63,
 }
 
 // Minimum and maximum Depth of Discharge values based on Marstek app limits (30-88%).
 // NOTE: Experience has shown that these limits may change over time!
 const DOD_MIN = 30;
 const DOD_MAX = 88;
+
+// The `set_v` field is a power-version *code*, not a wattage: it identifies the
+// device's rated output power, which is reported back as `mdp_w`. Code 0 means
+// "device default", which depends on the model and firmware version (2500 W for
+// a Venus C/D/E on recent firmware, less on older firmware, on a Venus A, or on
+// the Swiss variants). The regional variant cannot be told apart from MQTT
+// alone, so 0 is reported as the 2500 W default, which matches every observed
+// device dump (`set_v=0` alongside `mdp_w=2500`). Unknown codes are left
+// unmapped rather than guessed.
+const venusPowerVersions: Record<string, VenusVersionSet> = {
+  '0': '2500W',
+  '1': '800W',
+  '2': '600W',
+  '3': '2200W',
+  '4': '1200W',
+  '5': '1500W',
+  '6': '2300W',
+  '7': '2000W',
+  '8': '3000W',
+  '9': '3600W',
+};
+
+// Peak shaving caps the power drawn from the grid. The Marstek app defaults the
+// cap to 2000 W and does not enforce an upper bound of its own, so the limit
+// below only exists to give the Home Assistant number entity a sane range.
+const PEAK_SHAVING_POWER_DEFAULT = 2000;
+const PEAK_SHAVING_POWER_MAX = 20000;
+
+const venusVersionSetLabels: Record<VenusVersionSet, string> = {
+  '600W': '600W Version',
+  '800W': '800W Version',
+  '1200W': '1200W Version',
+  '1500W': '1500W Version',
+  '2000W': '2000W Version',
+  '2200W': '2200W Version',
+  '2300W': '2300W Version',
+  '2500W': '2500W Version',
+  '3000W': '3000W Version',
+  '3600W': '3600W Version',
+};
 
 /**
  * Process a command for the Venus device
@@ -1135,6 +1180,192 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       },
     });
 
+    // Peak shaving (cd=63), which caps how much power the device draws from the
+    // grid. Reported as `peak_status` (0/1) and `peak_power` (the cap, in W) on
+    // firmware that supports it (control v150 and up on Venus D/E). The device
+    // expects both parts in one command, so enabling sends `cd=63,as=1,vv=<W>`
+    // and disabling sends `cd=63,as=0`.
+    field({
+      key: 'peak_status',
+      path: ['peakShavingEnabled'],
+      transform: equalsBoolean('1'),
+    });
+    advertise(
+      ['peakShavingEnabled'],
+      switchComponent({
+        id: 'peak_shaving',
+        name: 'Peak Shaving',
+        icon: 'mdi:transmission-tower-import',
+        command: 'peak-shaving',
+      }),
+      { enabled: state => (state.peakShavingEnabled != null ? true : undefined) },
+    );
+
+    field({
+      key: 'peak_power',
+      path: ['peakShavingPower'],
+      transform: number(),
+    });
+    advertise(
+      ['peakShavingPower'],
+      numberComponent({
+        id: 'peak_shaving_power',
+        name: 'Peak Shaving Power',
+        icon: 'mdi:flash-alert',
+        unit_of_measurement: 'W',
+        device_class: 'power',
+        command: 'peak-shaving-power',
+        min: 0,
+        max: PEAK_SHAVING_POWER_MAX,
+        step: 1,
+      }),
+      { enabled: state => (state.peakShavingPower != null ? true : undefined) },
+    );
+
+    command('peak-shaving', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        const enable =
+          message.toLowerCase() === 'true' || message.toLowerCase() === 'on' || message === '1';
+        updateDeviceState(state => {
+          publishCallback(
+            enable
+              ? processCommand(CommandType.SET_PEAK_SHAVING, {
+                  as: 1,
+                  vv: state.peakShavingPower ?? PEAK_SHAVING_POWER_DEFAULT,
+                })
+              : processCommand(CommandType.SET_PEAK_SHAVING, { as: 0 }),
+          );
+          return { peakShavingEnabled: enable };
+        });
+      },
+    });
+
+    command('peak-shaving-power', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        const power = parseInt(message, 10);
+        if (isNaN(power) || power < 0 || power > PEAK_SHAVING_POWER_MAX) {
+          logger.warn('Invalid peak shaving power value:', message);
+          return;
+        }
+        updateDeviceState(state => {
+          // Changing the cap only takes effect while peak shaving is on; when it
+          // is off the value is stored and applied the next time it is enabled.
+          if (state.peakShavingEnabled) {
+            publishCallback(processCommand(CommandType.SET_PEAK_SHAVING, { as: 1, vv: power }));
+          }
+          return { peakShavingPower: power };
+        });
+      },
+    });
+
+    // Battery power (bp/rp) and grid power (gp), reported on newer firmware.
+    //
+    // The Marstek app shows a single battery-power value and a single
+    // grid-power value. Battery power normally comes from `bp` and grid power
+    // from `grd_o` (the Combined Power sensor), but on some models the app uses
+    // a "calculated" reading instead: `rp` for battery power and `gp` for grid
+    // power. Which models those are is not something the payload reveals, so
+    // both readings are published, with the calculated one disabled by default.
+    // On the devices seen so far the two differ slightly (e.g. bp=291 vs
+    // rp=347) while `gp` matched `grd_o` exactly.
+    field({
+      key: 'bp',
+      path: ['batteryPower'],
+      transform: number(),
+    });
+    advertise(
+      ['batteryPower'],
+      sensorComponent<number>({
+        id: 'battery_power',
+        name: 'Battery Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+      { enabled: state => (state.batteryPower != null ? true : undefined) },
+    );
+
+    field({
+      key: 'rp',
+      path: ['calculatedBatteryPower'],
+      transform: number(),
+    });
+    advertise(
+      ['calculatedBatteryPower'],
+      sensorComponent<number>({
+        id: 'calculated_battery_power',
+        name: 'Battery Power (Calculated)',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+        enabled_by_default: false,
+      }),
+      { enabled: state => (state.calculatedBatteryPower != null ? true : undefined) },
+    );
+
+    field({
+      key: 'gp',
+      path: ['gridPower'],
+      transform: number(),
+    });
+    advertise(
+      ['gridPower'],
+      sensorComponent<number>({
+        id: 'grid_power',
+        name: 'Grid Power',
+        device_class: 'power',
+        unit_of_measurement: 'W',
+        state_class: 'measurement',
+      }),
+      { enabled: state => (state.gridPower != null ? true : undefined) },
+    );
+
+    // Parallel operation (cd=23), for running two units in parallel. Reported as
+    // the `par` field; units that do not support it report 255, which maps to
+    // `unknown`. Enabling this changes how the units are wired together and the
+    // app guards it behind a wiring-safety notice, so the select is disabled by
+    // default.
+    field({
+      key: 'par',
+      path: ['parallelMode'],
+      transform: map(
+        {
+          '0': 'off',
+          '1': 'wiringCheck',
+          '2': 'on',
+        },
+        'unknown',
+      ),
+    });
+    advertise(
+      ['parallelMode'],
+      selectComponent<NonNullable<VenusDeviceData['parallelMode']>>({
+        id: 'parallel_mode',
+        name: 'Parallel Mode',
+        icon: 'mdi:call-split',
+        command: 'parallel-mode',
+        valueMappings: {
+          off: 'Turned Off',
+          wiringCheck: 'Wiring Check',
+          on: 'Turned On',
+          unknown: 'Unknown',
+        },
+        enabled_by_default: false,
+      }),
+      { enabled: state => (state.parallelMode != null ? true : undefined) },
+    );
+    command('parallel-mode', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        if (!isValidVenusParallelMode(message)) {
+          logger.warn('Invalid parallel mode value:', message);
+          return;
+        }
+        const mode = { off: 0, wiringCheck: 1, on: 2 }[message];
+        updateDeviceState(() => ({ parallelMode: message }));
+        publishCallback(processCommand(CommandType.SET_PARALLEL_MODE, { pm: mode }));
+      },
+    });
+
     // Inverter / micro module version (inv_v), reported on newer firmware.
     field({
       key: 'inv_v',
@@ -1306,7 +1537,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     field({
       key: 'set_v',
       path: ['versionSet'],
-      transform: map({ '0': '800W' }, '2500W'),
+      transform: map(venusPowerVersions),
     });
     advertise(
       ['versionSet'],
@@ -1315,11 +1546,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Version Set',
         icon: 'mdi:power-socket',
         command: 'version-set',
-        valueMappings: {
-          '800W': '800W Version',
-          '2500W': '2500W Version',
-        },
+        valueMappings: venusVersionSetLabels,
       }),
+      { enabled: state => (state.versionSet != null ? true : undefined) },
     );
 
     command('version-set', {
@@ -1333,7 +1562,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           versionSet: message,
         }));
 
-        const version = message === '2500W' ? 2500 : 800;
+        // The command carries the rated power in watts, not the `set_v` code.
+        const version = parseInt(message, 10);
         publishCallback(processCommand(CommandType.SET_DISCHARGE_POWER, { vs: version }));
       },
     });

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -865,6 +865,21 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: 'cd=15,vs=2500',
   },
   {
+    // The command carries the rated power in watts, not the set_v code.
+    description: 'Venus version-set 1200W',
+    deviceType: 'HMG-1',
+    command: 'version-set',
+    input: '1200W',
+    expectedOutput: 'cd=15,vs=1200',
+  },
+  {
+    description: 'Venus version-set 3600W',
+    deviceType: 'HMG-1',
+    command: 'version-set',
+    input: '3600W',
+    expectedOutput: 'cd=15,vs=3600',
+  },
+  {
     description: 'Venus version-set invalid',
     deviceType: 'HMG-1',
     command: 'version-set',
@@ -1032,6 +1047,86 @@ const commandTestCases: CommandTestCase[] = [
     initialState: { deviceVersion: 153 },
     command: 'local-api-port',
     input: '70000',
+    expectedOutput: null,
+  },
+
+  // parallel-mode command (cd=23)
+  {
+    description: 'Venus parallel-mode on',
+    deviceType: 'HMG-1',
+    command: 'parallel-mode',
+    input: 'on',
+    expectedOutput: 'cd=23,pm=2',
+  },
+  {
+    description: 'Venus parallel-mode wiring check',
+    deviceType: 'HMG-1',
+    command: 'parallel-mode',
+    input: 'wiringCheck',
+    expectedOutput: 'cd=23,pm=1',
+  },
+  {
+    description: 'Venus parallel-mode off',
+    deviceType: 'HMG-1',
+    command: 'parallel-mode',
+    input: 'off',
+    expectedOutput: 'cd=23,pm=0',
+  },
+  {
+    description: 'Venus parallel-mode rejects the read-only unknown state',
+    deviceType: 'HMG-1',
+    command: 'parallel-mode',
+    input: 'unknown',
+    expectedOutput: null,
+  },
+
+  // peak-shaving commands (cd=63)
+  {
+    description: 'Venus peak-shaving enable uses the configured cap',
+    deviceType: 'HMG-1',
+    initialState: { peakShavingPower: 4500 },
+    command: 'peak-shaving',
+    input: 'true',
+    expectedOutput: 'cd=63,as=1,vv=4500',
+  },
+  {
+    description: 'Venus peak-shaving enable falls back to the app default cap',
+    deviceType: 'HMG-1',
+    command: 'peak-shaving',
+    input: 'ON',
+    expectedOutput: 'cd=63,as=1,vv=2000',
+  },
+  {
+    description: 'Venus peak-shaving disable omits the cap',
+    deviceType: 'HMG-1',
+    initialState: { peakShavingPower: 4500 },
+    command: 'peak-shaving',
+    input: 'false',
+    expectedOutput: 'cd=63,as=0',
+  },
+  {
+    description: 'Venus peak-shaving-power while enabled re-applies the cap',
+    deviceType: 'HMG-1',
+    initialState: { peakShavingEnabled: true },
+    command: 'peak-shaving-power',
+    input: '3000',
+    expectedOutput: 'cd=63,as=1,vv=3000',
+  },
+  {
+    description: 'Venus peak-shaving-power while disabled only stores the cap',
+    deviceType: 'HMG-1',
+    initialState: { peakShavingEnabled: false },
+    command: 'peak-shaving-power',
+    input: '3000',
+    expectedOutput: null,
+    expectedStateChanges: { peakShavingPower: 3000 },
+  },
+  {
+    description: 'Venus peak-shaving-power invalid',
+    deviceType: 'HMG-1',
+    initialState: { peakShavingEnabled: true },
+    command: 'peak-shaving-power',
+    input: 'nonsense',
     expectedOutput: null,
   },
 

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -409,6 +409,40 @@ describe('Home Assistant Discovery', () => {
     expect(withPv.some(t => t.includes('pv4_'))).toBe(false);
   });
 
+  test('should advertise the Venus parallel mode select disabled by default', () => {
+    const device: Device = { deviceType: 'VNSD-0', deviceId: 'venusD123' };
+    const deviceTopics: DeviceTopics = {
+      deviceTopicOld: 'hame_energy/VNSD-0/device/venusD123/ctrl',
+      deviceTopicNew: 'marstek_energy/VNSD-0/device/venusD123/ctrl',
+      deviceControlTopicOld: 'hame_energy/VNSD-0/App/venusD123/ctrl',
+      deviceControlTopicNew: 'marstek_energy/VNSD-0/App/venusD123/ctrl',
+      availabilityTopic: 'hame_energy/VNSD-0/availability/venusD123',
+      controlSubscriptionTopic: 'hame_energy/VNSD-0/control/venusD123/control',
+      publishTopic: 'hame_energy/VNSD-0/device/venusD123/data',
+    };
+    const configsFor = (state: object) =>
+      generateDiscoveryConfigs(
+        device,
+        deviceTopics,
+        {},
+        DEFAULT_TOPIC_PREFIX,
+        'homeassistant',
+        state,
+      );
+
+    // Without a par reading the select stays deferred
+    expect(
+      configsFor({ batterySoc: 94 }).some(c => c.topic.includes('/parallel_mode/config')),
+    ).toBe(false);
+
+    // Enabling parallel operation rewires the units and disables backup power,
+    // so the control must never be advertised as enabled by default.
+    const config = configsFor({ parallelMode: 'off' }).find(c =>
+      c.topic.includes('/parallel_mode/config'),
+    )?.config;
+    expect(config).toMatchObject({ enabled_by_default: false });
+  });
+
   test('should generate discovery configs for the SMR smart meter reader', () => {
     const device: Device = { deviceType: 'SMR-0', deviceId: 'b8d08fc5f943' };
     const deviceTopics: DeviceTopics = {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -935,6 +935,36 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('bmsVersion', 116);
     expect(result).toHaveProperty('communicationModuleVersion', '202409090159');
     expect(result).toHaveProperty('shellyPort', 1010);
+    // set_v is a power-version code, not a wattage: 1 is the 800W version,
+    // which the same dump confirms via mdp_w=800.
+    expect(result).toHaveProperty('versionSet', '800W');
+    expect(result).toHaveProperty('maxDischargePower', 800);
+  });
+
+  test('maps the Venus set_v power-version code to the rated power', () => {
+    const base =
+      'cd=1,tot_i=1,tot_o=212,ele_d=0,ele_m=1,grd_d=212,grd_m=212,inc_d=0,inc_m=0,grd_f=0,grd_o=423,grd_t=3,gct_s=1,cel_s=2,cel_p=483,cel_c=94,err_t=0,err_a=0,dev_n=142,grd_y=0,wor_m=0,inc_a=0';
+    const expected: Record<string, string> = {
+      '0': '2500W',
+      '1': '800W',
+      '2': '600W',
+      '3': '2200W',
+      '4': '1200W',
+      '5': '1500W',
+      '6': '2300W',
+      '7': '2000W',
+      '8': '3000W',
+      '9': '3600W',
+    };
+
+    for (const [code, label] of Object.entries(expected)) {
+      const parsed = parseMessage(`${base},set_v=${code}`, 'VNSD-0', 'venusD123');
+      expect((parsed['data'] as VenusDeviceData).versionSet).toBe(label);
+    }
+
+    // Unknown codes are left unmapped rather than guessed.
+    const unknown = parseMessage(`${base},set_v=42`, 'VNSD-0', 'venusD123');
+    expect((unknown['data'] as VenusDeviceData).versionSet).toBeUndefined();
   });
 
   test('parses Venus v147 LED, backup, inverter/MPPT version and phase-diagnosis fields', () => {
@@ -950,6 +980,47 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('inverterVersion', 115);
     expect(result).toHaveProperty('mpptVersion', 104);
     expect(result).toHaveProperty('phaseDiagnosisStatus', 3);
+    // Battery and grid power, reported as bp/rp/gp
+    expect(result).toHaveProperty('batteryPower', 291);
+    expect(result).toHaveProperty('calculatedBatteryPower', 347);
+    expect(result).toHaveProperty('gridPower', 801);
+    // par=0 means parallel operation is turned off
+    expect(result).toHaveProperty('parallelMode', 'off');
+    // This firmware predates peak shaving, so it reports neither field
+    expect(result.peakShavingEnabled).toBeUndefined();
+    expect(result.peakShavingPower).toBeUndefined();
+  });
+
+  test('maps the Venus par field to the parallel mode', () => {
+    const base =
+      'cd=1,tot_i=6,tot_o=1109,ele_d=0,ele_m=0,grd_d=27,grd_m=27,inc_d=0,inc_m=0,grd_f=0,grd_o=801,grd_t=3,gct_s=1,cel_s=2,cel_p=233,cel_c=45,err_t=0,err_a=0,dev_n=147,grd_y=0,wor_m=5,inc_a=0';
+    const expected: Record<string, string> = {
+      '0': 'off',
+      '1': 'wiringCheck',
+      '2': 'on',
+      // Units without parallel support report 255
+      '255': 'unknown',
+    };
+
+    for (const [raw, mode] of Object.entries(expected)) {
+      const parsed = parseMessage(`${base},par=${raw}`, 'VNSD-0', 'venusD123');
+      expect((parsed['data'] as VenusDeviceData).parallelMode).toBe(mode);
+    }
+  });
+
+  test('parses Venus peak shaving state (peak_status/peak_power)', () => {
+    const base =
+      'cd=1,tot_i=6,tot_o=1109,ele_d=0,ele_m=0,grd_d=27,grd_m=27,inc_d=0,inc_m=0,grd_f=0,grd_o=801,grd_t=3,gct_s=1,cel_s=2,cel_p=233,cel_c=45,err_t=0,err_a=0,dev_n=150,grd_y=0,wor_m=5,inc_a=0';
+
+    const on = parseMessage(`${base},peak_status=1,peak_power=4000`, 'VNSD-0', 'venusD123');
+    const onResult = on['data'] as VenusDeviceData;
+    expect(onResult).toHaveProperty('peakShavingEnabled', true);
+    expect(onResult).toHaveProperty('peakShavingPower', 4000);
+
+    const off = parseMessage(`${base},peak_status=0,peak_power=2000`, 'VNSD-0', 'venusD123');
+    const offResult = off['data'] as VenusDeviceData;
+    expect(offResult).toHaveProperty('peakShavingEnabled', false);
+    expect(offResult).toHaveProperty('peakShavingPower', 2000);
   });
 
   test('parses Venus surplus feed-in state from the fu field', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,6 +304,18 @@ export type VenusCTType = 'none' | 'ct1' | 'ct2' | 'ct3' | 'shellyPro' | 'p1Mete
 export type VenusPhaseType = 'unknown' | 'phaseA' | 'phaseB' | 'phaseC' | 'notDetected';
 
 /**
+ * Venus parallel-operation mode, reported as the `par` field and set with
+ * `cd=23,pm=`. Values other than 0-2 (e.g. the 255 reported by units that do not
+ * support parallel operation) are reported as `unknown`.
+ */
+const validVenusParallelModes = ['off', 'wiringCheck', 'on'] as const;
+export type VenusParallelMode = (typeof validVenusParallelModes)[number];
+
+export function isValidVenusParallelMode(mode: string): mode is VenusParallelMode {
+  return validVenusParallelModes.includes(mode as VenusParallelMode);
+}
+
+/**
  * Venus device recharge mode
  */
 const validVenusRechargeModes = ['singlePhase', 'threePhase'] as const;
@@ -388,7 +400,22 @@ export function resolveMeterMac(meterType: MeterType, configuredMac?: string): s
 
 export type WeekdaySet = `${0 | ''}${1 | ''}${2 | ''}${3 | ''}${4 | ''}${5 | ''}${6 | ''}`;
 
-const venusValidVersionSets = ['800W', '2500W'] as const;
+// Rated output power ("power version") of a Venus. The device reports this as a
+// numeric code in the `set_v` field, while the `cd=15,vs=` command takes the
+// rated power in watts. These are the power versions the Marstek app offers;
+// which of them a given unit accepts depends on its model and region.
+const venusValidVersionSets = [
+  '600W',
+  '800W',
+  '1200W',
+  '1500W',
+  '2000W',
+  '2200W',
+  '2300W',
+  '2500W',
+  '3000W',
+  '3600W',
+] as const;
 export type VenusVersionSet = (typeof venusValidVersionSets)[number];
 
 export function isValidVenusVersionSet(set: string): set is VenusVersionSet {
@@ -492,6 +519,12 @@ export interface VenusDeviceData extends BaseDeviceData {
   phaseDiagnosisStatus?: number; // seq_s
   inverterVersion?: number; // inv_v
   mpptVersion?: number; // mppt
+  peakShavingEnabled?: boolean; // peak_status
+  peakShavingPower?: number; // peak_power
+  batteryPower?: number; // bp
+  calculatedBatteryPower?: number; // rp
+  gridPower?: number; // gp
+  parallelMode?: VenusParallelMode | 'unknown'; // par
 }
 
 export interface VenusBMSInfo extends BaseDeviceData {


### PR DESCRIPTION
## Summary

Extends Venus device support with three new features and improved power-version handling:

1. **Peak shaving control** (`cd=63`) — caps grid power draw for regions with grid-connection limits
2. **Parallel operation mode** (`cd=23`) — enables linking multiple units for higher combined output
3. **Battery and grid power sensors** — exposes `bp`, `rp`, and `gp` fields as separate sensors
4. **Power-version mapping overhaul** — expands from 2 to 10 supported power versions and fixes `set_v` code-to-wattage translation

## Key Changes

- **Peak shaving** (`peak-shaving` and `peak-shaving-power` commands):
  - Toggle with `cd=63,as=1,vv=<W>` (enable) or `cd=63,as=0` (disable)
  - Defaults to 2000 W cap when enabled without a stored value
  - Only re-applies cap to device when peak shaving is already on; stores value when off
  - Supported on control v150+ (Venus D/E)

- **Parallel mode** (`parallel-mode` command):
  - Three states: `off` (0), `wiringCheck` (1), `on` (2)
  - Disabled by default in Home Assistant due to safety implications (high-voltage wiring change)
  - Maps device's `par` field (0/1/2/255) to user-friendly labels

- **Power sensors**:
  - `batteryPower` (bp) — primary battery power reading
  - `calculatedBatteryPower` (rp) — app-calculated alternative, disabled by default
  - `gridPower` (gp) — grid power reading
  - All published as separate sensors with power device class

- **Power-version expansion**:
  - Added support for 600W, 1200W, 1500W, 2000W, 2200W, 2300W, 3000W, 3600W (was only 800W/2500W)
  - Fixed `set_v` code mapping: code 0 = 2500W default (not 800W), code 1 = 800W, etc.
  - Command now sends rated power in watts (`vs=<watts>`) instead of hardcoded values
  - Unknown codes left unmapped rather than guessed

- **Documentation updates**:
  - Clarified `set_v` as a power-version *code*, not wattage
  - Added detailed mapping table for all 10 power-version codes
  - Documented `bp`/`rp`/`gp` behavior and per-model selection logic
  - Added full parallel-mode safety warnings from Marstek app
  - Removed obsolete "Set maximum discharge power" section (now follows power-version)

## Validation

- All new commands covered by test cases (parallel-mode, peak-shaving, peak-shaving-power, version-set variants)
- Parser tests verify power-version code mapping and new sensor fields
- Discovery config test confirms parallel-mode select disabled by default
- Existing tests remain passing

https://claude.ai/code/session_01RyoYxT32n5aZep3iwsSZN8