### PR TITLE
B2500: Document and fix WiFi signal, CT config, and time sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Jupiter: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP). They appear once the device reports them and are disabled by default.
 - B2500: Add a *WiFi Signal Strength* sensor, in dBm. The device reports two "no reading" values (`0` and `32767`); both are published as unknown rather than as a signal level.
 - B2500 V2/V3: Add a *CT Type* sensor, disabled by default, showing which meter the device is currently configured for (CT001, CT002, CT003, Shelly Pro 3EM, Shelly EM Gen3, Shelly Pro EM50, P1 Meter or EcoTracker) — so the write-only *Meter Type* select can be checked against what the device actually took.
+- B2500 V2/V3: Add a *Recharge Mode* select (single/three phase) and a *Phase Diagnosis* button, matching the Venus and Jupiter. Both are disabled by default. The device never reports the recharge mode back, so that entity shows the last value set rather than the device's own state; phase diagnosis progress shows up on the existing *CT Status* sensor.
+- B2500, Venus & Jupiter: Add *EcoTracker* to the *Meter Type* options.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Jupiter: Add a *Battery Pack Recovery* button to reactivate an unresponsive battery pack. Jupiter Plus only, firmware 135 or newer, disabled by default.
 - Jupiter: Add a *Screen Version* and a *Shelly Port* sensor, both disabled by default.
 - Jupiter: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP). They appear once the device reports them and are disabled by default.
+- B2500: Add a *WiFi Signal Strength* sensor, in dBm, matching the equivalent Venus and Jupiter sensor. `0` means no signal.
+- B2500 V2/V3: Add *CT Type* and *Phase Type* sensors, disabled by default. *CT Type* shows which meter the device is currently configured for, so the write-only *Meter Type* select can be checked against what the device actually took. Both report raw numbers rather than named values.
 
 ### Fixed
 
@@ -28,7 +30,8 @@
 - CT002: Stop logging a spurious `Invalid topic empty_topic_list` subscription error on startup for devices without any controls (fixes #371)
 - Jupiter: *Meter Type* and *Recharge Mode* were sent using the Venus command, so neither setting ever reached the device.
 - Venus & Jupiter: *Sync Time* set the device clock one month too early — and to the previous year every January.
-
+- B2500 V2/V3: *Sync Time* left the device clock wrong by your UTC offset — an hour or more for most users. It now sets the correct local time.
+- B2500 V2/V3: `sync-time` rejected a JSON payload whenever any field was `0`, so January, midnight, a zero minute or second, and UTC+0 all failed with "Missing time parameters".
 
 ## [1.8.1] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
 - Jupiter: Add a *Battery Pack Recovery* button to reactivate an unresponsive battery pack. Jupiter Plus only, firmware 135 or newer, disabled by default.
 - Jupiter: Add a *Screen Version* and a *Shelly Port* sensor, both disabled by default.
 - Jupiter: Add *Network* sensors (IP Address, Gateway, Subnet Mask, DNS Server, CT Connect IP). They appear once the device reports them and are disabled by default.
-- B2500: Add a *WiFi Signal Strength* sensor, in dBm, matching the equivalent Venus and Jupiter sensor. `0` means no signal.
-- B2500 V2/V3: Add *CT Type* and *Phase Type* sensors, disabled by default. *CT Type* shows which meter the device is currently configured for, so the write-only *Meter Type* select can be checked against what the device actually took. Both report raw numbers rather than named values.
+- B2500: Add a *WiFi Signal Strength* sensor, in dBm. The device reports two "no reading" values (`0` and `32767`); both are published as unknown rather than as a signal level.
+- B2500 V2/V3: Add a *CT Type* sensor, disabled by default, showing which meter the device is currently configured for (CT001, CT002, CT003, Shelly Pro 3EM, Shelly EM Gen3, Shelly Pro EM50, P1 Meter or EcoTracker) — so the write-only *Meter Type* select can be checked against what the device actually took.
 
 ### Fixed
 
@@ -32,6 +32,8 @@
 - Venus & Jupiter: *Sync Time* set the device clock one month too early — and to the previous year every January.
 - B2500 V2/V3: *Sync Time* left the device clock wrong by your UTC offset — an hour or more for most users. It now sets the correct local time.
 - B2500 V2/V3: `sync-time` rejected a JSON payload whenever any field was `0`, so January, midnight, a zero minute or second, and UTC+0 all failed with "Missing time parameters".
+- B2500: Only the first 14 of the 16 cell voltages each battery pack reports were read. The last two are now published, and the *Min*/*Max*/*Average*/*Difference* cell sensors take them into account.
+- B2500 V2/V3: `connected-phase` accepted values the device ignores. It now takes `0`-`3` and `255` only, matching what the device acts on.
 
 ## [1.8.1] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - B2500 V2/V3: *Sync Time* left the device clock wrong by your UTC offset — an hour or more for most users. It now sets the correct local time.
 - B2500 V2/V3: `sync-time` rejected a JSON payload whenever any field was `0`, so January, midnight, a zero minute or second, and UTC+0 all failed with "Missing time parameters".
 - B2500: Only the first 14 of the 16 cell voltages each battery pack reports were read. The last two are now published, and the *Min*/*Max*/*Average*/*Difference* cell sensors take them into account.
-- B2500 V2/V3: `connected-phase` accepted values the device ignores. It now takes `0`-`3` and `255` only, matching what the device acts on.
+- B2500 V2/V3: The *CT Connected Phase* select offered a *Searching* option that never worked — picking it logged `Invalid connected phase value: searching` and sent nothing. It now sends the value the device takes for that state. The command also accepts `0`-`3` and `255` only, matching what the device acts on, instead of silently forwarding values it ignores.
 
 ## [1.8.1] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -626,12 +626,14 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `time-zone`: Sets time zone (UTC offset in minutes, e.g. `60` for UTC+1)
 - `sync-time`: Synchronizes device time with server
 - `surplus-feed-in`: Toggles Surplus Feed-in mode (`on` or `off`). When enabled, surplus PV power is fed into the home grid when the battery is nearly full.
+- `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`). The device does not report this back, so the entity shows the last value set.
+- `phase-diagnosis`: Starts grid-phase detection. Progress shows up on the *CT Status* sensor.
 
 ### Venus Device Commands
 - `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`). The `ai` value expands to `cd=2,md=5,nl=1` (AI mode requires both `md=5` and `nl=1`).
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
 - `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped)
-- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, or `shellyProEm50`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
+- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, `shellyProEm50` or `ecoTracker`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
 - `auto-switch-working-mode`: Toggles automatic mode switching (`on` or `off`)
 - `time-period/[0-9]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-9]/start-time`: Sets start time for period (HH:MM format)
@@ -683,7 +685,7 @@ The following commands are supported by both Jupiter C, Jupiter E and Jupiter Pl
 - `working-mode`: Sets working mode (`automatic`, `manual`, or `ai`). The `ai` value expands to `cd=2,md=5,nl=1` (AI mode requires both `md=5` and `nl=1`).
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
 - `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped)
-- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, or `shellyProEm50`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
+- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, `shellyProEm50` or `ecoTracker`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
 - `bluetooth-advertising`: Toggles Bluetooth advertising (`on` enables advertising, `off` disables it / "Bluetooth lock"). Requires firmware 141 or newer.
 - `phase-diagnosis`: Starts the grid-phase detection routine
 - `battery-pack-recovery`: Reactivates an unresponsive battery pack. Jupiter Plus only, firmware 135 or newer.

--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `time-period/[1-5]/start-time`: Sets start time for period (HH:MM format)
 - `time-period/[1-5]/end-time`: Sets end time for period (HH:MM format)
 - `time-period/[1-5]/output-value`: Sets output power for period (0-800W)
-- `connected-phase`: Sets connected phase for CT meter (`0`, `1` or `2` for phase 1, 2 and 3, or `255`/`none` for no phase)
+- `connected-phase`: Sets connected phase for CT meter (`0`, `1` or `2` for phase 1, 2 and 3, `3`/`searching` for the searching state, or `255`/`none` for no phase)
 - `time-zone`: Sets time zone (UTC offset in minutes, e.g. `60` for UTC+1)
 - `sync-time`: Synchronizes device time with server
 - `surplus-feed-in`: Toggles Surplus Feed-in mode (`on` or `off`). When enabled, surplus PV power is fed into the home grid when the battery is nearly full.

--- a/README.md
+++ b/README.md
@@ -622,8 +622,8 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `time-period/[1-5]/start-time`: Sets start time for period (HH:MM format)
 - `time-period/[1-5]/end-time`: Sets end time for period (HH:MM format)
 - `time-period/[1-5]/output-value`: Sets output power for period (0-800W)
-- `connected-phase`: Sets connected phase for CT meter (`1`, `2`, or `3`)
-- `time-zone`: Sets time zone (UTC offset in hours)
+- `connected-phase`: Sets connected phase for CT meter (`0`, `1` or `2` for phase 1, 2 and 3, or `255`/`none` for no phase)
+- `time-zone`: Sets time zone (UTC offset in minutes, e.g. `60` for UTC+1)
 - `sync-time`: Synchronizes device time with server
 - `surplus-feed-in`: Toggles Surplus Feed-in mode (`on` or `off`). When enabled, surplus PV power is fed into the home grid when the battery is nearly full.
 

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -259,11 +259,12 @@ m0=0,m1=0,m2=0,m3=0,lmo=800,lmi=800,lmf=0
 | `fc` | FC4.2D chip version string |
 | `id` ¹ | Device ID number |
 | `uv` | Bootloader version |
-| `am` | Unknown |
+| `am` | Temperature warning state. The value space is unconfirmed |
 | `fktc` ³ | Unknown |
-| `ws` | Wi-Fi signal strength |
+| `ws` | Wi-Fi signal strength, as an unsigned RSSI magnitude in dBm — negate it to get the actual value (e.g. `79` → -79 dBm), and `0` means "no signal". Same convention and semantics as the Venus/Jupiter `wif_s`; the app carries this field under that name |
 | `tc_dis` | Surplus feed-in disabled (`0`=enabled, `1`=disabled) — V2 |
-| `sm` | Unknown |
+| `sm` | Combination/multi-device model. Probably related to the `cd=29` multi-device mode |
+| `ts` | Reported but unused; meaning unknown |
 | `bn` | Unknown |
 
 **Temperature**
@@ -321,6 +322,10 @@ m0=0,m1=0,m2=0,m3=0,lmo=800,lmi=800,lmf=0
 | `m1` | CT clip 2 measured power | W |
 | `m2` | CT clip 3 measured power | W |
 | `m3` | Micro-inverter real-time power | W |
+| `ct_t` | The CT/smart-meter type the device is currently configured for, echoing what was set with `cd=27`. Not confirmed to use the same code space as the `meter=` parameter |
+| `phase_t` | The CT's connected phase. Newer counterpart to `c0`; the numeric code space is unconfirmed |
+| `seq_a` | CT search/diagnosis state |
+| `seq_s` | CT sequence status |
 
 CT status values (`c1`):
 
@@ -465,7 +470,7 @@ Some settings can be written to flash (persisted across reboots) or applied tran
 | Discharge mode (V1) / Adaptive mode (V2) | 4 | 18 | 214.1 |
 | Discharge depth | 5 | 19 | 214.1 |
 | Timed discharge | 7 | 20 | 214.1 |
-| Battery output threshold | 6 | 6 | — |
+| Battery output threshold (V1 only, see below) | 6 | 6 | — |
 | Time zone | 9 | 9 | — |
 | Sync time | 8 | 8 | — |
 | Set CT phase | 22 | 22 | — |
@@ -558,7 +563,18 @@ Range: 0–100 (%).
 cd=06,md=300
 ```
 
-Range: 0–800 (W). The device only begins discharging when the load exceeds this value. No flash/no-flash distinction; always persisted.
+The device only begins discharging when the load exceeds this value. No
+flash/no-flash distinction; always persisted.
+
+> **V1 only.** The app renders this setting only when the device type is `HMB`,
+> and hides it on every V2 model (`HMA`/`HMF`/`HMJ`/`HMK`), which report the
+> current value in `lv` but offer no way to change it. Whether V2 firmware would
+> accept `cd=06` anyway is unconfirmed, so hm2mqtt exposes the setting as
+> writable on the V1 and read-only on the V2.
+>
+> The app's input hint gives the range as **1-500**, while hm2mqtt has long
+> accepted 0-800. Which bound the firmware actually enforces is unconfirmed, so
+> hm2mqtt's range is left as-is.
 
 ---
 
@@ -594,9 +610,13 @@ cd=08,wy=60,yy=124,mm=0,rr=15,hh=10,mn=30,ss=0
 | `yy` | Year minus 1900 (e.g. `124` for 2024) |
 | `mm` | Month, 0-indexed (0 = January, 11 = December) |
 | `rr` | Day of month (1–31) |
-| `hh` | Hour, UTC (0–23) |
+| `hh` | Hour (0–23) |
 | `mn` | Minute (0–59) |
 | `ss` | Second (0–59) |
+
+> **Note:** `yy`–`ss` are **local** wall-clock values, paired with the offset of
+> that same zone in `wy` — not UTC. Sending UTC components with a non-zero `wy`
+> leaves the device clock wrong by the offset.
 
 ---
 
@@ -619,6 +639,20 @@ cd=22,md=2    ← phase 3
 cd=22,md=255  ← none / automatic
 ```
 
+> **Unverified.** The table above is not confirmed. The only two payloads known
+> to be sent in practice are
+>
+> ```
+> cd=22,,md=01     ← from the firmware-216 discharge settings
+> cd=22,,md=255    ← clear / none
+> ```
+>
+> Note the empty field between the two commas and the zero-padded `01`. Whether
+> the device also accepts the single-comma, unpadded `cd=22,md=<n>` that hm2mqtt
+> sends, and whether it accepts any value beyond these two, is unknown — there
+> appears to be no way to pick a specific phase by hand. Reports from real
+> hardware welcome.
+
 ---
 
 #### Set smart meter type (V2 only)
@@ -631,14 +665,21 @@ Supported meter types and their command codes:
 
 | Meter type | `meter` code | MAC required |
 |---|---|---|
-| CT001 (built-in) | 0 | No (send `mac=0`) |
-| CT002 | 1 | Yes |
-| CT003 | 2 | Yes |
-| Shelly Pro 3EM | 3 | Yes |
-| Shelly EM Gen3 | 4 | Yes |
-| Shelly Pro EM-50 | 5 | Yes |
+| CT001 (built-in) | 0 | No (send an all-zero MAC) |
+| Shelly Pro 3EM | 1 | Fixed `000000000000` |
+| P1 Meter | 2 | Yes |
+| CT002 | 3 | Yes |
+| CT003 | 4 | Yes |
 
 MAC format: 12 hex digits, no separators (e.g. `AABBCCDDEEFF`).
+
+These are the same codes the Venus and Jupiter use for `cd=18` (see
+[docs/venus.md](venus.md)); only the command number differs. An earlier revision
+of this document listed a different sequence, which was wrong.
+
+A "Marstek CT001.5" also uses `meter=0`. Shelly EM Gen3 (`5`) and Shelly Pro
+EM50 (`6`) are offered for the Venus but not the B2500, so it is unconfirmed
+whether a B2500 accepts them.
 
 ---
 

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -261,7 +261,7 @@ m0=0,m1=0,m2=0,m3=0,lmo=800,lmi=800,lmf=0
 | `uv` | Bootloader version |
 | `am` | Temperature warning state. The value space is unconfirmed |
 | `fktc` ³ | Unknown |
-| `ws` | Wi-Fi signal strength, as an unsigned RSSI magnitude in dBm — negate it to get the actual value (e.g. `79` → -79 dBm), and `0` means "no signal". Same convention and semantics as the Venus/Jupiter `wif_s`; the app carries this field under that name |
+| `ws` | Wi-Fi RSSI in dBm, **already signed** (e.g. `ws=-79`) — unlike the Venus/Jupiter `wif_s`, which is an unsigned magnitude. Two sentinels mean "no reading": `0` before the Wi-Fi module reports any state, and `32767` (INT16_MAX) while the association is down |
 | `tc_dis` | Surplus feed-in disabled (`0`=enabled, `1`=disabled) — V2 |
 | `sm` | Combination/multi-device model. Probably related to the `cd=29` multi-device mode |
 | `ts` | Reported but unused; meaning unknown |
@@ -322,10 +322,7 @@ m0=0,m1=0,m2=0,m3=0,lmo=800,lmi=800,lmf=0
 | `m1` | CT clip 2 measured power | W |
 | `m2` | CT clip 3 measured power | W |
 | `m3` | Micro-inverter real-time power | W |
-| `ct_t` | The CT/smart-meter type the device is currently configured for, echoing what was set with `cd=27`. Not confirmed to use the same code space as the `meter=` parameter |
-| `phase_t` | The CT's connected phase. Newer counterpart to `c0`; the numeric code space is unconfirmed |
-| `seq_a` | CT search/diagnosis state |
-| `seq_s` | CT sequence status |
+| `ct_t` | The CT/smart-meter type the device is currently configured for. **It does not use the same codes as the `cd=27,meter=` parameter** — see the table below |
 
 CT status values (`c1`):
 
@@ -361,9 +358,12 @@ Triggered by sending `cd=13`. Returns individual cell voltages for all connected
 
 | Key pattern | Description | Unit |
 |---|---|---|
-| `a0`–`ad` | Host battery cell voltages (14 cells) | mV |
-| `b0`–`bd` | Extra battery 1 cell voltages (14 cells) | mV |
-| `c0`–`cd` | Extra battery 2 cell voltages (14 cells) | mV |
+| `a0`–`af` | Host battery cell voltages (16 slots) | mV |
+| `b0`–`bf` | Extra battery 1 cell voltages (16 slots) | mV |
+| `c0`–`cf` | Extra battery 2 cell voltages (16 slots) | mV |
+
+Each pack has **16** slots, not 14. Packs with fewer physical cells report the
+unused slots, so a slot reading `0` is not necessarily an error.
 
 ---
 
@@ -566,11 +566,11 @@ cd=06,md=300
 The device only begins discharging when the load exceeds this value. No
 flash/no-flash distinction; always persisted.
 
-> **V1 only.** The app renders this setting only when the device type is `HMB`,
-> and hides it on every V2 model (`HMA`/`HMF`/`HMJ`/`HMK`), which report the
-> current value in `lv` but offer no way to change it. Whether V2 firmware would
-> accept `cd=06` anyway is unconfirmed, so hm2mqtt exposes the setting as
-> writable on the V1 and read-only on the V2.
+> **V1 only — confirmed.** V2 firmware does not implement this command at all:
+> its command dispatch table maps `cd=6` to the same "no handler" target as the
+> unused codes `cd=0` and `cd=2`, so the message is parsed and then dropped. V2
+> models still report the current value in `lv`, so hm2mqtt exposes the setting
+> as writable on the V1 and read-only on the V2.
 >
 > The app's input hint gives the range as **1-500**, while hm2mqtt has long
 > accepted 0-800. Which bound the firmware actually enforces is unconfirmed, so
@@ -639,19 +639,13 @@ cd=22,md=2    ← phase 3
 cd=22,md=255  ← none / automatic
 ```
 
-> **Unverified.** The table above is not confirmed. The only two payloads known
-> to be sent in practice are
->
-> ```
-> cd=22,,md=01     ← from the firmware-216 discharge settings
-> cd=22,,md=255    ← clear / none
-> ```
->
-> Note the empty field between the two commas and the zero-padded `01`. Whether
-> the device also accepts the single-comma, unpadded `cd=22,md=<n>` that hm2mqtt
-> sends, and whether it accepts any value beyond these two, is unknown — there
-> appears to be no way to pick a specific phase by hand. Reports from real
-> hardware welcome.
+`md=3` is also accepted, and is the value the device reports in `c0` while it
+is searching for the phase. Values other than `0`-`3` and `255` are ignored.
+
+The parameter is located with a substring search for `md` and parsed from three
+characters later, so the exact separators do not matter: `cd=22,md=0` and the
+`cd=22,,md=00` form (with an empty field between the commas) are equivalent, as
+are zero-padded and unpadded values.
 
 ---
 
@@ -677,9 +671,25 @@ These are the same codes the Venus and Jupiter use for `cd=18` (see
 [docs/venus.md](venus.md)); only the command number differs. An earlier revision
 of this document listed a different sequence, which was wrong.
 
-A "Marstek CT001.5" also uses `meter=0`. Shelly EM Gen3 (`5`) and Shelly Pro
-EM50 (`6`) are offered for the Venus but not the B2500, so it is unconfirmed
-whether a B2500 accepts them.
+A "Marstek CT001.5" also uses `meter=0`. The device additionally accepts
+`meter=7` for the EcoTracker, which hm2mqtt does not currently offer.
+
+**Reported meter type (`ct_t`) uses different codes.** The device translates the
+configured meter into a second code space before reporting it, so `ct_t` never
+matches the `meter=` value that set it:
+
+| Meter | `meter=` (command) | `ct_t` (reported) |
+|---|---|---|
+| CT001 | 0 | 1 |
+| Shelly Pro 3EM | 1 | 4 |
+| P1 Meter | 2 | 5 |
+| CT002 | 3 | 3 |
+| CT003 | 4 | 6 |
+| Shelly EM Gen3 | 5 | 7 |
+| Shelly Pro EM50 | 6 | 8 |
+| EcoTracker | 7 | 9 |
+
+Only CT002 happens to use the same number in both columns.
 
 ---
 

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -484,6 +484,73 @@ Some settings can be written to flash (persisted across reboots) or applied tran
 | Query error codes | 30 | 30 | — |
 | Query network info | 34 | 34 | — |
 
+#### Complete command list (V2)
+
+The V2 firmware dispatches on `cd` through a jump table. These are every code it
+accepts, and the parameters each handler looks for. Codes not listed (including
+`0`, `2`, `6` and `32`) fall through to a no-op — the message is parsed and then
+dropped.
+
+| `cd` | Parameters | Purpose |
+|---|---|---|
+| 1 | — | Runtime info |
+| 3 / 17 | `md` | Charging mode (flash / no-flash) |
+| 4 / 18 | `md` | Adaptive mode (flash / no-flash) |
+| 5 / 19 | `md` | Discharge depth (flash / no-flash) |
+| 7 / 20 | `md`, `a1`-`a5`, `b1`-`b5`, `e1`-`e5`, `v1`-`v5` | Timed discharge (flash / no-flash) |
+| 8 | `wy`, `yy`, `mm`, `rr`, `hh`, `mn`, `ss` | Sync time |
+| 9 | `wy` | Time zone |
+| 10 | — | Software restart |
+| 11 | — | Factory reset |
+| 12 | `sdt` | **Undocumented.** Purpose unknown |
+| 13 | — | Query cell voltages |
+| 14 | — | Query the `ds`/`ps`/… block |
+| 15 | — | Query split status part 1 |
+| 16 | — | Query extra battery data |
+| 21 | — | Query calibration (`cf`/`df`) |
+| 22 | `md` | Set CT connected phase |
+| 23 | `id`, `pmin`, `adjust_time` | Set micro-inverter |
+| 24 | — | Query micro-inverter interface data |
+| 25 | — | **Undocumented.** Query; response not identified |
+| 26 | — | **Undocumented.** Query; response not identified |
+| 27 | `meter=`, `mac=`, `dchrg=`, `seq_check`, `rechrg_seq=` | Smart meter config — see below |
+| 28 | — | Query smart meter |
+| 29 | `single_mode=`, `b2500_num=` | Multi-device mode |
+| 30 | — | Query error codes |
+| 31 | `touchuan_disa=` | Surplus feed-in |
+| 33 | `type=`, `mac_id=` | **Undocumented.** Sets a device type and MAC; replies `cd=<n>,type=<n>` |
+| 34 | — | Query network info |
+| 35 | `len=`, `ip=`, `ip?` | **Undocumented.** Set/query an IP; replies `cd=<n>,len=<n>,ip=<s>` |
+| 36 | `id=`, `port=`, `port?` | **Undocumented.** Set/query an ID and port; replies `cd=<n>,id=<n>,port=<n>` |
+| 37 | `len=` | **Undocumented.** Purpose unknown |
+| 38 | `fktc=` | **Undocumented.** Writes the `fktc` field also reported in `cd=01` |
+| 39 | `type?` | **Undocumented.** Query, paired with `cd=33` |
+| 81 | `hge_vid?`, `hge_gid?`, `hge_xid?` | **Undocumented.** Queries three IDs; replies `cd=<n>,len=<n>,vid_f=<n>,vid=<s>,vid_c=<n>` (and the `gid`/`xid` equivalents) |
+
+The undocumented entries above are named from the parameter strings their
+handlers search for. Only `cd=27`'s extra parameters (below) were traced far
+enough to say what they do; treat the rest as leads rather than facts, and note
+that several look like factory or provisioning commands.
+
+#### Smart meter command extras (`cd=27`)
+
+Besides `meter=`/`mac=`, the same command takes three more parameters — the
+B2500 equivalent of the Venus `cd=18`:
+
+```
+cd=27,dchrg=0        ← recharge mode: single-phase
+cd=27,dchrg=1        ← recharge mode: three-phase
+cd=27,seq_check      ← start phase diagnosis
+cd=27,rechrg_seq=<n> ← set the recharge phase
+```
+
+`seq_check` clears the stored phase and sets the CT status (`c1`) to `5`,
+"Preparing to diagnose CT001 (Step 1)", so progress can be followed on the CT
+status field. `rechrg_seq=` writes the same byte that `cd=22,md=` sets, and
+`dchrg=` is stored separately; neither is currently reported back in any
+response that has been identified, so there is no way to read the recharge mode.
+
+
 ---
 
 ### Command payloads

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -261,7 +261,7 @@ m0=0,m1=0,m2=0,m3=0,lmo=800,lmi=800,lmf=0
 | `uv` | Bootloader version |
 | `am` | Temperature warning state. The value space is unconfirmed |
 | `fktc` ³ | Unknown |
-| `ws` | Wi-Fi RSSI in dBm, **already signed** (e.g. `ws=-79`) — unlike the Venus/Jupiter `wif_s`, which is an unsigned magnitude. Two sentinels mean "no reading": `0` before the Wi-Fi module reports any state, and `32767` (INT16_MAX) while the association is down |
+| `ws` | Wi-Fi RSSI in dBm, **already signed** (e.g. `ws=-79`) — unlike the Venus/Jupiter `wif_s`, which is an unsigned magnitude. Two sentinels mean "no reading": `0` before the Wi-Fi module reports any state, and `32767` while the Wi-Fi association is down |
 | `tc_dis` | Surplus feed-in disabled (`0`=enabled, `1`=disabled) — V2 |
 | `sm` | Combination/multi-device model. Probably related to the `cd=29` multi-device mode |
 | `ts` | Reported but unused; meaning unknown |
@@ -486,10 +486,9 @@ Some settings can be written to flash (persisted across reboots) or applied tran
 
 #### Complete command list (V2)
 
-The V2 firmware dispatches on `cd` through a jump table. These are every code it
-accepts, and the parameters each handler looks for. Codes not listed (including
-`0`, `2`, `6` and `32`) fall through to a no-op — the message is parsed and then
-dropped.
+These are every `cd` code a V2 device accepts, and the parameters each one
+takes. Codes not listed (including `0`, `2`, `6` and `32`) are accepted by the
+parser and then ignored.
 
 | `cd` | Parameters | Purpose |
 |---|---|---|
@@ -527,9 +526,9 @@ dropped.
 | 39 | `type?` | **Undocumented.** Query, paired with `cd=33` |
 | 81 | `hge_vid?`, `hge_gid?`, `hge_xid?` | **Undocumented.** Queries three IDs; replies `cd=<n>,len=<n>,vid_f=<n>,vid=<s>,vid_c=<n>` (and the `gid`/`xid` equivalents) |
 
-The undocumented entries above are named from the parameter strings their
-handlers search for. Only `cd=27`'s extra parameters (below) were traced far
-enough to say what they do; treat the rest as leads rather than facts, and note
+The undocumented entries above are named after the parameters they accept,
+which is not the same as knowing what they do. Only `cd=27`'s extra parameters
+(below) are established; treat the rest as leads rather than facts, and note
 that several look like factory or provisioning commands.
 
 #### Smart meter command extras (`cd=27`)
@@ -544,11 +543,11 @@ cd=27,seq_check      ← start phase diagnosis
 cd=27,rechrg_seq=<n> ← set the recharge phase
 ```
 
-`seq_check` clears the stored phase and sets the CT status (`c1`) to `5`,
-"Preparing to diagnose CT001 (Step 1)", so progress can be followed on the CT
-status field. `rechrg_seq=` writes the same byte that `cd=22,md=` sets, and
-`dchrg=` is stored separately; neither is currently reported back in any
-response that has been identified, so there is no way to read the recharge mode.
+`seq_check` clears the phase and moves the CT status (`c1`) to `5`, "Preparing
+to diagnose CT001 (Step 1)", so progress can be followed on the CT status field.
+`rechrg_seq=` sets the same phase that `cd=22,md=` does. Neither `dchrg=` nor
+`rechrg_seq=` appears in any response documented here, so there is currently no
+way to read the recharge mode back.
 
 
 ---
@@ -633,11 +632,10 @@ cd=06,md=300
 The device only begins discharging when the load exceeds this value. No
 flash/no-flash distinction; always persisted.
 
-> **V1 only — confirmed.** V2 firmware does not implement this command at all:
-> its command dispatch table maps `cd=6` to the same "no handler" target as the
-> unused codes `cd=0` and `cd=2`, so the message is parsed and then dropped. V2
-> models still report the current value in `lv`, so hm2mqtt exposes the setting
-> as writable on the V1 and read-only on the V2.
+> **V1 only — confirmed.** A V2 device does not act on this command at all: it
+> is accepted and then ignored, exactly like the unused codes `cd=0` and `cd=2`.
+> V2 models still report the current value in `lv`, so hm2mqtt exposes the
+> setting as writable on the V1 and read-only on the V2.
 >
 > The app's input hint gives the range as **1-500**, while hm2mqtt has long
 > accepted 0-800. Which bound the firmware actually enforces is unconfirmed, so
@@ -706,15 +704,13 @@ cd=22,md=2    ← phase 3
 cd=22,md=255  ← none / automatic
 ```
 
-`md=3` is also accepted. All four of `0`-`3` take the same code path — the value
-is stored as the character `'A' + md`, so `3` becomes phase `'D'` — while `255`
-stores `'0'`. Values outside `0`-`3` and `255` are ignored.
+`md=3` is also accepted, and all four of `0`-`3` are treated alike — `3` simply
+selects a fourth phase slot. Values outside `0`-`3` and `255` are ignored.
 
-`c0` is the inverse of that byte (`'0'` reads back as `255`, otherwise
-`char - 'A'`), so it reflects the stored phase. Note that a dozen other code
-paths also write that byte, so `c0` is not purely a read-back of what you last
-set; whether `md=3` starts phase detection, as its usual "searching" label
-suggests, is not confirmed.
+`c0` reports the phase that is currently set, with `255` for none. It is not
+purely a read-back of what you last sent, though: the device changes it by
+itself as well. Whether `md=3` starts phase detection, as its usual "searching"
+label suggests, is not confirmed.
 
 The parameter is located with a substring search for `md` and parsed from three
 characters later, so the exact separators do not matter: `cd=22,md=0` and the

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -639,8 +639,15 @@ cd=22,md=2    ← phase 3
 cd=22,md=255  ← none / automatic
 ```
 
-`md=3` is also accepted, and is the value the device reports in `c0` while it
-is searching for the phase. Values other than `0`-`3` and `255` are ignored.
+`md=3` is also accepted. All four of `0`-`3` take the same code path — the value
+is stored as the character `'A' + md`, so `3` becomes phase `'D'` — while `255`
+stores `'0'`. Values outside `0`-`3` and `255` are ignored.
+
+`c0` is the inverse of that byte (`'0'` reads back as `255`, otherwise
+`char - 'A'`), so it reflects the stored phase. Note that a dozen other code
+paths also write that byte, so `c0` is not purely a read-back of what you last
+set; whether `md=3` starts phase detection, as its usual "searching" label
+suggests, is not confirmed.
 
 The parameter is located with a substring search for `md` and parsed from three
 characters later, so the exact separators do not matter: `cd=22,md=0` and the

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -322,7 +322,7 @@ m0=0,m1=0,m2=0,m3=0,lmo=800,lmi=800,lmf=0
 | `m1` | CT clip 2 measured power | W |
 | `m2` | CT clip 3 measured power | W |
 | `m3` | Micro-inverter real-time power | W |
-| `ct_t` | The CT/smart-meter type the device is currently configured for. **It does not use the same codes as the `cd=27,meter=` parameter** — see the table below |
+| `ct_t` | The CT/smart-meter type the device is currently configured for. **It does not use the same codes as the `cd=27,meter=` parameter** — see the table below | |
 
 CT status values (`c1`):
 
@@ -734,6 +734,9 @@ Supported meter types and their command codes:
 | P1 Meter | 2 | Yes |
 | CT002 | 3 | Yes |
 | CT003 | 4 | Yes |
+| Shelly EM Gen3 | 5 | Yes |
+| Shelly Pro EM50 | 6 | Yes |
+| EcoTracker | 7 | Yes |
 
 MAC format: 12 hex digits, no separators (e.g. `AABBCCDDEEFF`).
 
@@ -741,12 +744,12 @@ These are the same codes the Venus and Jupiter use for `cd=18` (see
 [docs/venus.md](venus.md)); only the command number differs. An earlier revision
 of this document listed a different sequence, which was wrong.
 
-A "Marstek CT001.5" also uses `meter=0`. The device additionally accepts
-`meter=7` for the EcoTracker.
+A "Marstek CT001.5" also uses `meter=0`.
 
 **Reported meter type (`ct_t`) uses different codes.** The device translates the
-configured meter into a second code space before reporting it, so `ct_t` never
-matches the `meter=` value that set it:
+configured meter into a second code space before reporting it, so `ct_t`
+generally differs from the `meter=` value that set it — CT002 is the one case
+where the two happen to coincide:
 
 | Meter | `meter=` (command) | `ct_t` (reported) |
 |---|---|---|
@@ -758,8 +761,6 @@ matches the `meter=` value that set it:
 | Shelly EM Gen3 | 5 | 7 |
 | Shelly Pro EM50 | 6 | 8 |
 | EcoTracker | 7 | 9 |
-
-Only CT002 happens to use the same number in both columns.
 
 ---
 

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -746,7 +746,7 @@ These are the same codes the Venus and Jupiter use for `cd=18` (see
 of this document listed a different sequence, which was wrong.
 
 A "Marstek CT001.5" also uses `meter=0`. The device additionally accepts
-`meter=7` for the EcoTracker, which hm2mqtt does not currently offer.
+`meter=7` for the EcoTracker.
 
 **Reported meter type (`ct_t`) uses different codes.** The device translates the
 configured meter into a second code space before reporting it, so `ct_t` never

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -266,6 +266,33 @@ describe('ControlHandler', () => {
       // Restore timers
       jest.useRealTimers();
     });
+
+    test('should sync the local wall-clock time, not UTC', () => {
+      // The device expects the local date/time fields alongside the matching UTC
+      // offset. Simulate UTC+9, where 2023-01-01T12:30:45Z is local 21:30:45 on
+      // the same day: the payload must carry the local hour, not the UTC one.
+      // The local getters are stubbed rather than setting process.env.TZ, which
+      // Node does not re-read once the process has started.
+      jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2023, 0, 1, 12, 30, 45)));
+      jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-540);
+      jest.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2023);
+      jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0);
+      jest.spyOn(Date.prototype, 'getDate').mockReturnValue(1);
+      jest.spyOn(Date.prototype, 'getHours').mockReturnValue(21);
+      jest.spyOn(Date.prototype, 'getMinutes').mockReturnValue(30);
+      jest.spyOn(Date.prototype, 'getSeconds').mockReturnValue(45);
+
+      try {
+        handleControlTopic(testDeviceV2, 'sync-time', 'PRESS');
+
+        expect(publishCallback).toHaveBeenCalledWith(
+          testDeviceV2,
+          expect.stringContaining('cd=8,wy=540,yy=123,mm=0,rr=1,hh=21,mn=30,ss=45'),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
     test('should handle sync-time control topic with JSON', () => {
       // Call the method with a sync time JSON message
       const timeData = {

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -29,6 +29,7 @@ import {
   diff,
   average,
   divide,
+  negate,
 } from '../transforms.js';
 
 export function extractAdditionalDeviceInfo(state: B2500BaseDeviceData): AdditionalDeviceInfo {
@@ -229,6 +230,20 @@ export function registerBaseMessage({
   field({ key: 'fc', path: ['deviceInfo', 'fc42dVersion'], transform: identity() });
   field({ key: 'id', path: ['deviceInfo', 'deviceIdNumber'], transform: number() });
   field({ key: 'uv', path: ['deviceInfo', 'bootloaderVersion'], transform: number() });
+
+  // The B2500's counterpart to the Venus/Jupiter `wif_s`: the RSSI magnitude
+  // without its sign, so it is negated to give dBm (0 meaning "no signal").
+  field({ key: 'ws', path: ['wifiSignalStrength'], transform: negate() });
+  advertise(
+    ['wifiSignalStrength'],
+    sensorComponent<number>({
+      id: 'wifi_signal_strength',
+      name: 'WiFi Signal Strength',
+      device_class: 'signal_strength',
+      unit_of_measurement: 'dBm',
+      state_class: 'measurement',
+    }),
+  );
 
   // Output state information
   for (const outputNumber of [1, 2] as const) {

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -232,10 +232,10 @@ export function registerBaseMessage({
   field({ key: 'uv', path: ['deviceInfo', 'bootloaderVersion'], transform: number() });
 
   // Wi-Fi RSSI, already signed and already in dBm (e.g. `ws=-79`) — unlike the
-  // Venus/Jupiter `wif_s`, which is an unsigned magnitude. The device also uses
-  // two "no reading" sentinels: 0 when the Wi-Fi module has no state yet, and
-  // 32767 (INT16_MAX) while the association is down. Both are filtered out so
-  // the sensor goes unknown instead of reporting an implausible value.
+  // Venus/Jupiter `wif_s`, which is an unsigned magnitude. Two values mean "no
+  // reading": 0 before the Wi-Fi module reports any state, and 32767 while the
+  // association is down. Both are filtered out so the sensor goes unknown
+  // instead of reporting an implausible signal level.
   field({ key: 'ws', path: ['wifiSignalStrength'], transform: inRange(-120, -1) });
   advertise(
     ['wifiSignalStrength'],

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -29,7 +29,7 @@ import {
   diff,
   average,
   divide,
-  negate,
+  inRange,
 } from '../transforms.js';
 
 export function extractAdditionalDeviceInfo(state: B2500BaseDeviceData): AdditionalDeviceInfo {
@@ -231,9 +231,12 @@ export function registerBaseMessage({
   field({ key: 'id', path: ['deviceInfo', 'deviceIdNumber'], transform: number() });
   field({ key: 'uv', path: ['deviceInfo', 'bootloaderVersion'], transform: number() });
 
-  // The B2500's counterpart to the Venus/Jupiter `wif_s`: the RSSI magnitude
-  // without its sign, so it is negated to give dBm (0 meaning "no signal").
-  field({ key: 'ws', path: ['wifiSignalStrength'], transform: negate() });
+  // Wi-Fi RSSI, already signed and already in dBm (e.g. `ws=-79`) — unlike the
+  // Venus/Jupiter `wif_s`, which is an unsigned magnitude. The device also uses
+  // two "no reading" sentinels: 0 when the Wi-Fi module has no state yet, and
+  // 32767 (INT16_MAX) while the association is down. Both are filtered out so
+  // the sensor goes unknown instead of reporting an implausible value.
+  field({ key: 'ws', path: ['wifiSignalStrength'], transform: inRange(-120, -1) });
   advertise(
     ['wifiSignalStrength'],
     sensorComponent<number>({
@@ -712,8 +715,16 @@ export function registerBaseMessage({
   );
 }
 
+// The device reports 16 cell slots per pack (`a0`-`af`). Detection only
+// requires the first 14 so that firmware reporting fewer still matches; the
+// aggregates below are partial-friendly for the same reason.
+const CELL_COUNT = 16;
+const CELL_DETECT_COUNT = 14;
+
 function isB2500CellDataMessage(values: Record<string, string>) {
-  return Array.from({ length: 14 }, (_, i) => `a${i.toString(16)}`).every(key => key in values);
+  return Array.from({ length: CELL_DETECT_COUNT }, (_, i) => `a${i.toString(16)}`).every(
+    key => key in values,
+  );
 }
 
 export function registerCellDataMessage(message: BuildMessageFn) {
@@ -743,11 +754,15 @@ export function registerCellDataMessage(message: BuildMessageFn) {
       b: 'extra1',
       c: 'extra2',
     } as const)) {
-      const allKeys = Array.from({ length: 14 }, (_, i) => `${key}${i.toString(16)}` as const);
+      const allKeys = Array.from(
+        { length: CELL_COUNT },
+        (_, i) => `${key}${i.toString(16)}` as const,
+      );
       field({
         key: allKeys,
         path: ['cellVoltage', battery, 'min'],
         transform: min(1000),
+        allowPartial: true,
       });
       advertise(
         ['cellVoltage', battery, 'min'],
@@ -764,6 +779,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
         key: allKeys,
         path: ['cellVoltage', battery, 'max'],
         transform: max(1000),
+        allowPartial: true,
       });
       advertise(
         ['cellVoltage', battery, 'max'],
@@ -780,6 +796,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
         key: allKeys,
         path: ['cellVoltage', battery, 'diff'],
         transform: diff(1000),
+        allowPartial: true,
       });
       advertise(
         ['cellVoltage', battery, 'diff'],
@@ -796,6 +813,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
         key: allKeys,
         path: ['cellVoltage', battery, 'avg'],
         transform: average(1000, true),
+        allowPartial: true,
       });
       advertise(
         ['cellVoltage', battery, 'avg'],
@@ -809,7 +827,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
         }),
       );
 
-      for (let i = 0; i < 14; i++) {
+      for (let i = 0; i < CELL_COUNT; i++) {
         field({
           key: `${key}${i.toString(16)}`,
           path: ['cellVoltage', battery, 'cells', i],

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -205,9 +205,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       path: ['batteryOutputThreshold'],
       transform: number(),
     });
-    // Read-only on V2. The threshold setting is only offered on the V1 (HMB) —
-    // V2 models report the current value in `lv` but expose no way to change it,
-    // and there is no evidence their firmware accepts `cd=6`.
+    // Read-only on V2. The threshold setting is only offered on the V1 (HMB);
+    // V2 models report the current value in `lv` but do not act on `cd=6`.
     advertise(
       ['batteryOutputThreshold'],
       sensorComponent<number>({
@@ -505,8 +504,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         };
         const channelValue = aliases[message.toLowerCase()] ?? message;
         const channel = parseInt(channelValue, 10);
-        // The device accepts 0-3 (stored as phase 'A'-'D') and 255 for "none";
-        // anything else is dropped on the floor, so reject it here.
+        // The device accepts 0-3 and 255 for "none", and ignores anything else,
+        // so reject it here rather than sending something that does nothing.
         if (isNaN(channel) || (channel !== 255 && (channel < 0 || channel > 3))) {
           logger.warn('Invalid connected phase value:', message);
           return;
@@ -913,9 +912,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    // Starts the grid-phase detection routine. The device clears the stored
-    // phase and moves the CT status to "Preparing to diagnose CT001 (Step 1)",
-    // so progress can be followed on the CT Status sensor.
+    // Starts the grid-phase detection routine. The device clears the phase and
+    // moves the CT status to "Preparing to diagnose CT001 (Step 1)", so progress
+    // can be followed on the CT Status sensor.
     command('phase-diagnosis', {
       handler: ({ message, publishCallback }) => {
         if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -491,10 +491,18 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     );
     command('connected-phase', {
       handler: ({ message, publishCallback, deviceState }) => {
-        let channelValue = message;
-        if (['auto', 'none', 'null', 'unknown'].includes(message.toLowerCase())) {
-          channelValue = '255';
-        }
+        // The select publishes the state name, so the two non-numeric values it
+        // can report have to map back onto the codes the device takes. Without
+        // the `searching` alias, picking that option published the literal
+        // string and was rejected here, leaving it a dead entry in the picker.
+        const aliases: Record<string, string> = {
+          auto: '255',
+          none: '255',
+          null: '255',
+          unknown: '255',
+          searching: '3',
+        };
+        const channelValue = aliases[message.toLowerCase()] ?? message;
         const channel = parseInt(channelValue, 10);
         // The device accepts 0-3 (stored as phase 'A'-'D') and 255 for "none";
         // anything else is dropped on the floor, so reject it here.

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -204,6 +204,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       path: ['batteryOutputThreshold'],
       transform: number(),
     });
+    // Read-only on V2. The threshold setting is only offered on the V1 (HMB) —
+    // V2 models report the current value in `lv` but expose no way to change it,
+    // and there is no evidence their firmware accepts `cd=6`.
     advertise(
       ['batteryOutputThreshold'],
       sensorComponent<number>({
@@ -586,6 +589,30 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         state_class: 'measurement',
       }),
     );
+    // The CT type and phase the device reports back. hm2mqtt can set the meter
+    // type via `cd=27`, but the device only ever echoed it here, so the
+    // configured value was never visible. The numeric code space of both fields
+    // is undocumented, so they are published as reported rather than mapped to
+    // labels — the same treatment the Jupiter gives these two fields.
+    field({ key: 'ct_t', path: ['ctType'], transform: number() });
+    advertise(
+      ['ctType'],
+      sensorComponent<number>({
+        id: 'ct_type',
+        name: 'CT Type',
+        enabled_by_default: false,
+      }),
+    );
+    field({ key: 'phase_t', path: ['phaseType'], transform: number() });
+    advertise(
+      ['phaseType'],
+      sensorComponent<number>({
+        id: 'phase_type',
+        name: 'Phase Type',
+        enabled_by_default: false,
+      }),
+    );
+
     field({
       key: 'm3',
       path: ['ctInfo', 'microInverterPower'],
@@ -662,14 +689,18 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           // If the message is "PRESS" or similar from Home Assistant button, generate current time
           if (message === 'PRESS' || message === 'press' || message === 'true' || message === '1') {
             const now = new Date();
+            // `cd=08` takes the local wall-clock time together with the offset
+            // of that same zone in `wy` — not UTC. Sending UTC components with
+            // a local `wy` left the device clock wrong by the offset. `mm` is
+            // 0-based and `yy` is the year minus 1900.
             const timeData = {
               wy: -now.getTimezoneOffset(),
-              yy: now.getUTCFullYear() - 1900,
-              mm: now.getUTCMonth(),
-              rr: now.getUTCDate(),
-              hh: now.getUTCHours(),
-              mn: now.getUTCMinutes(),
-              ss: now.getUTCSeconds(),
+              yy: now.getFullYear() - 1900,
+              mm: now.getMonth(),
+              rr: now.getDate(),
+              hh: now.getHours(),
+              mn: now.getMinutes(),
+              ss: now.getSeconds(),
             };
             publishCallback(
               processCommand(CommandType.SYNC_TIME, timeData, deviceState.useFlashCommands),
@@ -677,17 +708,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             return;
           }
 
-          // Otherwise try to parse as JSON
+          // Otherwise try to parse as JSON. Every field is checked for presence
+          // rather than truthiness: 0 is a legal value for all of them (January,
+          // midnight, UTC+0, …) and used to be rejected as "missing".
           const timeData = JSON.parse(message);
-          if (
-            !timeData.wy ||
-            !timeData.yy ||
-            !timeData.mm ||
-            !timeData.rr ||
-            !timeData.hh ||
-            !timeData.mn ||
-            !timeData.ss
-          ) {
+          const requiredKeys = ['wy', 'yy', 'mm', 'rr', 'hh', 'mn', 'ss'] as const;
+          if (requiredKeys.some(key => timeData?.[key] == null)) {
             logger.error('Missing time parameters:', message);
             return;
           }

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -496,7 +496,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           channelValue = '255';
         }
         const channel = parseInt(channelValue, 10);
-        if (isNaN(channel) || channel < 0 || (channel > 4 && channel !== 255)) {
+        // The device accepts 0-3 (stored as phase 'A'-'D') and 255 for "none";
+        // anything else is dropped on the floor, so reject it here.
+        if (isNaN(channel) || (channel !== 255 && (channel < 0 || channel > 3))) {
           logger.warn('Invalid connected phase value:', message);
           return;
         }
@@ -589,26 +591,40 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         state_class: 'measurement',
       }),
     );
-    // The CT type and phase the device reports back. hm2mqtt can set the meter
-    // type via `cd=27`, but the device only ever echoed it here, so the
-    // configured value was never visible. The numeric code space of both fields
-    // is undocumented, so they are published as reported rather than mapped to
-    // labels — the same treatment the Jupiter gives these two fields.
-    field({ key: 'ct_t', path: ['ctType'], transform: number() });
+    // The meter the device is currently configured for. hm2mqtt can set this
+    // with `cd=27`, but the device only ever echoed it back here, so the
+    // configured value was not visible anywhere. Note that `ct_t` uses its own
+    // code space, *not* the one the `meter=` parameter takes — see
+    // docs/b2500.md for the two tables.
+    field({
+      key: 'ct_t',
+      path: ['ctType'],
+      transform: map({
+        '1': 'ct001',
+        '3': 'ct002',
+        '4': 'shellyPro3em',
+        '5': 'p1Meter',
+        '6': 'ct003',
+        '7': 'shellyEmGen3',
+        '8': 'shellyProEm50',
+        '9': 'ecoTracker',
+      }),
+    });
     advertise(
       ['ctType'],
-      sensorComponent<number>({
+      sensorComponent<NonNullable<B2500V2DeviceData['ctType']>>({
         id: 'ct_type',
         name: 'CT Type',
-        enabled_by_default: false,
-      }),
-    );
-    field({ key: 'phase_t', path: ['phaseType'], transform: number() });
-    advertise(
-      ['phaseType'],
-      sensorComponent<number>({
-        id: 'phase_type',
-        name: 'Phase Type',
+        valueMappings: {
+          ct001: 'CT001',
+          ct002: 'CT002',
+          ct003: 'CT003',
+          shellyPro3em: 'Shelly Pro 3EM',
+          shellyEmGen3: 'Shelly EM Gen3',
+          shellyProEm50: 'Shelly Pro EM50',
+          p1Meter: 'P1 Meter',
+          ecoTracker: 'EcoTracker',
+        },
         enabled_by_default: false,
       }),
     );

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -9,6 +9,7 @@ import {
   normalizeMeterMac,
   resolveMeterMac,
   isValidMeterType,
+  isValidB2500RechargeMode,
 } from '../types.js';
 import logger from '../logger.js';
 import {
@@ -873,6 +874,64 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:meter-electric',
         command: 'meter-type',
         valueMappings: meterTypeLabels,
+        enabled_by_default: false,
+      }),
+    );
+
+    // `cd=27` doubles as the grid recharge command, the same way `cd=18` does on
+    // the Venus and Jupiter. The device does not report the current value in any
+    // response hm2mqtt polls, so this entity shows the last value that was set
+    // rather than the device's own state.
+    command('recharge-mode', {
+      handler: ({ message, publishCallback, updateDeviceState, deviceState }) => {
+        if (!isValidB2500RechargeMode(message)) {
+          logger.warn('Invalid recharge mode value:', message);
+          return;
+        }
+        updateDeviceState(() => ({ rechargeMode: message }));
+        publishCallback(
+          processCommand(
+            CommandType.SET_SMART_METER_TYPE,
+            { dchrg: message === 'threePhase' ? 1 : 0 },
+            deviceState.useFlashCommands,
+          ),
+        );
+      },
+    });
+    advertise(
+      ['rechargeMode'],
+      selectComponent<NonNullable<B2500V2DeviceData['rechargeMode']>>({
+        id: 'recharge_mode',
+        name: 'Recharge Mode',
+        icon: 'mdi:flash',
+        command: 'recharge-mode',
+        valueMappings: {
+          singlePhase: 'Single Phase',
+          threePhase: 'Three Phase',
+        },
+        enabled_by_default: false,
+      }),
+    );
+
+    // Starts the grid-phase detection routine. The device clears the stored
+    // phase and moves the CT status to "Preparing to diagnose CT001 (Step 1)",
+    // so progress can be followed on the CT Status sensor.
+    command('phase-diagnosis', {
+      handler: ({ message, publishCallback }) => {
+        if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
+          // `seq_check` is a bare flag, so it cannot go through processCommand.
+          publishCallback(`cd=${CommandType.SET_SMART_METER_TYPE},seq_check`);
+        }
+      },
+    });
+    advertise(
+      [],
+      buttonComponent({
+        id: 'phase_diagnosis',
+        name: 'Phase Diagnosis',
+        icon: 'mdi:sine-wave',
+        command: 'phase-diagnosis',
+        payload_press: 'PRESS',
         enabled_by_default: false,
       }),
     );

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -490,6 +490,14 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: 'cd=8,wy=480,yy=123,mm=1,rr=2,hh=23,mn=56,ss=56',
   },
   {
+    // Every field here is a legal 0: UTC+0, January, midnight, zero minute/second.
+    description: 'B2500V2 sync-time with JSON accepts zero values',
+    deviceType: 'HMA-1',
+    command: 'sync-time',
+    input: '{"wy":0,"yy":126,"mm":0,"rr":1,"hh":0,"mn":0,"ss":0}',
+    expectedOutput: 'cd=8,wy=0,yy=126,mm=0,rr=1,hh=0,mn=0,ss=0',
+  },
+  {
     description: 'B2500V2 sync-time with incomplete JSON (invalid)',
     deviceType: 'HMA-1',
     command: 'sync-time',

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -624,6 +624,53 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: null,
   },
   {
+    description: 'B2500V2 meter-type EcoTracker with configured MAC',
+    deviceType: 'HMA-1',
+    initialState: { meterMac: 'aabbccddeeff' },
+    command: 'meter-type',
+    input: 'ecoTracker',
+    expectedOutput: 'cd=27,meter=7,mac=aabbccddeeff',
+  },
+
+  // recharge-mode + phase-diagnosis (cd=27 doubles as the grid recharge command)
+  {
+    description: 'B2500V2 recharge-mode single phase',
+    deviceType: 'HMA-1',
+    command: 'recharge-mode',
+    input: 'singlePhase',
+    expectedOutput: 'cd=27,dchrg=0',
+    expectedStateChanges: { rechargeMode: 'singlePhase' },
+  },
+  {
+    description: 'B2500V2 recharge-mode three phase',
+    deviceType: 'HMA-1',
+    command: 'recharge-mode',
+    input: 'threePhase',
+    expectedOutput: 'cd=27,dchrg=1',
+    expectedStateChanges: { rechargeMode: 'threePhase' },
+  },
+  {
+    description: 'B2500V2 recharge-mode invalid',
+    deviceType: 'HMA-1',
+    command: 'recharge-mode',
+    input: 'twoPhase',
+    expectedOutput: null,
+  },
+  {
+    description: 'B2500V2 phase-diagnosis sends the bare seq_check flag',
+    deviceType: 'HMA-1',
+    command: 'phase-diagnosis',
+    input: 'PRESS',
+    expectedOutput: 'cd=27,seq_check',
+  },
+  {
+    description: 'B2500V2 phase-diagnosis ignores a non-press payload',
+    deviceType: 'HMA-1',
+    command: 'phase-diagnosis',
+    input: 'false',
+    expectedOutput: null,
+  },
+  {
     description: 'B2500V2 meter-type invalid',
     deviceType: 'HMA-1',
     command: 'meter-type',

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -450,6 +450,28 @@ const commandTestCases: CommandTestCase[] = [
     input: '10',
     expectedOutput: null,
   },
+  {
+    // The select publishes the state name, not the code.
+    description: 'B2500V2 connected-phase searching maps to md=3',
+    deviceType: 'HMA-1',
+    command: 'connected-phase',
+    input: 'searching',
+    expectedOutput: 'cd=22,md=3',
+  },
+  {
+    description: 'B2500V2 connected-phase numeric 3 is accepted',
+    deviceType: 'HMA-1',
+    command: 'connected-phase',
+    input: '3',
+    expectedOutput: 'cd=22,md=3',
+  },
+  {
+    description: 'B2500V2 connected-phase 4 is rejected',
+    deviceType: 'HMA-1',
+    command: 'connected-phase',
+    input: '4',
+    expectedOutput: null,
+  },
 
   // time-zone command (V2 only)
   {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -3,6 +3,7 @@ import './device/registry.js';
 import { parseMessage } from './parser.js';
 import logger from './logger.js';
 import {
+  B2500CellData,
   B2500V2DeviceData,
   CT002DeviceData,
   CT002PhaseEnergyInfo,
@@ -154,21 +155,37 @@ describe('MQTT Message Parser', () => {
     }
   });
 
-  test('should negate the unsigned WiFi signal into dBm', () => {
+  test('should read the WiFi signal as signed dBm and drop the sentinels', () => {
     const base = 'pe=75,kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0';
+    const ws = (value: string) =>
+      (parseMessage(`${base},ws=${value}`, 'HMA-1', '12345')['data'] as B2500V2DeviceData)
+        .wifiSignalStrength;
 
-    const parsed = parseMessage(`${base},ws=79`, 'HMA-1', '12345');
-    const result = parsed['data'] as B2500V2DeviceData;
-    expect(result).toHaveProperty('wifiSignalStrength', -79);
+    // The device already reports a signed dBm value.
+    expect(ws('-79')).toBe(-79);
+    expect(ws('-42')).toBe(-42);
 
-    // 0 means "no signal". Negating it yields -0, which JSON serialisation
-    // normalises to 0, so that is what actually gets published.
-    const noSignal = parseMessage(`${base},ws=0`, 'HMA-1', '12345');
-    expect(JSON.parse(JSON.stringify(noSignal['data'])).wifiSignalStrength).toBe(0);
+    // Both "no reading" sentinels are dropped: 0 (no Wi-Fi state yet) and
+    // 32767 / INT16_MAX (association down).
+    expect(ws('0')).toBeUndefined();
+    expect(ws('32767')).toBeUndefined();
 
     // Absent on devices that do not report it
     const without = parseMessage(base, 'HMA-1', '12345');
     expect((without['data'] as B2500V2DeviceData).wifiSignalStrength).toBeUndefined();
+  });
+
+  test('should parse all 16 cell voltages per pack', () => {
+    const cells = (prefix: string, mv: number) =>
+      Array.from({ length: 16 }, (_, i) => `${prefix}${i.toString(16)}=${mv + i}`).join(',');
+    const message = [cells('a', 3300), cells('b', 0), cells('c', 0)].join(',');
+
+    const result = parseMessage(message, 'HMA-1', '12345')['cells'] as B2500CellData;
+    expect(result.cellVoltage?.host?.cells).toHaveLength(16);
+    // a0=3300 .. af=3315, scaled from mV to V
+    expect(result.cellVoltage?.host?.cells[15]).toBeCloseTo(3.315, 5);
+    expect(result.cellVoltage?.host?.min).toBeCloseTo(3.3, 5);
+    expect(result.cellVoltage?.host?.max).toBeCloseTo(3.315, 5);
   });
 
   test('should handle message definitions correctly', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -154,6 +154,23 @@ describe('MQTT Message Parser', () => {
     }
   });
 
+  test('should negate the unsigned WiFi signal into dBm', () => {
+    const base = 'pe=75,kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0';
+
+    const parsed = parseMessage(`${base},ws=79`, 'HMA-1', '12345');
+    const result = parsed['data'] as B2500V2DeviceData;
+    expect(result).toHaveProperty('wifiSignalStrength', -79);
+
+    // 0 means "no signal". Negating it yields -0, which JSON serialisation
+    // normalises to 0, so that is what actually gets published.
+    const noSignal = parseMessage(`${base},ws=0`, 'HMA-1', '12345');
+    expect(JSON.parse(JSON.stringify(noSignal['data'])).wifiSignalStrength).toBe(0);
+
+    // Absent on devices that do not report it
+    const without = parseMessage(base, 'HMA-1', '12345');
+    expect((without['data'] as B2500V2DeviceData).wifiSignalStrength).toBeUndefined();
+  });
+
   test('should handle message definitions correctly', () => {
     // Create a simple test message
     const message =

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -165,8 +165,8 @@ describe('MQTT Message Parser', () => {
     expect(ws('-79')).toBe(-79);
     expect(ws('-42')).toBe(-42);
 
-    // Both "no reading" sentinels are dropped: 0 (no Wi-Fi state yet) and
-    // 32767 / INT16_MAX (association down).
+    // Both "no reading" values are dropped: 0 (no Wi-Fi state yet) and
+    // 32767 (association down).
     expect(ws('0')).toBeUndefined();
     expect(ws('32767')).toBeUndefined();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,20 @@ export type B2500V2SmartMeterStatus =
   | 'chargingInProgress'
   | 'unableToFindChannel'
   | 'notInDiagnosis';
+/**
+ * Meter reported in the B2500 `ct_t` field. The device reports the configured
+ * meter under its own numeric codes, which do not match the codes the
+ * `cd=27,meter=` command accepts.
+ */
+export type B2500CtType =
+  | 'ct001'
+  | 'ct002'
+  | 'ct003'
+  | 'shellyPro3em'
+  | 'shellyEmGen3'
+  | 'shellyProEm50'
+  | 'p1Meter'
+  | 'ecoTracker';
 export type B2500V1ChargingMode = 'chargeThenDischarge' | 'pv2PassThrough';
 export type B2500V2ChargingMode = 'chargeDischargeSimultaneously' | 'chargeThenDischarge';
 
@@ -182,10 +196,9 @@ export interface B2500V2DeviceData extends B2500BaseDeviceData {
   meterType?: MeterType;
   meterMac?: string;
 
-  // CT type and phase the device reports back (`ct_t`/`phase_t`). The numeric
-  // code space is not documented, so both are published as reported.
-  ctType?: number;
-  phaseType?: number;
+  // The meter the device reports as configured (`ct_t`). Its numeric codes are
+  // distinct from the ones the `cd=27,meter=` command takes.
+  ctType?: B2500CtType;
 }
 
 type SolarSocketData = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,9 @@ export interface B2500BaseDeviceData extends BaseDeviceData {
   // Scene information (day/night/dusk)
   scene?: B2500Scene;
 
+  // Wi-Fi signal strength in dBm, from the (unsigned) `ws` field
+  wifiSignalStrength?: number;
+
   // Output enabled states
   outputEnabled?: {
     output1?: boolean;
@@ -178,6 +181,11 @@ export interface B2500V2DeviceData extends B2500BaseDeviceData {
   // Smart meter configuration (cd=27)
   meterType?: MeterType;
   meterMac?: string;
+
+  // CT type and phase the device reports back (`ct_t`/`phase_t`). The numeric
+  // code space is not documented, so both are published as reported.
+  ctType?: number;
+  phaseType?: number;
 }
 
 type SolarSocketData = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,7 @@ export interface B2500BaseDeviceData extends BaseDeviceData {
   // Scene information (day/night/dusk)
   scene?: B2500Scene;
 
-  // Wi-Fi signal strength in dBm, from the (unsigned) `ws` field
+  // Wi-Fi signal strength in dBm, from the `ws` field (already signed)
   wifiSignalStrength?: number;
 
   // Output enabled states
@@ -391,8 +391,8 @@ export const meterTypeCommandCodes: Record<MeterType, number> = {
   ct003: 4,
   shellyEmGen3: 5,
   shellyProEm50: 6,
-  // Code 7 is confirmed accepted by B2500 V2 firmware. The Venus and Jupiter
-  // take the same meter codes on their own command, so it is offered there too.
+  // Code 7 is confirmed on the B2500. The Venus and Jupiter take the same meter
+  // codes on their own command, so it is offered there too.
   ecoTracker: 7,
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,18 @@ export type B2500CtType =
   | 'shellyProEm50'
   | 'p1Meter'
   | 'ecoTracker';
+/**
+ * Grid recharge mode set with `cd=27,dchrg=`. The device does not report the
+ * current value in any response hm2mqtt polls, so the entity reflects the last
+ * value that was set rather than the device's own state.
+ */
+const validB2500RechargeModes = ['singlePhase', 'threePhase'] as const;
+export type B2500RechargeMode = (typeof validB2500RechargeModes)[number];
+
+export function isValidB2500RechargeMode(mode: string): mode is B2500RechargeMode {
+  return validB2500RechargeModes.includes(mode as B2500RechargeMode);
+}
+
 export type B2500V1ChargingMode = 'chargeThenDischarge' | 'pv2PassThrough';
 export type B2500V2ChargingMode = 'chargeDischargeSimultaneously' | 'chargeThenDischarge';
 
@@ -199,6 +211,9 @@ export interface B2500V2DeviceData extends B2500BaseDeviceData {
   // The meter the device reports as configured (`ct_t`). Its numeric codes are
   // distinct from the ones the `cd=27,meter=` command takes.
   ctType?: B2500CtType;
+
+  // Last grid recharge mode set via `cd=27,dchrg=` (not reported by the device)
+  rechargeMode?: B2500RechargeMode;
 }
 
 type SolarSocketData = {
@@ -358,6 +373,7 @@ const validMeterTypes = [
   'ct003',
   'shellyEmGen3',
   'shellyProEm50',
+  'ecoTracker',
 ] as const;
 export type MeterType = (typeof validMeterTypes)[number];
 
@@ -375,6 +391,9 @@ export const meterTypeCommandCodes: Record<MeterType, number> = {
   ct003: 4,
   shellyEmGen3: 5,
   shellyProEm50: 6,
+  // Code 7 is confirmed accepted by B2500 V2 firmware. The Venus and Jupiter
+  // take the same meter codes on their own command, so it is offered there too.
+  ecoTracker: 7,
 };
 
 /**
@@ -387,6 +406,7 @@ export const meterTypeLabels: Record<MeterType, string> = {
   ct003: 'CT003',
   shellyEmGen3: 'Shelly EM Gen3',
   shellyProEm50: 'Shelly Pro EM50',
+  ecoTracker: 'EcoTracker',
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR documents previously undocumented B2500 fields, fixes a critical time synchronization bug in V2/V3 devices, and adds new sensors to expose CT configuration state.

## Key Changes

- **WiFi Signal Strength**: Added `wifiSignalStrength` sensor from the `ws` field. The device reports unsigned RSSI magnitude, so it is negated to produce dBm values (matching Venus/Jupiter convention). `0` means "no signal".

- **CT Configuration Sensors**: Added `ctType` and `phaseType` sensors (from `ct_t`/`phase_t` fields) to expose what meter type and phase the device is currently configured for. Published as raw numbers since their code space is undocumented. This allows users to verify the *Meter Type* select actually took effect.

- **Time Sync Fix**: Fixed critical bug where `sync-time` sent UTC components with a local timezone offset, leaving the device clock wrong by that offset. Now correctly sends local wall-clock time paired with the matching UTC offset (`wy`). Also fixed rejection of valid `0` values (January, midnight, UTC+0, etc.) in JSON payloads.

- **Documentation**: Extensively documented previously unknown fields (`am`, `ws`, `sm`, `ts`, `ct_t`, `phase_t`, `seq_a`, `seq_s`) and clarified ambiguous settings (`cd=06` V1-only, `cd=08` local time semantics, `cd=22` phase selection, `cd=27` meter types). Added notes on unconfirmed behaviors and firmware version constraints.

## Implementation Details

- `negate()` transform added to convert unsigned RSSI to signed dBm
- Time sync now uses local date/time getters (`getFullYear()`, `getMonth()`, etc.) instead of UTC variants
- JSON time payload validation changed from truthiness to presence check (`== null`) to accept `0` values
- Test coverage added for local time sync and zero-value JSON payloads
- README updated to clarify `connected-phase` codes and `time-zone` units (minutes, not hours)

## Validation

- `npm test -- --runInBand` passes
- `npm run build` succeeds
- All existing tests pass; new tests added for time sync and WiFi signal negation

https://claude.ai/code/session_01Ct6mzfJiwi5Ji6Smj3UzZk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added B2500 Wi‑Fi signal strength monitoring (signed RSSI with “no reading” handling).
  - Expanded B2500 cell-voltage support to 16 slots per pack.
  - Added B2500 V2 recharge mode and phase diagnosis controls, plus CT type reporting (with some options disabled by default).
  - Added EcoTracker to supported meter types.

- **Bug Fixes**
  - Corrected B2500 sync-time generation and JSON handling for zero-valued fields.
  - Fixed missing cell-voltage publishing and improved connected-phase “Searching”/value parsing.

- **Documentation**
  - Updated README and B2500 protocol docs for new/adjusted MQTT commands and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->