### PR TITLE
Fix cell voltage aggregates for B2500 packs with <16 cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Next]
 
+### Fixed
+
+- B2500: Fix the cell voltage sensors on packs with fewer than 16 cells. Reading all 16 slots (new in 1.9.0) meant the unused slots, which the device reports as `0`, were counted as 0 V cells: *Min Cell Voltage* dropped to 0 V, *Cell Voltage Difference* jumped to the full cell voltage and *Average Cell Voltage* was pulled down. Empty slots are now ignored by the aggregates and the individual *Cell Voltage* sensors for those slots show as unknown instead of 0 V (fixes #384)
+
 
 ## [1.9.0] - 2026-07-28
 

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -30,6 +30,7 @@ import {
   average,
   divide,
   inRange,
+  chain,
 } from '../transforms.js';
 
 export function extractAdditionalDeviceInfo(state: B2500BaseDeviceData): AdditionalDeviceInfo {
@@ -718,6 +719,12 @@ export function registerBaseMessage({
 // The device reports 16 cell slots per pack (`a0`-`af`). Detection only
 // requires the first 14 so that firmware reporting fewer still matches; the
 // aggregates below are partial-friendly for the same reason.
+//
+// Packs with fewer than 16 physical cells report the unused slots as `0`, so
+// both the individual cell sensors and the aggregates have to drop zeroes.
+// Otherwise an empty slot is read as a 0 V cell: the minimum collapses to 0,
+// the difference becomes the full cell voltage and the average is pulled down
+// by the missing cells (see #384).
 const CELL_COUNT = 16;
 const CELL_DETECT_COUNT = 14;
 
@@ -761,7 +768,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
       field({
         key: allKeys,
         path: ['cellVoltage', battery, 'min'],
-        transform: min(1000),
+        transform: min(1000, true),
         allowPartial: true,
       });
       advertise(
@@ -778,7 +785,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
       field({
         key: allKeys,
         path: ['cellVoltage', battery, 'max'],
-        transform: max(1000),
+        transform: max(1000, true),
         allowPartial: true,
       });
       advertise(
@@ -795,7 +802,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
       field({
         key: allKeys,
         path: ['cellVoltage', battery, 'diff'],
-        transform: diff(1000),
+        transform: diff(1000, true),
         allowPartial: true,
       });
       advertise(
@@ -812,7 +819,7 @@ export function registerCellDataMessage(message: BuildMessageFn) {
       field({
         key: allKeys,
         path: ['cellVoltage', battery, 'avg'],
-        transform: average(1000, true),
+        transform: average(1000, true, true),
         allowPartial: true,
       });
       advertise(
@@ -831,7 +838,10 @@ export function registerCellDataMessage(message: BuildMessageFn) {
         field({
           key: `${key}${i.toString(16)}`,
           path: ['cellVoltage', battery, 'cells', i],
-          transform: divide(1000),
+          // Unused slots read exactly 0; publish them as unknown rather than as
+          // a 0 V cell. The upper bound is only there because `inRange` needs
+          // one — no real cell comes anywhere near it.
+          transform: chain(divide(1000), inRange(0.001, 100)),
         });
         advertise(
           ['cellVoltage', battery, 'cells', i],

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -188,6 +188,27 @@ describe('MQTT Message Parser', () => {
     expect(result.cellVoltage?.host?.max).toBeCloseTo(3.315, 5);
   });
 
+  test('should ignore unused cell slots reported as 0 (issue #384)', () => {
+    // A 14-cell pack fills the first 14 slots and reports the remaining two as
+    // 0. Those must not drag the minimum to 0, blow up the difference or pull
+    // the average down.
+    const used = Array.from({ length: 14 }, (_, i) => `a${i.toString(16)}=${3300 + i}`);
+    const unused = ['ae=0', 'af=0'];
+    const message = [...used, ...unused].join(',');
+
+    const result = parseMessage(message, 'HMA-1', '12345')['cells'] as B2500CellData;
+    expect(result.cellVoltage?.host?.min).toBeCloseTo(3.3, 5);
+    expect(result.cellVoltage?.host?.max).toBeCloseTo(3.313, 5);
+    expect(result.cellVoltage?.host?.diff).toBeCloseTo(0.013, 5);
+    // Average over the 14 populated cells only: 3300..3313 -> 3306.5, rounded
+    // to 3307 mV before scaling.
+    expect(result.cellVoltage?.host?.avg).toBeCloseTo(3.307, 5);
+    // The empty slots are published as unknown, not as 0 V cells
+    expect(result.cellVoltage?.host?.cells[13]).toBeCloseTo(3.313, 5);
+    expect(result.cellVoltage?.host?.cells[14]).toBeUndefined();
+    expect(result.cellVoltage?.host?.cells[15]).toBeUndefined();
+  });
+
   test('should handle message definitions correctly', () => {
     // Create a simple test message
     const message =


### PR DESCRIPTION
## Summary

Fixes cell voltage sensor calculations on B2500 packs with fewer than 16 physical cells. The device reports unused cell slots as `0`, which were being counted as 0 V cells, causing *Min Cell Voltage* to drop to 0 V, *Cell Voltage Difference* to spike, and *Average Cell Voltage* to be artificially lowered.

## Changes

- **Transform functions**: Updated `min()`, `max()`, and `diff()` calls to filter out zero values (new `ignoreZero` parameter)
- **Average calculation**: Added third parameter to `average()` to ignore zeros
- **Individual cell sensors**: Applied `inRange(0.001, 100)` filter via `chain()` to publish unused slots as `undefined` instead of 0 V
- **Test coverage**: Added comprehensive test case validating that a 14-cell pack correctly ignores the two unused slots in aggregates and individual readings
- **Documentation**: Updated code comments and CHANGELOG explaining the fix for issue #384

## Validation

- ✅ `npm run lint` 
- ✅ `npm run format:check`
- ✅ `npm test -- --runInBand` (new test included)
- ✅ `npm run build`

Closes #384

https://claude.ai/code/session_01Hcd17kzekJHbT86AhhxDSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cell voltage calculations for devices with fewer than 16 cells.
  * Empty cell slots are now excluded from minimum, maximum, difference, and average voltage readings.
  * Unused per-cell voltage sensors now appear as unknown instead of reporting 0 V.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->