### PR TITLE
Fix write-only meter controls showing template warnings in Home Assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Next]
 
+### Fixed
+
+- B2500 V2/V3, Venus & Jupiter: Stop Home Assistant logging a `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. Both are write-only settings that the device never reports back, so the state topic they were advertised with never carried the value and Home Assistant warned each time it rendered the template. They are now advertised without a state topic, which puts them into Home Assistant's optimistic mode: the entity shows the last value that was set. This also fixes the *Meter MAC* text entity failing with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
+- B2500 V2/V3: The *Recharge Mode* select had the same problem and is now advertised the same way
 
 ## [1.9.1] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ### Fixed
 
-- B2500 V2/V3, Venus & Jupiter: Stop Home Assistant logging a `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. Both are write-only settings that the device never reports back, so the state topic they were advertised with never carried the value and Home Assistant warned each time it rendered the template. They are now advertised without a state topic, which puts them into Home Assistant's optimistic mode: the entity shows the last value that was set. This also fixes the *Meter MAC* text entity failing with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
-- B2500 V2/V3: The *Recharge Mode* select had the same problem and is now advertised the same way
+- B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
+- B2500 V2/V3: *Recharge Mode* was affected the same way and got the same fix
 
 ## [1.9.1] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -632,8 +632,8 @@ homeassistant/{component}/{node_id}/{object_id}/config
 ### Venus Device Commands
 - `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`). The `ai` value expands to `cd=2,md=5,nl=1` (AI mode requires both `md=5` and `nl=1`).
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
-- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped)
-- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, `shellyProEm50` or `ecoTracker`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
+- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped). The device does not report this back, so the entity shows the last value set.
+- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, `shellyProEm50` or `ecoTracker`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC. The device does not report this back, so the entity shows the last value set.
 - `auto-switch-working-mode`: Toggles automatic mode switching (`on` or `off`)
 - `time-period/[0-9]/enabled`: Enables/disables time period (`on` or `off`)
 - `time-period/[0-9]/start-time`: Sets start time for period (HH:MM format)
@@ -684,8 +684,8 @@ The following commands are supported by both Jupiter C, Jupiter E and Jupiter Pl
 - `sync-time`: Synchronizes device time with server
 - `working-mode`: Sets working mode (`automatic`, `manual`, or `ai`). The `ai` value expands to `cd=2,md=5,nl=1` (AI mode requires both `md=5` and `nl=1`).
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
-- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped)
-- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, `shellyProEm50` or `ecoTracker`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC.
+- `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped). The device does not report this back, so the entity shows the last value set.
+- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`, `ct003`, `shellyEmGen3`, `shellyProEm50` or `ecoTracker`). For CT002/CT003 and the Shelly EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero MAC. The device does not report this back, so the entity shows the last value set.
 - `bluetooth-advertising`: Toggles Bluetooth advertising (`on` enables advertising, `off` disables it / "Bluetooth lock"). Requires firmware 141 or newer.
 - `phase-diagnosis`: Starts the grid-phase detection routine
 - `battery-pack-recovery`: Reactivates an unresponsive battery pack. Jupiter Plus only, firmware 135 or newer.

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -835,6 +835,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:identifier',
         command: 'meter-mac',
         pattern: '^[0-9A-Fa-f]{12}$',
+        // Write-only: the device never reports the configured MAC back.
+        optimistic: true,
         enabled_by_default: false,
       }),
     );
@@ -873,6 +875,9 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:meter-electric',
         command: 'meter-type',
         valueMappings: meterTypeLabels,
+        // Write-only: the device never reports the configured meter type back.
+        // The separate CT Type sensor shows what the device actually took.
+        optimistic: true,
         enabled_by_default: false,
       }),
     );
@@ -908,6 +913,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           singlePhase: 'Single Phase',
           threePhase: 'Three Phase',
         },
+        // Write-only: the device never reports the recharge mode back.
+        optimistic: true,
         enabled_by_default: false,
       }),
     );

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -836,6 +836,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         command: 'meter-mac',
         // The device uses a plain 12 hex digit MAC without ':'/'-' separators.
         pattern: '^[0-9A-Fa-f]{12}$',
+        // Write-only: the device never reports the configured MAC back.
+        optimistic: true,
         enabled_by_default: false,
       }),
     );
@@ -873,6 +875,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:meter-electric',
         command: 'meter-type',
         valueMappings: meterTypeLabels,
+        // Write-only: the device never reports the configured meter type back.
+        optimistic: true,
         enabled_by_default: false,
       }),
     );

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1967,6 +1967,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         command: 'meter-mac',
         // The device uses a plain 12 hex digit MAC without ':'/'-' separators.
         pattern: '^[0-9A-Fa-f]{12}$',
+        // Write-only: the device never reports the configured MAC back.
+        optimistic: true,
         enabled_by_default: false,
       }),
     );
@@ -2004,6 +2006,8 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:meter-electric',
         command: 'meter-type',
         valueMappings: meterTypeLabels,
+        // Write-only: the device never reports the configured meter type back.
+        optimistic: true,
         enabled_by_default: false,
       }),
     );

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -268,6 +268,10 @@ export function getDeviceDefinition(
   return undefined;
 }
 
+export function getRegisteredDeviceTypes(): string[] {
+  return [...deviceDefinitionRegistry.keys()];
+}
+
 export function getSuggestedDeviceType(baseType: string): string | undefined {
   const threshold = Math.max(1, Math.floor(baseType.length / 2));
   let bestMatch: string | undefined;

--- a/src/discoveryStateTopics.test.ts
+++ b/src/discoveryStateTopics.test.ts
@@ -1,0 +1,113 @@
+import './device/registry.js';
+import {
+  BaseDeviceData,
+  getDeviceDefinition,
+  getRegisteredDeviceTypes,
+  MessageDefinition,
+} from './deviceDefinition.js';
+
+const COMMAND_TOPIC = 'hame_energy/HMA-1/control/test123/control';
+const STATE_TOPIC = 'hame_energy/HMA-1/device/test123/data';
+
+/** Keys every published payload carries, independent of the message definition. */
+const BASE_KEYS: ReadonlyArray<keyof BaseDeviceData> = [
+  'deviceType',
+  'deviceId',
+  'timestamp',
+  'values',
+];
+
+function joinPath(keyPath: ReadonlyArray<string | number>): string {
+  return keyPath.join('.');
+}
+
+/**
+ * The paths a message can actually publish: the base keys, the message's default
+ * state and every field the parser fills in.
+ */
+function publishablePaths(message: MessageDefinition<BaseDeviceData>): string[] {
+  return [
+    ...BASE_KEYS,
+    ...Object.keys(message.defaultState ?? {}),
+    ...message.fields.map(field => joinPath(field.path as ReadonlyArray<string | number>)),
+  ];
+}
+
+function isPublished(keyPath: string, publishable: string[]): boolean {
+  return publishable.some(
+    path => path === keyPath || keyPath.startsWith(`${path}.`) || path.startsWith(`${keyPath}.`),
+  );
+}
+
+function statefulAdvertisements() {
+  const result: Array<{
+    deviceType: string;
+    publishPath: string;
+    keyPath: string;
+    id: string;
+    hasStateTopic: boolean;
+  }> = [];
+  for (const deviceType of getRegisteredDeviceTypes()) {
+    const definition = getDeviceDefinition(deviceType);
+    for (const message of definition?.messages ?? []) {
+      for (const advertisement of message.advertisements) {
+        const keyPath = advertisement.keyPath as ReadonlyArray<string | number>;
+        if (keyPath.length === 0) {
+          // Non-stateful component (e.g. a button)
+          continue;
+        }
+        const config = advertisement.advertise({
+          commandTopic: COMMAND_TOPIC,
+          stateTopic: STATE_TOPIC,
+          keyPath,
+        });
+        result.push({
+          deviceType,
+          publishPath: message.publishPath,
+          keyPath: joinPath(keyPath),
+          id: config.id,
+          hasStateTopic: 'state_topic' in config && config.state_topic != null,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+describe('discovery state topics', () => {
+  /**
+   * Advertising a state topic for a value the device never reports makes Home
+   * Assistant render the value template against every published payload and log
+   * a `'dict object' has no attribute …` warning each time (see issue #346).
+   * Such write-only controls have to be advertised without a state topic, which
+   * puts the entity into optimistic mode.
+   */
+  test('every advertised state topic points at a value that is actually published', () => {
+    const unbacked = statefulAdvertisements()
+      .filter(advertisement => advertisement.hasStateTopic)
+      .filter(advertisement => {
+        const definition = getDeviceDefinition(advertisement.deviceType);
+        const message = definition!.messages.find(m => m.publishPath === advertisement.publishPath);
+        return !isPublished(advertisement.keyPath, publishablePaths(message!));
+      })
+      .map(a => `${a.deviceType}/${a.publishPath}: ${a.id} reads value_json.${a.keyPath}`);
+
+    expect(unbacked).toEqual([]);
+  });
+
+  test.each(['HMA', 'HMF', 'HMJ', 'HMK', 'HMG', 'VNSA', 'VNSD', 'VNSE3', 'HMN', 'HMM', 'JPLS'])(
+    '%s advertises the write-only meter controls without a state topic',
+    deviceType => {
+      const meterControls = statefulAdvertisements().filter(
+        advertisement =>
+          advertisement.deviceType === deviceType &&
+          ['meter_type', 'meter_mac'].includes(advertisement.id),
+      );
+
+      expect(meterControls).toHaveLength(2);
+      for (const control of meterControls) {
+        expect(control.hasStateTopic).toBe(false);
+      }
+    },
+  );
+});

--- a/src/homeAssistantDiscovery.ts
+++ b/src/homeAssistantDiscovery.ts
@@ -14,6 +14,16 @@ export interface HaBaseStateComponent extends HaBaseComponent {
   value_template: string;
 }
 
+/**
+ * Base for components that can be advertised without a state topic. Home
+ * Assistant treats such an entity as optimistic: it shows the last value that
+ * was set instead of subscribing to a state topic.
+ */
+export interface HaOptionalStateComponent extends HaBaseComponent {
+  state_topic?: string;
+  value_template?: string;
+}
+
 export interface HaBinarySensorComponent extends HaBaseStateComponent {
   type: 'binary_sensor';
   payload_on: string | number | boolean;
@@ -44,7 +54,7 @@ export interface HaNumberComponent extends Omit<HaSensorComponent, 'type'> {
   step?: number;
 }
 
-export interface HaTextComponent extends HaBaseStateComponent {
+export interface HaTextComponent extends HaOptionalStateComponent {
   type: 'text';
   command_topic: string;
   min?: number;
@@ -52,11 +62,10 @@ export interface HaTextComponent extends HaBaseStateComponent {
   pattern?: string;
 }
 
-export interface HaSelectComponent extends HaBaseStateComponent {
+export interface HaSelectComponent extends HaOptionalStateComponent {
   type: 'select';
   command_topic: string;
   options: string[];
-  value_template: string;
   command_template: string;
 }
 
@@ -168,6 +177,29 @@ export interface HaBaseStateComponentArgs extends HaBaseComponentArgs {
   defaultValue?: string;
 }
 
+/**
+ * Marks a control whose value the device never reports back, e.g. a setting that
+ * can only be written. Such a control must not be advertised with a state topic:
+ * Home Assistant would render the value template against every published payload
+ * and log a `'dict object' has no attribute …` warning each time, because the key
+ * is simply never there. Without a state topic Home Assistant switches the entity
+ * to optimistic mode and shows the last value that was set.
+ */
+export interface HaOptimisticComponentArgs {
+  optimistic?: boolean;
+}
+
+function stateSource(
+  definition: HaOptimisticComponentArgs,
+  args: AdvertiseBuilderArgs,
+  buildValueTemplate: () => string,
+): { state_topic?: string; value_template?: string } {
+  if (definition.optimistic) {
+    return {};
+  }
+  return { state_topic: args.stateTopic, value_template: buildValueTemplate() };
+}
+
 const baseSensor =
   (definitions: HaBaseComponentArgs) =>
   (_args: Omit<AdvertiseBuilderArgs, 'keyPath'>): HaBaseComponent => ({
@@ -258,38 +290,41 @@ export const switchComponent =
   });
 export const textComponent =
   <T extends string = string>(
-    definition: HaBaseStateComponentArgs & {
-      command: string;
-      max?: number;
-      min?: number;
-      pattern?: string;
-    },
+    definition: HaBaseStateComponentArgs &
+      HaOptimisticComponentArgs & {
+        command: string;
+        max?: number;
+        min?: number;
+        pattern?: string;
+      },
   ): HaStatefulAdvertiseBuilder<T> =>
   args => ({
-    ...baseStateSensor(definition)(args),
+    ...baseSensor(definition)(args),
+    ...stateSource(definition, args, () => valueTemplate(args)),
     type: 'text',
-    state_topic: args.stateTopic,
     command_topic: commandTopic({ ...args, ...definition }),
-    value_template: valueTemplate(args),
     max: definition.max,
     min: definition.min,
     pattern: definition.pattern,
   });
 export const selectComponent =
   <T extends string | number>(
-    definition: HaBaseStateComponentArgs & {
-      command: string;
-      valueMappings: Record<T, string>;
-      defaultValue?: T;
-    },
+    definition: HaBaseStateComponentArgs &
+      HaOptimisticComponentArgs & {
+        command: string;
+        valueMappings: Record<T, string>;
+        defaultValue?: T;
+      },
   ): HaStatefulAdvertiseBuilder<T, HaSelectComponent> =>
   args => ({
-    ...baseStateSensor(definition)(args),
+    ...baseSensor(definition)(args),
+    ...stateSource(definition, args, () =>
+      mappingValueTemplate({
+        value: getJinjaPath(args.keyPath),
+        valueMappings: definition.valueMappings,
+      }),
+    ),
     type: 'select',
-    value_template: mappingValueTemplate({
-      value: getJinjaPath(args.keyPath),
-      valueMappings: definition.valueMappings,
-    }),
     command_template: mappingValueTemplate({
       value: 'value',
       valueMappings: reverseMappings(definition.valueMappings),


### PR DESCRIPTION
## Summary

Fixes Home Assistant logging template variable warnings for write-only meter configuration controls (`meter-mac`, `meter-type`, and `recharge-mode`) that the device never reports back. These controls are now advertised without a state topic, putting them into Home Assistant's optimistic mode.

## Changes

- **New interface `HaOptionalStateComponent`**: Base for Home Assistant components that can be advertised without a state topic, allowing Home Assistant to operate in optimistic mode (showing the last set value rather than subscribing to a state topic).

- **New helper function `stateSource()`**: Determines whether to include `state_topic` and `value_template` based on an `optimistic` flag. When `optimistic: true`, these fields are omitted.

- **Updated `textComponent` and `selectComponent`**: Now accept an `HaOptimisticComponentArgs` parameter and use `stateSource()` to conditionally include state topic configuration.

- **Marked write-only controls as optimistic**:
  - B2500 V2/V3: `meter-mac`, `meter-type`, and `recharge-mode`
  - Venus: `meter-mac` and `meter-type`
  - Jupiter: `meter-mac` and `meter-type`

- **New test file `discoveryStateTopics.test.ts`**: Validates that every advertised state topic points to a value actually published by the device, and verifies that write-only meter controls are advertised without a state topic.

- **Updated documentation**: README.md now clarifies that `meter-mac` and `meter-type` are write-only and show the last set value.

- **Updated CHANGELOG.md**: Documents the fix for issue #346.

## Validation

- `npm run lint` ✓
- `npm run format:check` ✓
- `npm test -- --runInBand` ✓
- `npm run build` ✓

## Related Issue

Closes #346

https://claude.ai/code/session_01KLzc6ojiMsKLB4JzVbnGjb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Home Assistant handling for write-only meter settings and B2500 recharge mode.
  - Prevented missing-attribute warnings and invalid empty Meter MAC values.
  - Settings now retain the last submitted value when devices cannot report it back.

- **Documentation**
  - Clarified that Venus and Jupiter meter settings display the last configured values.

- **Tests**
  - Added coverage for device advertisements and state topic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->