### PR TITLE
Fix Jupiter BMS cell voltage parsing: use 3-field blocks per battery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
 - B2500 V2/V3: *Recharge Mode* was affected the same way and got the same fix
+- Jupiter: Fix the cell voltage sensors for external battery packs. Each pack occupies three `volX` fields, not four, so every external pack was read from the wrong offset: the *Cell With Highest/Lowest Voltage* sensors showed nonsensical cell numbers (such as 157 or 248, well beyond the 16 cells a pack has) and the *Highest/Lowest Cell Voltage* sensors mixed up voltages with packed cell numbers. The internal battery was unaffected. Confirmed against a device with four packs, see discussion #393
 
 ## [1.9.1] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
 - B2500 V2/V3: *Recharge Mode* was affected the same way and got the same fix
-- Jupiter: Fix the cell voltage sensors for external battery packs. Each pack occupies three `volX` fields, not four, so every external pack was read from the wrong offset: the *Cell With Highest/Lowest Voltage* sensors showed nonsensical cell numbers (such as 157 or 248, well beyond the 16 cells a pack has) and the *Highest/Lowest Cell Voltage* sensors mixed up voltages with packed cell numbers. The internal battery was unaffected. Confirmed against a device with four packs, see discussion #393
+- Jupiter: Fix the cell voltage sensors of external battery packs. *Cell With Highest Voltage* and *Cell With Lowest Voltage* showed cell numbers far beyond the 16 cells a pack has (such as 62 or 248), *Lowest Cell Voltage* could read 0 mV, and *Cell Voltage Difference* was correspondingly wrong. The sensors of the internal battery were not affected (see discussion #393)
 
 ## [1.9.1] - 2026-07-29
 

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -1248,6 +1248,13 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
       //   vol9=774  (cells 6/3)    vol10=3338  vol11=3327
       //   vol12=vol13=vol14=vol15=0
       //
+      // A dump from a device with one external pack (`b_num=2`) rules out a
+      // block size of four outright, as it only populates six fields:
+      //
+      //   vol0=526 (cells 14/2)    vol1=3241   vol2=3237
+      //   vol3=256 (cells 0/1)     vol4=3390   vol5=3386
+      //   vol6..vol15=0
+      //
       // See: https://github.com/tomquist/hm2mqtt/discussions/253
       //      https://github.com/tomquist/hm2mqtt/discussions/393
 

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -1232,21 +1232,28 @@ function registerJupiterBMSInfoMessage(message: BuildMessageFn) {
       // byte encodes the cell with the maximum voltage.
       //
       // In addition to that, Marstek Jupiter C Plus can have up to 3 extra
-      // batteries attached, and the remaining `volX` fields should provide
-      // voltages for those batteries in the same way. However, we don't know
-      // where the block of values for the next battery starts. When no external
-      // batteries are attached, `vol3` to `vol15` are all `0`.
+      // batteries attached, and the remaining `volX` fields provide the same
+      // information for those batteries. Each battery gets a block of *three*
+      // `volX` fields, so battery N starts at `vol${N * 3}`. When fewer
+      // batteries are attached, the trailing fields are all `0`.
       //
-      // For now, we will assume that four `volX` fields correspond to each
-      // battery, as it nicely aligns with 16 being divisible by 4 (1 internal
-      // battery + up to 3 external batteries). I don't have external batteries,
-      // so I can't verify this assumption.
+      // This was confirmed by a dump from a device with four battery packs
+      // (`b_num=4`), where each 3-field block decodes into plausible values,
+      // while a 4-field block does not (it yields cell numbers such as 248,
+      // which is way out of range for a 16-cell pack):
+      //
+      //   vol0=1039 (cells 15/4)   vol1=3353   vol2=3326
+      //   vol3=1    (cells 1/0)    vol4=3320   vol5=3319
+      //   vol6=2063 (cells 15/8)   vol7=3362   vol8=3328
+      //   vol9=774  (cells 6/3)    vol10=3338  vol11=3327
+      //   vol12=vol13=vol14=vol15=0
       //
       // See: https://github.com/tomquist/hm2mqtt/discussions/253
+      //      https://github.com/tomquist/hm2mqtt/discussions/393
 
       // Batteries: 1 internal (battery 0) + up to 3 external (batteries 1-3)
       for (let batteryIndex = 0; batteryIndex < 4; batteryIndex++) {
-        const baseIndex = batteryIndex * 4;
+        const baseIndex = batteryIndex * 3;
         const batteryLabel =
           batteryIndex === 0 ? 'Internal Battery' : `External Battery ${batteryIndex}`;
         const volNumberKey = `vol${baseIndex}`;

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -794,13 +794,14 @@ describe('MQTT Message Parser', () => {
   });
 
   test('should parse Jupiter BMS cell voltages with one external battery pack', () => {
-    // Real-world message from a Jupiter C Plus with one external battery pack
-    // (`b_num=2`), see https://github.com/tomquist/hm2mqtt/discussions/393
+    // Real-world message from a Jupiter C Plus (JPLS-8H) with one external
+    // battery pack (`b_num=2`), see
+    // https://github.com/tomquist/hm2mqtt/discussions/393
     // Only vol0-vol5 are populated, which is what pins the block size down to
     // three: a block size of four would need vol4-vol7 for the second pack.
     const message =
       'bms:c_vol=584,c_cur=500,d_cur=500,soc=38,soh=0,b_cap=5120,b_vol=5420,b_cur=300,b_temp=290,b_err=0,b_war=0,b_err2=0,b_war2=0,c_flag=192,s_flag=0,b_num=2,vol0=526,vol1=3241,vol2=3237,vol3=256,vol4=3390,vol5=3386,vol6=0,vol7=0,vol8=0,vol9=0,vol10=0,vol11=0,vol12=0,vol13=0,vol14=0,vol15=0,b_temp0=29,b_temp1=28,b_temp2=28,b_temp3=28,env_t=37,mos_t=30,lck=0';
-    const deviceType = 'JPLS-1';
+    const deviceType = 'JPLS-8H';
     const deviceId = 'jupiter123';
 
     const parsed = parseMessage(message, deviceType, deviceId);

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -635,16 +635,20 @@ describe('MQTT Message Parser', () => {
     // Cell voltages (vol0-vol15)
     expect(result).toHaveProperty('cells');
 
-    // Battery cell voltages: 4 batteries, each using 4 volX values
-    // Battery 0 (internal): vol0, vol1, vol2, vol3
-    // Battery 1 (external 1): vol4, vol5, vol6, vol7
-    // Battery 2 (external 2): vol8, vol9, vol10, vol11
-    // Battery 3 (external 3): vol12, vol13, vol14, vol15
+    // Battery cell voltages: 4 batteries, each using 3 volX values
+    // Battery 0 (internal): vol0, vol1, vol2
+    // Battery 1 (external 1): vol3, vol4, vol5
+    // Battery 2 (external 2): vol6, vol7, vol8
+    // Battery 3 (external 3): vol9, vol10, vol11
+    //
+    // NOTE: The volX values in this message are synthetic (all 16 are non-zero
+    // and in the same range), so they only exercise the field indexing. See the
+    // "multiple battery packs" test below for a real-world message.
     expect(result).toHaveProperty('batteries');
     expect(Array.isArray(result.batteries)).toBe(true);
     expect(result.batteries).toHaveLength(4);
 
-    // Battery 0 (internal): vol0=3280 (0x0CD0), vol1=3281, vol2=3283, vol3=3283
+    // Battery 0 (internal): vol0=3280 (0x0CD0), vol1=3281, vol2=3283
     expect(result.batteries?.[0]).toHaveProperty('cellVoltages');
     expect(result.batteries?.[0]?.cellVoltages?.maxVoltage).toBe(3281);
     expect(result.batteries?.[0]?.cellVoltages?.minVoltage).toBe(3283);
@@ -655,30 +659,30 @@ describe('MQTT Message Parser', () => {
     // Drift (difference) between highest and lowest cell voltage
     expect(result.batteries?.[0]?.cellVoltages?.voltageDiff).toBe(2);
 
-    // Battery 1 (external 1): vol4=3283 (0x0CD3), vol5=3283, vol6=3280, vol7=3284
+    // Battery 1 (external 1): vol3=3283 (0x0CD3), vol4=3283, vol5=3283
     expect(result.batteries?.[1]).toHaveProperty('cellVoltages');
     expect(result.batteries?.[1]?.cellVoltages?.maxVoltage).toBe(3283);
-    expect(result.batteries?.[1]?.cellVoltages?.minVoltage).toBe(3280);
+    expect(result.batteries?.[1]?.cellVoltages?.minVoltage).toBe(3283);
     // Low byte: 0xD3 = 211
     expect(result.batteries?.[1]?.cellVoltages?.maxVoltageCell).toBe(211);
     // High byte: 0x0C = 12
     expect(result.batteries?.[1]?.cellVoltages?.minVoltageCell).toBe(12);
 
-    // Battery 2 (external 2): vol8=3283 (0x0CD3), vol9=3284, vol10=3282, vol11=3286
+    // Battery 2 (external 2): vol6=3280 (0x0CD0), vol7=3284, vol8=3283
     expect(result.batteries?.[2]).toHaveProperty('cellVoltages');
     expect(result.batteries?.[2]?.cellVoltages?.maxVoltage).toBe(3284);
-    expect(result.batteries?.[2]?.cellVoltages?.minVoltage).toBe(3282);
-    // Low byte: 0xD3 = 211
-    expect(result.batteries?.[2]?.cellVoltages?.maxVoltageCell).toBe(211);
+    expect(result.batteries?.[2]?.cellVoltages?.minVoltage).toBe(3283);
+    // Low byte: 0xD0 = 208
+    expect(result.batteries?.[2]?.cellVoltages?.maxVoltageCell).toBe(208);
     // High byte: 0x0C = 12
     expect(result.batteries?.[2]?.cellVoltages?.minVoltageCell).toBe(12);
 
-    // Battery 3 (external 3): vol12=3277 (0x0CCD), vol13=3286, vol14=3283, vol15=3284
+    // Battery 3 (external 3): vol9=3284 (0x0CD4), vol10=3282, vol11=3286
     expect(result.batteries?.[3]).toHaveProperty('cellVoltages');
-    expect(result.batteries?.[3]?.cellVoltages?.maxVoltage).toBe(3286);
-    expect(result.batteries?.[3]?.cellVoltages?.minVoltage).toBe(3283);
-    // Low byte: 0xCD = 205
-    expect(result.batteries?.[3]?.cellVoltages?.maxVoltageCell).toBe(205);
+    expect(result.batteries?.[3]?.cellVoltages?.maxVoltage).toBe(3282);
+    expect(result.batteries?.[3]?.cellVoltages?.minVoltage).toBe(3286);
+    // Low byte: 0xD4 = 212
+    expect(result.batteries?.[3]?.cellVoltages?.maxVoltageCell).toBe(212);
     // High byte: 0x0C = 12
     expect(result.batteries?.[3]?.cellVoltages?.minVoltageCell).toBe(12);
 
@@ -747,6 +751,46 @@ describe('MQTT Message Parser', () => {
     expect(result.inverter).toHaveProperty('gridPower', 119);
     expect(result.inverter).toHaveProperty('gridPowerFactor', 0);
     expect(result.inverter).toHaveProperty('gridFrequency', 50.02);
+  });
+
+  test('should parse Jupiter BMS cell voltages for multiple battery packs', () => {
+    // Real-world message from a Jupiter C Plus (JPLS-8H) with four battery
+    // packs (`b_num=4`), see https://github.com/tomquist/hm2mqtt/discussions/393
+    // Each pack occupies three volX fields: packed cell numbers, maximum cell
+    // voltage, minimum cell voltage. The trailing vol12-vol15 are unused.
+    const message =
+      'inv:g_state=1,w_state1=1,w_state2=1,i_err=0,i_war=0,g_vol=2436,g_cur=0,g_pf=0,g_fre=5000,b_vol=536,g_power=0,i_temp=40,mppt:m_state=148,m_err=0,m_temp=38,m_war=0,pv1=429|26|1121,pv2=114|0|0,pv3=114|0|0,pv4=435|27|1179,b_vol=532,b_cur=43,base_v=220,pe_v=161,fail_t=0,bms:c_vol=584,c_cur=500,d_cur=500,soc=81,soh=0,b_cap=10240,b_vol=5340,b_cur=48,b_temp=290,b_err=0,b_war=0,b_err2=0,b_war2=0,c_flag=192,s_flag=0,b_num=4,vol0=1039,vol1=3353,vol2=3326,vol3=1,vol4=3320,vol5=3319,vol6=2063,vol7=3362,vol8=3328,vol9=774,vol10=3338,vol11=3327,vol12=0,vol13=0,vol14=0,vol15=0,b_temp0=28,b_temp1=28,b_temp2=28,b_temp3=29,env_t=36,mos_t=28,lck=0';
+    const deviceType = 'JPLS-8H';
+    const deviceId = 'jupiter123';
+
+    const parsed = parseMessage(message, deviceType, deviceId);
+    const result = parsed['bms'] as JupiterBMSInfo;
+
+    expect(result.bms).toHaveProperty('bmsNumber', 4);
+    expect(result.batteries).toHaveLength(4);
+
+    // All decoded cell numbers must be within range of a 16-cell pack, and all
+    // voltages must be plausible cell voltages. This is what rules out a
+    // 4-field block, which would decode voltages as cell numbers (e.g. 248).
+    const expected = [
+      // vol0=1039 (0x040F), vol1=3353, vol2=3326
+      { maxVoltageCell: 15, minVoltageCell: 4, maxVoltage: 3353, minVoltage: 3326, diff: 27 },
+      // vol3=1 (0x0001), vol4=3320, vol5=3319
+      { maxVoltageCell: 1, minVoltageCell: 0, maxVoltage: 3320, minVoltage: 3319, diff: 1 },
+      // vol6=2063 (0x080F), vol7=3362, vol8=3328
+      { maxVoltageCell: 15, minVoltageCell: 8, maxVoltage: 3362, minVoltage: 3328, diff: 34 },
+      // vol9=774 (0x0306), vol10=3338, vol11=3327
+      { maxVoltageCell: 6, minVoltageCell: 3, maxVoltage: 3338, minVoltage: 3327, diff: 11 },
+    ];
+
+    expected.forEach((values, index) => {
+      const cellVoltages = result.batteries?.[index]?.cellVoltages;
+      expect(cellVoltages?.maxVoltageCell).toBe(values.maxVoltageCell);
+      expect(cellVoltages?.minVoltageCell).toBe(values.minVoltageCell);
+      expect(cellVoltages?.maxVoltage).toBe(values.maxVoltage);
+      expect(cellVoltages?.minVoltage).toBe(values.minVoltage);
+      expect(cellVoltages?.voltageDiff).toBe(values.diff);
+    });
   });
 
   test('should convert negative Jupiter BMS temperatures correctly', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -793,6 +793,36 @@ describe('MQTT Message Parser', () => {
     });
   });
 
+  test('should parse Jupiter BMS cell voltages with one external battery pack', () => {
+    // Real-world message from a Jupiter C Plus with one external battery pack
+    // (`b_num=2`), see https://github.com/tomquist/hm2mqtt/discussions/393
+    // Only vol0-vol5 are populated, which is what pins the block size down to
+    // three: a block size of four would need vol4-vol7 for the second pack.
+    const message =
+      'bms:c_vol=584,c_cur=500,d_cur=500,soc=38,soh=0,b_cap=5120,b_vol=5420,b_cur=300,b_temp=290,b_err=0,b_war=0,b_err2=0,b_war2=0,c_flag=192,s_flag=0,b_num=2,vol0=526,vol1=3241,vol2=3237,vol3=256,vol4=3390,vol5=3386,vol6=0,vol7=0,vol8=0,vol9=0,vol10=0,vol11=0,vol12=0,vol13=0,vol14=0,vol15=0,b_temp0=29,b_temp1=28,b_temp2=28,b_temp3=28,env_t=37,mos_t=30,lck=0';
+    const deviceType = 'JPLS-1';
+    const deviceId = 'jupiter123';
+
+    const parsed = parseMessage(message, deviceType, deviceId);
+    const result = parsed['bms'] as JupiterBMSInfo;
+
+    expect(result.bms).toHaveProperty('bmsNumber', 2);
+
+    // Internal battery: vol0=526 (0x020E), vol1=3241, vol2=3237
+    expect(result.batteries?.[0]?.cellVoltages?.maxVoltageCell).toBe(14);
+    expect(result.batteries?.[0]?.cellVoltages?.minVoltageCell).toBe(2);
+    expect(result.batteries?.[0]?.cellVoltages?.maxVoltage).toBe(3241);
+    expect(result.batteries?.[0]?.cellVoltages?.minVoltage).toBe(3237);
+    expect(result.batteries?.[0]?.cellVoltages?.voltageDiff).toBe(4);
+
+    // External battery 1: vol3=256 (0x0100), vol4=3390, vol5=3386
+    expect(result.batteries?.[1]?.cellVoltages?.maxVoltageCell).toBe(0);
+    expect(result.batteries?.[1]?.cellVoltages?.minVoltageCell).toBe(1);
+    expect(result.batteries?.[1]?.cellVoltages?.maxVoltage).toBe(3390);
+    expect(result.batteries?.[1]?.cellVoltages?.minVoltage).toBe(3386);
+    expect(result.batteries?.[1]?.cellVoltages?.voltageDiff).toBe(4);
+  });
+
   test('should convert negative Jupiter BMS temperatures correctly', () => {
     const message =
       'inv:g_state=1,w_state1=1,w_state2=1,i_err=0,i_war=0,g_vol=2340,g_cur=0,g_pf=0,g_fre=4997,b_vol=544,g_power=0,i_temp=-31,mppt:m_state=244,m_err=0,m_temp=5,m_war=0,pv1=377|3|146,pv2=389|6|258,pv3=387|6|236,pv4=376|3|141,b_vol=545,b_cur=14,base_v=222,pe_v=165,bms:c_vol=600,c_cur=75,d_cur=100,soc=44,soh=0,b_cap=2560,b_vol=5420,b_cur=14,b_temp=-25,b_err=0,b_war=0,b_err2=0,b_war2=0,c_flag=192,s_flag=0,b_num=1,vol0=3343,vol1=3397,vol2=3320,vol3=0,vol4=0,vol5=0,vol6=0,vol7=0,vol8=0,vol9=0,vol10=0,vol11=0,vol12=0,vol13=0,vol14=0,vol15=0,b_temp0=255,b_temp1=254,b_temp2=253,b_temp3=252,env_t=128,mos_t=127';


### PR DESCRIPTION
## Summary

Corrects the Jupiter BMS cell voltage parsing logic to use 3-field blocks per battery instead of 4-field blocks. This fix is based on real-world device data from users with multiple battery packs.

## Changes

- **Parser logic** (`src/device/jupiter.ts`): Changed battery block size from 4 to 3 `volX` fields per battery. Each battery now uses `vol${batteryIndex * 3}` as its base index instead of `vol${batteryIndex * 4}`.

- **Test updates** (`src/parser.test.ts`):
  - Updated existing synthetic test case to reflect 3-field blocks and corrected expected values
  - Added new test case `'should parse Jupiter BMS cell voltages for multiple battery packs'` with real-world data from a device with 4 battery packs (`b_num=4`)
  - Added new test case `'should parse Jupiter BMS cell voltages with one external battery pack'` with real-world data from a device with 1 external pack (`b_num=2`)

- **Documentation** (`src/device/jupiter.ts`): Enhanced code comments with detailed analysis of the 3-field block structure, including hex dumps from real devices that confirm the block size and rule out the 4-field assumption.

## Validation

The fix is validated by:
1. Real-world message from a Jupiter C Plus (JPLS-8H) with 4 battery packs, where each 3-field block decodes into plausible cell numbers (0–15) and voltages (~3.3V), while a 4-field block would yield invalid cell numbers (e.g., 248)
2. Real-world message from a Jupiter C Plus (JPLS-1) with 1 external pack, which only populates 6 fields—confirming that a 4-field block would require 8 fields for 2 batteries
3. All existing tests pass with corrected expectations

Closes #393

https://claude.ai/code/session_01SraKptFjHEHFyrJeeLK6xD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Jupiter battery-pack cell counts.
  * Fixed minimum cell voltage readings that incorrectly displayed as zero.
  * Improved cell-voltage difference calculations.
  * Added support for accurate readings across two- and four-pack configurations.

* **Documentation**
  * Added a changelog entry describing the Jupiter battery-pack fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->