### PR TITLE
B2500: Drop implausible state of charge readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
 - B2500 V2/V3: *Recharge Mode* was affected the same way and got the same fix
 - Jupiter: Fix the cell voltage sensors of external battery packs. *Cell With Highest Voltage* and *Cell With Lowest Voltage* showed cell numbers far beyond the 16 cells a pack has (such as 62 or 248), *Lowest Cell Voltage* could read 0 mV, and *Cell Voltage Difference* was correspondingly wrong. The sensors of the internal battery were not affected (see discussion #393)
+- B2500: Ignore state of charge readings outside 0-100%. The extra batteries occasionally report values like 4873% or 56577%, which ended up in Home Assistant's long-term statistics; the *Battery Percentage* and *Battery SoC* sensors now show unknown for that poll instead (fixes #97)
 
 ## [1.9.1] - 2026-07-29
 

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -77,10 +77,13 @@ export function registerBaseMessage({
   );
 
   // Battery information
+  // State of charge is a percentage, so anything outside 0-100 is a corrupt
+  // reading. Drop it so the sensor goes unknown for that poll instead of
+  // writing an implausible spike into the long-term statistics.
   field({
     key: 'pe',
     path: ['batteryPercentage'],
-    transform: number(),
+    transform: inRange(0, 100),
   });
   advertise(
     ['batteryPercentage'],
@@ -567,10 +570,14 @@ export function registerBaseMessage({
   );
 
   // Battery capacity values
+  // The host and the attached extra batteries report their state of charge as
+  // a percentage. The firmware occasionally emits garbage here (values such as
+  // 2425 or 56577, see issue #97), so readings outside 0-100 are dropped and
+  // the sensor goes unknown for that poll rather than polluting the statistics.
   field({
     key: 'a0',
     path: ['batteryCapacities', 'host'],
-    transform: number(),
+    transform: inRange(0, 100),
   });
   advertise(
     ['batteryCapacities', 'host'],
@@ -585,7 +592,7 @@ export function registerBaseMessage({
   field({
     key: 'a1',
     path: ['batteryCapacities', 'extra1'],
-    transform: number(),
+    transform: inRange(0, 100),
   });
   advertise(
     ['batteryCapacities', 'extra1'],
@@ -601,7 +608,7 @@ export function registerBaseMessage({
   field({
     key: 'a2',
     path: ['batteryCapacities', 'extra2'],
-    transform: number(),
+    transform: inRange(0, 100),
   });
   advertise(
     ['batteryCapacities', 'extra2'],

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -175,6 +175,40 @@ describe('MQTT Message Parser', () => {
     expect((without['data'] as B2500V2DeviceData).wifiSignalStrength).toBeUndefined();
   });
 
+  test('should drop out-of-range state of charge readings (issue #97)', () => {
+    const base = 'pe=75,kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0';
+    const soc = (keys: string) =>
+      parseMessage(`${base},${keys}`, 'HMA-1', '12345')['data'] as B2500V2DeviceData;
+
+    // Plausible readings pass through unchanged, including both boundaries.
+    const valid = soc('a0=14,a1=0,a2=100');
+    expect(valid.batteryCapacities).toHaveProperty('host', 14);
+    expect(valid.batteryCapacities).toHaveProperty('extra1', 0);
+    expect(valid.batteryCapacities).toHaveProperty('extra2', 100);
+
+    // The firmware occasionally reports impossible percentages for the extra
+    // batteries. Those are dropped so the sensor goes unknown for that poll.
+    const spike = soc('a0=14,a1=56577,a2=2425');
+    expect(spike.batteryCapacities).toHaveProperty('host', 14);
+    expect(spike.batteryCapacities?.extra1).toBeUndefined();
+    expect(spike.batteryCapacities?.extra2).toBeUndefined();
+    // The published payload leaves the keys out entirely, so Home Assistant
+    // sees the sensors as unknown and keeps them out of the statistics.
+    expect(JSON.parse(JSON.stringify(spike.batteryCapacities))).toEqual({ host: 14 });
+
+    // Negative readings are rejected as well.
+    expect(soc('a0=-1,a1=0,a2=0').batteryCapacities?.host).toBeUndefined();
+
+    // The main battery percentage uses the same bounds.
+    const mainSpike = parseMessage(
+      'pe=4873,kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0',
+      'HMA-1',
+      '12345',
+    )['data'] as B2500V2DeviceData;
+    expect(mainSpike.batteryPercentage).toBeUndefined();
+    expect(soc('a0=0').batteryPercentage).toBe(75);
+  });
+
   test('should parse all 16 cell voltages per pack', () => {
     const cells = (prefix: string, mv: number) =>
       Array.from({ length: 16 }, (_, i) => `${prefix}${i.toString(16)}=${mv + i}`).join(',');

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -199,14 +199,18 @@ describe('MQTT Message Parser', () => {
     // Negative readings are rejected as well.
     expect(soc('a0=-1,a1=0,a2=0').batteryCapacities?.host).toBeUndefined();
 
-    // The main battery percentage uses the same bounds.
-    const mainSpike = parseMessage(
-      'pe=4873,kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0',
-      'HMA-1',
-      '12345',
-    )['data'] as B2500V2DeviceData;
-    expect(mainSpike.batteryPercentage).toBeUndefined();
-    expect(soc('a0=0').batteryPercentage).toBe(75);
+    expect(soc('a0=0').batteryCapacities).toHaveProperty('host', 0);
+
+    // The main battery percentage uses the same bounds, boundaries included.
+    const main = (pe: string) =>
+      parseMessage(
+        `pe=${pe},kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0`,
+        'HMA-1',
+        '12345',
+      )['data'] as B2500V2DeviceData;
+    expect(main('4873').batteryPercentage).toBeUndefined();
+    expect(main('0').batteryPercentage).toBe(0);
+    expect(main('100').batteryPercentage).toBe(100);
   });
 
   test('should parse all 16 cell voltages per pack', () => {


### PR DESCRIPTION
## What changed

`pe`, `a0`, `a1` and `a2` in `src/device/b2500Base.ts` now use `transform: inRange(0, 100)` instead of `number()`, so a percentage outside 0–100 is dropped rather than published.

Affected entities: *Battery Percentage*, *Host Battery SoC*, *Extra 1 Battery SoC*, *Extra 2 Battery SoC*.

## Why

The B2500 intermittently reports impossible SoC values for attached P2500 extra batteries — 2425%, 4873% and 56577% have all been seen, a few times a day. These landed in Home Assistant long-term statistics and wrecked the history graphs.

**Dropped, not clamped.** Capping at 100 would write a plausible-looking datapoint into statistics that is indistinguishable from a genuinely full battery. Returning `undefined` means `JSON.stringify` omits the key, the sensor goes unknown for that poll, and — because these sensors carry `state_class: measurement` — Home Assistant excludes it from statistics entirely. The result is a gap rather than a spike.

This follows the existing precedent for the WiFi RSSI field (`b2500Base.ts`), which filters its two "no reading" sentinels the same way.

## Scope

`pe` (main battery) was included alongside the extra-battery fields even though reporters only ever observed spikes on the extras: it has identical semantics, arrives in the same runtime-info payload from the same firmware, and nothing downstream computes from it. `isB2500RuntimeInfoMessage` tests `'pe' in values` against the raw string map, not the transformed output, so filtering the parsed value cannot cause a payload to be misclassified.

Venus per-pack `socN` and Jupiter `soc` were deliberately left alone — no spikes reported there.

## Validation

Run on this branch rebased onto current `develop`:

```
npm run lint          # exit 0
npm run format:check  # exit 0
npm test -- --runInBand   # 14 suites, 475 tests, all passing
npm run build         # exit 0
```

New test in `src/parser.test.ts` covers an out-of-range reading being dropped and the inclusive 0 and 100 boundaries still parsing.

## For review

- `setValueAtPath` assigns the key with value `undefined` rather than omitting it, so `'extra1' in state.batteryCapacities` remains `true` in the in-memory state. The HA-visible behaviour is correct because `JSON.stringify` drops undefined values, and the test asserts that explicitly rather than relying on the in-memory shape. I found no consumer that inspects device state with `in` or `Object.keys`, but that is the one place worth a second look.
- `0` remains valid and is preserved. This does not distinguish "no extra pack attached" from "pack at 0%" — unchanged from current behaviour.

Closes #97
Also covers the duplicate reports in #375 and #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ju4zYmDyP3puBZqsKL4UE

---
_Generated by [Claude Code](https://claude.ai/code/session_018ju4zYmDyP3puBZqsKL4UE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid B2500 battery state-of-charge readings below 0% or above 100% are now ignored.
  * Battery Percentage and Battery SoC sensors show as unknown when readings are invalid.
  * Invalid host and extra battery capacity values are excluded from reported data.
* **Documentation**
  * Added a changelog entry describing the updated battery reading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->