### PR TITLE
B2500 V2/V3: Gate extra battery voltage/current sensors on what the device reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Jupiter: Fix the cell voltage sensors of external battery packs. *Cell With Highest Voltage* and *Cell With Lowest Voltage* showed cell numbers far beyond the 16 cells a pack has (such as 62 or 248), *Lowest Cell Voltage* could read 0 mV, and *Cell Voltage Difference* was correspondingly wrong. The sensors of the internal battery were not affected (see discussion #393)
 - B2500: On devices with a CT meter attached, an ordinary status poll was mistaken for an extra battery reading, so the *Input Voltage* and *Extra Battery 2 Voltage* sensors showed the meter's power readings scaled down to a few volts
 - B2500: Ignore state of charge readings outside 0-100%. The extra batteries occasionally report values like 4873% or 56577%, which ended up in Home Assistant's long-term statistics; the *Battery Percentage* and *Battery SoC* sensors now show unknown for that poll instead (fixes #97)
+- B2500 V2/V3: Remove the extra battery voltage and current sensors on firmware that does not report them. On 113.x they sat permanently at unknown; they reappear after a firmware upgrade that reports them (fixes #280)
 
 ## [1.9.1] - 2026-07-29
 

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -972,6 +972,30 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
     getAdditionalDeviceInfo: () => ({}),
     enabled: process.env.POLL_EXTRA_BATTERY_DATA === 'true',
   } as const;
+  // Some firmware versions (e.g. B2500 113.x) answer `cd=16` without the
+  // voltage/current keys, which leaves the corresponding sensors permanently
+  // unknown. `timestamp` cannot be used as the "we got a `cd=16` response"
+  // marker because the device state handed to the discovery generator is a flat
+  // merge of all message paths and every message carries a timestamp. The
+  // top-level `cd=16` keys are exclusive to this message instead, and
+  // `isB2500CD16Message` guarantees at least one of them is set for every
+  // recognized response.
+  const hasExtraBatteryData = (state: B2500V2CD16Data) =>
+    state.input1 != null ||
+    state.input2 != null ||
+    state.output1 != null ||
+    state.output2 != null ||
+    state.batteryData != null;
+  // Defer the decision until a `cd=16` response has been seen, then advertise
+  // the sensor only if the device actually reports its value.
+  const isExtraBatteryValueReported =
+    (getValue: (state: B2500V2CD16Data) => number | undefined) =>
+    (state: B2500V2CD16Data): boolean | undefined => {
+      if (!hasExtraBatteryData(state)) {
+        return undefined;
+      }
+      return getValue(state) != null;
+    };
   message<B2500V2CD16Data>(options, ({ field, advertise }) => {
     advertise(
       ['timestamp'],
@@ -998,6 +1022,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
           unit_of_measurement: 'V',
           state_class: 'measurement',
         }),
+        { enabled: isExtraBatteryValueReported(state => state[`input${input}`]?.voltage) },
       );
       field({
         key: `c${input}`,
@@ -1013,6 +1038,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
           unit_of_measurement: 'A',
           state_class: 'measurement',
         }),
+        { enabled: isExtraBatteryValueReported(state => state[`input${input}`]?.current) },
       );
       field({
         key: `w${input}`,
@@ -1033,6 +1059,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
           unit_of_measurement: 'V',
           state_class: 'measurement',
         }),
+        { enabled: isExtraBatteryValueReported(state => state[`output${input}`]?.voltage) },
       );
       field({
         key: `c${input + 2}`,
@@ -1048,6 +1075,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
           unit_of_measurement: 'A',
           state_class: 'measurement',
         }),
+        { enabled: isExtraBatteryValueReported(state => state[`output${input}`]?.current) },
       );
       field({
         key: `g${input}`,
@@ -1073,6 +1101,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         unit_of_measurement: 'V',
         state_class: 'measurement',
       }),
+      { enabled: isExtraBatteryValueReported(state => state.batteryData?.host?.voltage) },
     );
     field({
       key: 'bc',
@@ -1088,6 +1117,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         unit_of_measurement: 'A',
         state_class: 'measurement',
       }),
+      { enabled: isExtraBatteryValueReported(state => state.batteryData?.host?.current) },
     );
     field({
       key: 'sb',
@@ -1108,6 +1138,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         state_class: 'measurement',
         enabled_by_default: false,
       }),
+      { enabled: isExtraBatteryValueReported(state => state.batteryData?.extra1?.voltage) },
     );
     field({
       key: 'sc',
@@ -1124,6 +1155,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         state_class: 'measurement',
         enabled_by_default: false,
       }),
+      { enabled: isExtraBatteryValueReported(state => state.batteryData?.extra1?.current) },
     );
     field({
       key: 'lb',
@@ -1144,6 +1176,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         state_class: 'measurement',
         enabled_by_default: false,
       }),
+      { enabled: isExtraBatteryValueReported(state => state.batteryData?.extra2?.voltage) },
     );
     field({
       key: 'lc',
@@ -1160,6 +1193,7 @@ export function registerExtraBatteryData(message: BuildMessageFn) {
         state_class: 'measurement',
         enabled_by_default: false,
       }),
+      { enabled: isExtraBatteryValueReported(state => state.batteryData?.extra2?.current) },
     );
   });
 }

--- a/src/generateDiscoveryConfigs.test.ts
+++ b/src/generateDiscoveryConfigs.test.ts
@@ -733,4 +733,159 @@ describe('Home Assistant Discovery', () => {
     ).filter(c => /phase\d_charge/.test(c.topic));
     expect(smr).toHaveLength(0);
   });
+
+  describe('B2500 V2 extra battery voltage/current sensors', () => {
+    const device: Device = { deviceType: 'HMJ-2', deviceId: 'b2500123' };
+    const deviceTopics: DeviceTopics = {
+      deviceTopicOld: 'hame_energy/HMJ-2/device/b2500123/ctrl',
+      deviceTopicNew: 'marstek_energy/HMJ-2/device/b2500123/ctrl',
+      deviceControlTopicOld: 'hame_energy/HMJ-2/App/b2500123/ctrl',
+      deviceControlTopicNew: 'marstek_energy/HMJ-2/App/b2500123/ctrl',
+      availabilityTopic: 'hame_energy/HMJ-2/availability/b2500123',
+      controlSubscriptionTopic: 'hame_energy/HMJ-2/control/b2500123/control',
+      publishTopic: 'hame_energy/HMJ-2/device/b2500123/data',
+    };
+
+    const gatedObjectIds = [
+      'solar_input_voltage_1',
+      'solar_input_voltage_2',
+      'solar_input_current_1',
+      'solar_input_current_2',
+      'output_voltage_1',
+      'output_voltage_2',
+      'output_current_1',
+      'output_current_2',
+      'battery_voltage',
+      'battery_current',
+      'battery_extra1_voltage',
+      'battery_extra1_current',
+      'battery_extra2_voltage',
+      'battery_extra2_current',
+    ];
+
+    // The `cd=16` message is only built when POLL_EXTRA_BATTERY_DATA is set, so the
+    // device definitions have to be registered again with the flag turned on.
+    const gatedConfigs = async (state: object) => {
+      const previous = process.env.POLL_EXTRA_BATTERY_DATA;
+      process.env.POLL_EXTRA_BATTERY_DATA = 'true';
+      jest.resetModules();
+      try {
+        await import('./device/registry.js');
+        const { generateDiscoveryConfigs: generate } =
+          await import('./generateDiscoveryConfigs.js');
+        return generate(
+          device,
+          deviceTopics,
+          {},
+          DEFAULT_TOPIC_PREFIX,
+          'homeassistant',
+          state,
+        ).filter(c => gatedObjectIds.includes(c.topic.split('/').slice(-2)[0]));
+      } finally {
+        if (previous == null) {
+          delete process.env.POLL_EXTRA_BATTERY_DATA;
+        } else {
+          process.env.POLL_EXTRA_BATTERY_DATA = previous;
+        }
+        jest.resetModules();
+      }
+    };
+
+    test('should not announce or remove them before a cd=16 response arrived', async () => {
+      // Only cd=01 data so far. The merged device state carries a timestamp from
+      // that message, which must not be mistaken for a cd=16 response.
+      const configs = await gatedConfigs({
+        deviceType: 'HMJ-2',
+        deviceId: 'b2500123',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        batteryPercentage: 50,
+      });
+      expect(configs).toHaveLength(0);
+    });
+
+    test('should announce the values the device reports', async () => {
+      const configs = await gatedConfigs({
+        deviceType: 'HMJ-2',
+        deviceId: 'b2500123',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        input1: { voltage: 30, current: 1, power: 30 },
+        input2: { voltage: 0, current: 0, power: 0 },
+        output1: { voltage: 52, current: 0.5, power: 25 },
+        output2: { voltage: 0, current: 0, power: 0 },
+        batteryData: {
+          host: { power: 100, voltage: 52, current: 2 },
+          extra1: { power: 0, voltage: 51, current: 0 },
+          extra2: { power: 0, voltage: 50, current: 0 },
+        },
+      });
+      expect(configs).toHaveLength(gatedObjectIds.length);
+      expect(configs.every(c => c.config !== null)).toBe(true);
+    });
+
+    test('should remove them when the device answers cd=16 without them', async () => {
+      // Firmware 113.x answers cd=16 without any voltage/current keys (fixes #280)
+      const configs = await gatedConfigs({
+        deviceType: 'HMJ-2',
+        deviceId: 'b2500123',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        input1: { power: 30 },
+        input2: { power: 0 },
+        output1: { power: 25 },
+        output2: { power: 0 },
+        batteryData: {
+          host: { power: 100 },
+          extra1: { power: 0 },
+          extra2: { power: 0 },
+        },
+      });
+      expect(configs).toHaveLength(gatedObjectIds.length);
+      expect(configs.every(c => c.config === null)).toBe(true);
+    });
+
+    test('should gate each value on its own, not on the message as a whole', async () => {
+      // A response that carries the input voltages but none of the currents
+      const configs = await gatedConfigs({
+        deviceType: 'HMJ-2',
+        deviceId: 'b2500123',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        input1: { voltage: 30, power: 30 },
+        input2: { voltage: 0, power: 0 },
+      });
+      const byObjectId = Object.fromEntries(
+        configs.map(c => [c.topic.split('/').slice(-2)[0], c.config]),
+      );
+      expect(byObjectId['solar_input_voltage_1']).not.toBeNull();
+      expect(byObjectId['solar_input_voltage_2']).not.toBeNull();
+      expect(byObjectId['solar_input_current_1']).toBeNull();
+      expect(byObjectId['output_voltage_1']).toBeNull();
+      expect(byObjectId['battery_voltage']).toBeNull();
+    });
+
+    test('should keep the extra battery timestamp sensor ungated', async () => {
+      const previous = process.env.POLL_EXTRA_BATTERY_DATA;
+      process.env.POLL_EXTRA_BATTERY_DATA = 'true';
+      jest.resetModules();
+      try {
+        await import('./device/registry.js');
+        const { generateDiscoveryConfigs: generate } =
+          await import('./generateDiscoveryConfigs.js');
+        const timestampConfig = generate(
+          device,
+          deviceTopics,
+          {},
+          DEFAULT_TOPIC_PREFIX,
+          'homeassistant',
+          { deviceType: 'HMJ-2', deviceId: 'b2500123' },
+        ).find(c => c.topic.includes('/timestamp_extra_battery_data/config'));
+        expect(timestampConfig?.config).not.toBeNull();
+      } finally {
+        if (previous == null) {
+          delete process.env.POLL_EXTRA_BATTERY_DATA;
+        } else {
+          process.env.POLL_EXTRA_BATTERY_DATA = previous;
+        }
+        jest.resetModules();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## What changed

Adds `hasExtraBatteryData` / `isExtraBatteryValueReported` helpers in `src/device/b2500V2.ts` and passes them as the `enabled` predicate to the 14 voltage/current sensors advertised from the `cd=16` extra-battery message.

Each sensor is gated on **its own** value, so a firmware that reports some fields but not others keeps the ones it does report.

Gated: *Input Voltage 1/2*, *Input Current 1/2*, *Output Voltage 1/2*, *Output Current 1/2*, *Host Battery Voltage/Current*, *Extra 1 Battery Voltage/Current*, *Extra 2 Battery Voltage/Current*.

Left alone: *Extra Battery Last Updated* (it is the arrival marker), and the power fields, which have no `advertise` call.

## Why

Firmware 113.x answers `cd=16` without any voltage or current readings, leaving about a dozen entities permanently stuck at unknown (#280). Firmware 116.6 reports them normally — three reporters confirmed the upgrade fixes it.

The `enabled` predicate is three-state in `generateDiscoveryConfigs`, which is exactly what this needs:

- `undefined` → publish nothing (device has not answered `cd=16` yet)
- `true` → publish the discovery config
- `false` → publish `config: null`, removing the entity from Home Assistant

Presence-gating rather than version-gating: only 113.1 (broken) and 116.6 (working) are confirmed, so any version threshold would be a guess. Presence also self-heals — the entities come back on their own after a firmware upgrade. Same approach as the Venus PV strings.

## Implementation note

`DeviceManager.getDeviceState` returns a **flat** merge of all message states, so `cd=16` data appears at top level as `input1`/`input2`/`output1`/`output2`/`batteryData` — the `publishPath` is not a key in that object. The marker for "a `cd=16` has actually arrived" is therefore the presence of one of those `cd=16`-exclusive keys.

`timestamp` is **not** usable as the marker: `parseMessage` stamps it on every message, so it is set as soon as any `cd=01` arrives, and using it would have deleted these sensors for every user. There is a regression test for exactly that case.

## Validation

Run on this branch rebased onto current `develop`:

```
npm run lint          # exit 0
npm run format:check  # exit 0
npm test -- --runInBand   # 14 suites, 475 tests, all passing
npm run build         # exit 0
```

Five new cases in `src/generateDiscoveryConfigs.test.ts`: no `cd=16` yet → 0 configs (with a `timestamp` present, guarding the trap above); `cd=16` with values → 14 non-null; `cd=16` without values → 14 nulls; per-field gating; and the timestamp sensor staying ungated.

## For review

- **The predicate only runs when `POLL_EXTRA_BATTERY_DATA=true`.** `deviceDefinition.ts` already short-circuits a disabled message's advertisements to `config: null`, so these entities are removed today for anyone not polling `cd=16`. That is pre-existing behaviour, not a change here, but it is why the new tests re-register the device definitions with the env var set.
- **`Closes #280` may be premature.** No reporter ever attached a raw 113.x payload, and neither shape accepted by `isB2500CD16Message` exactly matches the reported set of missing fields. If 113.x sends a `cd=16` response that `isB2500CD16Message` does not recognise at all, no state is stored, the predicate correctly defers, and the stale entities would persist rather than be removed. This fix is correct for every recognised response; worth confirming against a real payload before closing, and happy to downgrade the keyword to a plain reference.
- The extra1/extra2 pairs go slightly beyond the literal issue: an absent `sv`/`lv` could in principle mean "no extra pack attached" rather than "old firmware". Removing the entity still seems better than a permanent unknown, but it is a judgement call.

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ju4zYmDyP3puBZqsKL4UE

---
_Generated by [Claude Code](https://claude.ai/code/session_018ju4zYmDyP3puBZqsKL4UE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extra B2500 V2/V3 battery voltage and current sensors now appear only when supported and reported by the device firmware.
  * Sensors are handled independently, preventing unavailable readings from appearing.
  * Existing sensors become available automatically after upgrading to firmware that reports these values.
* **Documentation**
  * Added a changelog entry describing sensor availability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->