### PR TITLE
B2500: Stop classifying a runtime poll as extra battery data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
 - B2500 V2/V3: *Recharge Mode* was affected the same way and got the same fix
 - Jupiter: Fix the cell voltage sensors of external battery packs. *Cell With Highest Voltage* and *Cell With Lowest Voltage* showed cell numbers far beyond the 16 cells a pack has (such as 62 or 248), *Lowest Cell Voltage* could read 0 mV, and *Cell Voltage Difference* was correspondingly wrong. The sensors of the internal battery were not affected (see discussion #393)
+- B2500: On devices with a CT meter attached, an ordinary status poll was mistaken for an extra battery reading, so the *Input Voltage* and *Extra Battery 2 Voltage* sensors showed the meter's power readings scaled down to a few volts
 - B2500: Ignore state of charge readings outside 0-100%. The extra batteries occasionally report values like 4873% or 56577%, which ended up in Home Assistant's long-term statistics; the *Battery Percentage* and *Battery SoC* sensors now show unknown for that poll instead (fixes #97)
 
 ## [1.9.1] - 2026-07-29

--- a/src/device/b2500V1.ts
+++ b/src/device/b2500V1.ts
@@ -190,6 +190,12 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
 }
 
 function isB2500CD16Message(message: Record<string, string>): boolean {
+  // None of the keys below are exclusive to cd=16, so a complete cd=01 runtime
+  // response can satisfy them as well. Such a response is never extra battery
+  // data.
+  if (isB2500RuntimeInfoMessage(message)) {
+    return false;
+  }
   const cd16VoltageInfo = ['p1', 'p2', 'm1', 'm2', 'w1', 'w2', 'e1', 'e2', 'o1', 'o2', 'g1', 'g2'];
   const forbiddenKeys = ['m3', 'cj'];
   if (cd16VoltageInfo.every(k => k in message) && !forbiddenKeys.some(k => k in message)) {

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -949,6 +949,13 @@ function isB2500CD16Message(message: Record<string, string>): boolean {
   if (cd16BatteryInfo.every(k => k in message)) {
     return true;
   }
+  // None of the keys below are exclusive to cd=16: in a cd=01 runtime response
+  // `m1`/`m2` are the CT clip 2/3 measured power instead of the input voltages,
+  // so a status poll from a device with a CT meter attached looks the same. A
+  // complete runtime response is never extra battery data.
+  if (isB2500RuntimeInfoMessage(message)) {
+    return false;
+  }
   const cd16VoltageInfo = ['p1', 'p2', 'm1', 'm2', 'w1', 'w2', 'e1', 'e2', 'o1', 'o2', 'g1', 'g2'];
   const forbiddenKeys = ['m3', 'cj'];
   return cd16VoltageInfo.every(k => k in message) && !forbiddenKeys.some(k => k in message);

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -4,6 +4,7 @@ import { parseMessage } from './parser.js';
 import logger from './logger.js';
 import {
   B2500CellData,
+  B2500V2CD16Data,
   B2500V2DeviceData,
   CT002DeviceData,
   CT002PhaseEnergyInfo,
@@ -211,6 +212,46 @@ describe('MQTT Message Parser', () => {
     expect(main('4873').batteryPercentage).toBeUndefined();
     expect(main('0').batteryPercentage).toBe(0);
     expect(main('100').batteryPercentage).toBe(100);
+  });
+
+  test('should not read a runtime poll as extra battery data', () => {
+    const runtime =
+      'pe=75,kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0';
+    const paths = (message: string, deviceType = 'HMA-1') =>
+      Object.keys(parseMessage(message, deviceType, '12345')).sort();
+
+    // A runtime response from a device with a CT meter attached carries the
+    // clip power readings (m0/m1/m2) and a second time period. In a cd=16
+    // response m1/m2 are the input voltages instead, so this used to be
+    // published as extra battery data too, turning a 200 W clip reading into an
+    // input voltage of 0.2 V.
+    expect(paths(runtime)).toEqual(['data']);
+    expect(paths(`${runtime},m0=100,m1=200,m2=300,e2=0:0`)).toEqual(['data']);
+    expect(paths(`${runtime},m0=100,m1=200,m2=300,e2=0:0`, 'HMB-1')).toEqual(['data']);
+    // A micro-inverter power reading or the scene field already kept those
+    // messages out before, and still does.
+    expect(paths(`${runtime},m0=100,m1=200,m2=300,e2=0:0,m3=50`)).toEqual(['data']);
+    expect(paths(`${runtime},m0=100,m1=200,m2=300,e2=0:0,cj=1`)).toEqual(['data']);
+
+    // Genuine cd=16 responses are still recognised: the full payload with the
+    // per-pack battery measurements ...
+    const full =
+      'm1=32000,m2=0,c1=1000,c2=0,w1=32,w2=0,i1=230000,i2=0,c3=100,c4=0,g1=23,g2=0,' +
+      'bb=100,bv=52000,bc=1900,sb=0,sv=0,sc=0,lb=0,lv=0,lc=0';
+    expect(paths(full)).toEqual(['extraBatteryData']);
+    const fullData = parseMessage(full, 'HMA-1', '12345')['extraBatteryData'] as B2500V2CD16Data;
+    expect(fullData.input1?.voltage).toBeCloseTo(32, 5);
+    expect(fullData.batteryData?.host?.voltage).toBeCloseTo(52, 5);
+
+    // ... and the input/output-only payload.
+    const inputsOnly = 'p1=0,p2=0,m1=32000,m2=0,w1=32,w2=0,e1=0,e2=0,o1=0,o2=0,g1=23,g2=0';
+    expect(paths(inputsOnly)).toEqual(['extraBatteryData']);
+    const inputsOnlyData = parseMessage(inputsOnly, 'HMA-1', '12345')[
+      'extraBatteryData'
+    ] as B2500V2CD16Data;
+    expect(inputsOnlyData.input1?.voltage).toBeCloseTo(32, 5);
+    expect(inputsOnlyData.output1?.power).toBe(23);
+    expect(paths(inputsOnly, 'HMB-1')).toEqual(['extraBatteryData']);
   });
 
   test('should parse all 16 cell voltages per pack', () => {


### PR DESCRIPTION
## What changed

`isB2500CD16Message` now rejects any message that `isB2500RuntimeInfoMessage` accepts — a complete runtime response is never extra battery data. Same guard added to the parallel V1 classifier.

## Why

Marstek messages are unlabeled, so the message type is inferred from which keys are present. The `cd=16` classifier accepted anything containing `p1, p2, m1, m2, w1, w2, e1, e2, o1, o2, g1, g2` as long as `m3` and `cj` were absent.

Those keys are not exclusive to `cd=16`. Per `docs/b2500.md`, `m1`/`m2` are the **CT clip 2/3 measured power** in a `cd=01` runtime response, and only the **input 1/2 voltage** in `cd=16`. So an ordinary status poll from a device with a CT meter attached, no micro-inverter reading and no scene field matched *both* message definitions.

Reproduced by feeding raw payloads through `parseMessage`, using the runtime fixture already in `parser.test.ts` as `base`:

```
base                                        -> ["data"]
base + m0=100,m1=200,m2=300,e2=0:0          -> ["data", "extraBatteryData"]   <-- bug
base + m0=100,m1=200,m2=300,e2=0:0,m3=50    -> ["data"]
```

The colliding case published `input1: {voltage: 0.2}`, `input2: {voltage: 0.3}` and `batteryData: {extra2: {voltage: 0.3}}` — a 200 W clip reading shown as 0.2 V. `POLL_EXTRA_BATTERY_DATA` gates polling, not parsing, so this affected users who never enabled the feature.

## Why this discriminator is safe

The `cd=16` payload tables in `docs/b2500.md` list only `m1 m2 c1 c2 w1 w2 i1 i2 c3 c4 g1 g2 bb bv bc sb sv sc lb lv lc`. None of `pe`, `kn`, `do`, `vv` — the runtime-only keys the guard keys off — appear in any documented `cd=16` payload, V1 or V2. Neither `registerExtraBatteryData` implementation reads them either. On split-status firmware (`cd=15` + `cd=16`) those fields land in the `cd=15` half, so the guard still holds.

Placement matters: the guard sits **after** the `bb/bv/bc/sb/sv/sc/lb/lv/lc` branch in V2. Those keys are `cd=16`-exclusive and no runtime response can satisfy that branch, so leaving it unguarded costs nothing and keeps genuine extra-battery data recognisable. The existing `m3`/`cj` exclusions are kept — now largely subsumed, but still catching a truncated runtime message carrying `cj` without `pe`.

## Validation

```
npm run lint          # exit 0
npm run format:check  # exit 0
npm test -- --runInBand   # 14 suites, 472 tests, all passing
npm run build         # exit 0
```

New regression tests in `src/parser.test.ts` drive **raw message strings through `parseMessage`** rather than hand-built parsed state: the colliding `cd=01` no longer yields `extraBatteryData`, both genuine `cd=16` shapes still classify, and the `m3`/`cj` cases still behave. Reverting only the two device-file edits makes the new test fail with `+ "extraBatteryData"`, so it genuinely covers the bug.

## For review

- **The loose branch itself is untouched.** It requires `p1 p2 e1 e2 o1 o2`, keys that appear in no documented `cd=16` payload. It dates to the squashed initial import with no issue reference, and its `m3`/`cj` exclusions read like an earlier, incomplete attempt at exactly this discrimination. Tightening it further is a separate question.
- **If some firmware really does answer `cd=16` including `pe`/`kn`/`do`/`vv`, this guard would now reject it.** Such a payload was already broken — it would have been double-published as runtime data before.
- **The genuine `cd=16` test fixtures are synthetic.** There were no pre-existing `cd=16` fixtures anywhere in the suite, so they were built from the documentation tables. Worth a glance from someone with a real device capture, particularly the `bv=52000` / `m1=32000` scaling.
- The V1 change is not reachable today — the CT block is V2-only per the docs, and `m0`–`m3` are parsed only in `b2500V2.ts`. Added for consistency and in case V1 firmware gains CT support.

Found while reviewing #397, which used the presence of `extraBatteryData` as a signal to remove Home Assistant entities. On top of this fix that signal becomes trustworthy; without it, the misclassification would have deleted entities and their registry customisations rather than merely showing a wrong value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ju4zYmDyP3puBZqsKL4UE

---
_Generated by [Claude Code](https://claude.ai/code/session_018ju4zYmDyP3puBZqsKL4UE)_