### PR TITLE
Use "next" as development add-on version between releases

### DIFF
--- a/bump-version.ts
+++ b/bump-version.ts
@@ -31,7 +31,9 @@ function updatePackageJson(newVersion: string) {
 function updateConfigYaml(newVersion: string) {
   const configPath = path.join(__dirname, 'ha_addon', 'config.yaml');
   let config = fs.readFileSync(configPath, 'utf8');
-  config = config.replace(/version: *["']?[\d.]+["']?/, `version: "${newVersion}"`);
+  // Between releases develop carries `version: "next"`, so this has to match a
+  // non-numeric version too.
+  config = config.replace(/^version: *["']?[^"'\n]+["']?/m, `version: "${newVersion}"`);
   fs.writeFileSync(configPath, config);
   console.log(`Updated ha_addon/config.yaml to version ${newVersion}`);
 }

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -1,5 +1,5 @@
 name: "hm2mqtt"
-version: "1.9.1"
+version: "next"
 slug: "hm2mqtt"
 description: "Connect Hame energy storage devices to Home Assistant via MQTT"
 url: "https://github.com/tomquist/hm2mqtt"

--- a/release.sh
+++ b/release.sh
@@ -42,6 +42,11 @@ VERSION="$1"
 RELEASE_BRANCH="release/v${VERSION}"
 CURRENT_DATE=$(date +%Y-%m-%d)
 
+# Add-on version that develop carries between releases. It doubles as the image
+# tag the Home Assistant Supervisor pulls, and matches the `next` tag CI pushes
+# for every commit on develop.
+DEV_ADDON_VERSION="next"
+
 # Validate version format (semantic versioning)
 if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     print_error "Version must follow semantic versioning format (e.g., 1.2.3)"
@@ -233,6 +238,20 @@ if ! grep -q "\[Next\]" CHANGELOG.md; then
 
     git add CHANGELOG.md
     git commit -m "Add new [Next] section to CHANGELOG.md"
+fi
+
+# Point the add-on back at the development image. The Home Assistant Supervisor
+# uses the `version` from ha_addon/config.yaml as the tag of the prebuilt
+# `image`, so as long as develop carries the released version, installing the
+# add-on from the `#develop` repository pulls the released image instead of the
+# development build that CI publishes as `:next`.
+if ! grep -q "^version: \"${DEV_ADDON_VERSION}\"" ha_addon/config.yaml; then
+    print_info "Restoring add-on version '${DEV_ADDON_VERSION}' in ha_addon/config.yaml"
+    sed -i.bak "s/^version: \"[^\"]*\"/version: \"${DEV_ADDON_VERSION}\"/" ha_addon/config.yaml
+    rm ha_addon/config.yaml.bak
+
+    git add ha_addon/config.yaml
+    git commit -m "Point the add-on back at the ${DEV_ADDON_VERSION} image on develop"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updates the release workflow to use `"next"` as the add-on version on the `develop` branch between releases. This ensures that Home Assistant Supervisor pulls the development image (tagged `:next` by CI) rather than the previously-released image when installing from the `#develop` repository.

## Changes

- **release.sh**: Added logic to restore the add-on version to `"next"` after creating a release branch, ensuring `develop` carries the development version between releases
- **bump-version.ts**: Updated the regex pattern to match non-numeric versions (like `"next"`) when bumping versions during release, not just semantic version numbers
- **ha_addon/config.yaml**: Changed version from `"1.9.1"` to `"next"` to reflect the development state

## Implementation Details

The release process now:
1. Creates a release branch with the semantic version (e.g., `1.9.1`)
2. Restores `develop` to use `version: "next"` in `ha_addon/config.yaml`
3. Ensures the version bump script can handle both numeric versions and the `"next"` placeholder

This maintains the correct image tag resolution: the `version` field in `ha_addon/config.yaml` is used by Home Assistant Supervisor as the image tag, so using `"next"` on develop ensures the latest development build is pulled rather than a stale released version.

https://claude.ai/code/session_01NDY6zKSNTzTwfZMiMbuVHa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version handling to support non-numeric release labels such as “next.”
  * Updated the add-on version to “next.”
  * Enhanced release automation to preserve the development version during branch synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->