### PR TITLE
B2500: ignore the CT no-reading value; rename Jupiter's daily energy sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@
 - B2500: On devices with a CT meter attached, an ordinary status poll was mistaken for an extra battery reading, so the *Input Voltage* and *Extra Battery 2 Voltage* sensors showed the meter's power readings scaled down to a few volts
 - MQTT Proxy: Stop logging `Modified client ID … (conflict resolution)` over and over for a single reconnecting device and leaving its old connection open. Only devices that really do share one client ID are renamed now (fixes #398, PR #400)
 - B2500: Ignore state of charge readings outside 0-100%. The extra batteries occasionally report values like 4873% or 56577%, which ended up in Home Assistant's long-term statistics; the *Battery Percentage* and *Battery SoC* sensors now show unknown for that poll instead (fixes #97)
-- B2500 V2/V3: Ignore the CT sensor's "no reading" value on the *CT Transmitted Power*, *CT Clip Power 1-3* and *Micro Inverter Power* sensors. When the clamp has nothing to measure it reports 65535, which Home Assistant recorded as a real 65535 W spike in its long-term statistics and which distorted any average or maximum computed from those sensors. Such a poll is now skipped and the sensors keep their previous reading, matching what the Marstek app shows
+- B2500 V2/V3: Ignore the CT sensor's "no reading" value on the *CT Transmitted Power*, *CT Clip Power 1-3* and *Micro Inverter Power* sensors. When the clamp has nothing to measure it reports 65535, which Home Assistant recorded as a real 65535 W spike in its long-term statistics, distorting any average or maximum computed from those sensors. Those readings are now ignored and the sensors keep their previous value, matching what the Marstek app shows (PR #403)
 
 ### Changed
 
-- Jupiter: The *Daily Charging Capacity* sensor measures the energy the solar panels produced today, not the energy charged into the battery, and has been renamed to *Daily Power Generation* (`daily_charging_capacity` becomes `daily_power_generation`). If you added it to the Energy Dashboard, move it from a battery entry to *Solar production*; its recorded history stays with the old entity. The monthly and yearly counters are unchanged for now
-- Venus: The *Working Mode* option *Automatic* is now called *Self Consumption*, the name the Marstek app uses for the same mode. Automations that select the mode by name need updating; sending `automatic` to the MQTT command topic still works
+- Jupiter: The *Daily Charging Capacity* sensor measures the energy the solar panels produced today, not the energy charged into the battery, and has been renamed to *Daily Power Generation* (`daily_charging_capacity` becomes `daily_power_generation`). If you added it to the Energy Dashboard, move it from a battery entry to *Solar production*; its recorded history stays with the old entity. The monthly and yearly counters are unchanged for now (PR #403)
 
 ## [1.9.1] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - B2500: On devices with a CT meter attached, an ordinary status poll was mistaken for an extra battery reading, so the *Input Voltage* and *Extra Battery 2 Voltage* sensors showed the meter's power readings scaled down to a few volts
 - MQTT Proxy: Stop logging `Modified client ID … (conflict resolution)` over and over for a single reconnecting device and leaving its old connection open. Only devices that really do share one client ID are renamed now (fixes #398, PR #400)
 - B2500: Ignore state of charge readings outside 0-100%. The extra batteries occasionally report values like 4873% or 56577%, which ended up in Home Assistant's long-term statistics; the *Battery Percentage* and *Battery SoC* sensors now show unknown for that poll instead (fixes #97)
+- B2500 V2/V3: Ignore the CT sensor's "no reading" value on the *CT Transmitted Power*, *CT Clip Power 1-3* and *Micro Inverter Power* sensors. When the clamp has nothing to measure it reports 65535, which Home Assistant recorded as a real 65535 W spike in its long-term statistics and which distorted any average or maximum computed from those sensors. Such a poll is now skipped and the sensors keep their previous reading, matching what the Marstek app shows
 
 ## [1.9.1] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - B2500: Ignore state of charge readings outside 0-100%. The extra batteries occasionally report values like 4873% or 56577%, which ended up in Home Assistant's long-term statistics; the *Battery Percentage* and *Battery SoC* sensors now show unknown for that poll instead (fixes #97)
 - B2500 V2/V3: Ignore the CT sensor's "no reading" value on the *CT Transmitted Power*, *CT Clip Power 1-3* and *Micro Inverter Power* sensors. When the clamp has nothing to measure it reports 65535, which Home Assistant recorded as a real 65535 W spike in its long-term statistics and which distorted any average or maximum computed from those sensors. Such a poll is now skipped and the sensors keep their previous reading, matching what the Marstek app shows
 
+### Changed
+
+- Jupiter: The *Daily Charging Capacity* sensor measures the energy the solar panels produced today, not the energy charged into the battery, and has been renamed to *Daily Power Generation* (`daily_charging_capacity` becomes `daily_power_generation`). If you added it to the Energy Dashboard, move it from a battery entry to *Solar production*; its recorded history stays with the old entity. The monthly and yearly counters are unchanged for now
+- Venus: The *Working Mode* option *Automatic* is now called *Self Consumption*, the name the Marstek app uses for the same mode. Automations that select the mode by name need updating; sending `automatic` to the MQTT command topic still works
+
 ## [1.9.1] - 2026-07-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@
 - B2500: On devices with a CT meter attached, an ordinary status poll was mistaken for an extra battery reading, so the *Input Voltage* and *Extra Battery 2 Voltage* sensors showed the meter's power readings scaled down to a few volts
 - MQTT Proxy: Stop logging `Modified client ID … (conflict resolution)` over and over for a single reconnecting device and leaving its old connection open. Only devices that really do share one client ID are renamed now (fixes #398, PR #400)
 - B2500: Ignore state of charge readings outside 0-100%. The extra batteries occasionally report values like 4873% or 56577%, which ended up in Home Assistant's long-term statistics; the *Battery Percentage* and *Battery SoC* sensors now show unknown for that poll instead (fixes #97)
-- B2500 V2/V3: Ignore the CT sensor's "no reading" value on the *CT Transmitted Power*, *CT Clip Power 1-3* and *Micro Inverter Power* sensors. When the clamp has nothing to measure it reports 65535, which Home Assistant recorded as a real 65535 W spike in its long-term statistics, distorting any average or maximum computed from those sensors. Those readings are now ignored and the sensors keep their previous value, matching what the Marstek app shows (PR #403)
+- B2500 V2/V3: Ignore implausible CT sensor readings. With nothing to measure the clamp reports 65535 W, which ended up in Home Assistant's long-term statistics; *CT Transmitted Power*, *CT Clip Power 1-3* and *Micro Inverter Power* now keep their previous value instead (PR #403)
 
 ### Changed
 
-- Jupiter: The *Daily Charging Capacity* sensor measures the energy the solar panels produced today, not the energy charged into the battery, and has been renamed to *Daily Power Generation* (`daily_charging_capacity` becomes `daily_power_generation`). If you added it to the Energy Dashboard, move it from a battery entry to *Solar production*; its recorded history stays with the old entity. The monthly and yearly counters are unchanged for now (PR #403)
+- Jupiter: *Daily Charging Capacity* reports today's solar production, not the energy charged into the battery, and is now called *Daily Power Generation*. If you added it to the Energy Dashboard, move it from a battery entry to *Solar production* (PR #403)
 
 ## [1.9.1] - 2026-07-29
 

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -35,7 +35,28 @@ import {
   switchComponent,
   textComponent,
 } from '../homeAssistantDiscovery.js';
-import { number, boolean, map, timeString, equalsBoolean, divide } from '../transforms.js';
+import { number, boolean, map, timeString, equalsBoolean, divide, inRange } from '../transforms.js';
+
+/**
+ * The CT sensor reports a sentinel instead of a reading when it has no valid
+ * measurement (typically 65535, the top of its 16-bit range). The Marstek app
+ * checks every CT power field against 60000 and discards anything at or above
+ * it, so the same cut-off is applied here to `st`, `m0`, `m1`, `m2` and `m3` —
+ * the exact five fields the app guards. `sp` is deliberately not guarded: the
+ * app does not guard it either.
+ *
+ * Out-of-range readings are dropped rather than reported as 0 W, so the sensor
+ * keeps its last real value instead of a fabricated zero.
+ */
+const CT_POWER_SENTINEL = 60000;
+
+/**
+ * A CT power reading in watts, ignoring the sensor's no-reading sentinel.
+ *
+ * The app applies no lower bound; the one here exists only because `inRange`
+ * requires it, and -60 kW is far outside what a B2500 CT clamp can measure.
+ */
+const ctPower = () => inRange(-(CT_POWER_SENTINEL - 1), CT_POWER_SENTINEL - 1);
 
 /**
  * Create a time period handler for a specific setting
@@ -457,7 +478,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     field({
       key: 'st',
       path: ['ctInfo', 'transmittedPower'],
-      transform: number(),
+      transform: ctPower(),
     });
     advertise(
       ['ctInfo', 'transmittedPower'],
@@ -557,7 +578,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     field({
       key: 'm0',
       path: ['ctInfo', 'phase1'],
-      transform: number(),
+      transform: ctPower(),
     });
     advertise(
       ['ctInfo', 'phase1'],
@@ -572,7 +593,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     field({
       key: 'm1',
       path: ['ctInfo', 'phase2'],
-      transform: number(),
+      transform: ctPower(),
     });
     advertise(
       ['ctInfo', 'phase2'],
@@ -587,7 +608,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     field({
       key: 'm2',
       path: ['ctInfo', 'phase3'],
-      transform: number(),
+      transform: ctPower(),
     });
     advertise(
       ['ctInfo', 'phase3'],
@@ -640,7 +661,7 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
     field({
       key: 'm3',
       path: ['ctInfo', 'microInverterPower'],
-      transform: number(),
+      transform: ctPower(),
     });
     advertise(
       ['ctInfo', 'microInverterPower'],

--- a/src/device/jupiter.ts
+++ b/src/device/jupiter.ts
@@ -208,17 +208,21 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
+    // `ele_d` counts the energy the panels produced today, which the Marstek app
+    // shows as the day's power generation. It is not the energy charged into the
+    // battery, which is what this sensor used to claim to be.
     field({
       key: 'ele_d',
-      path: ['dailyChargingCapacity'],
+      path: ['dailyPowerGeneration'],
       transform: divide(100),
       monotonic: true,
     });
     advertise(
-      ['dailyChargingCapacity'],
+      ['dailyPowerGeneration'],
       sensorComponent<number>({
-        id: 'daily_charging_capacity',
-        name: 'Daily Charging Capacity',
+        id: 'daily_power_generation',
+        name: 'Daily Power Generation',
+        icon: 'mdi:solar-power-variant',
         device_class: 'energy',
         unit_of_measurement: 'kWh',
         state_class: 'total_increasing',

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1000,7 +1000,10 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:cog',
         command: 'working-mode',
         valueMappings: {
-          automatic: 'Automatic',
+          // `wor_m=0` is the self-consumption mode. The internal value stays
+          // `automatic` (which is also what Marstek calls it internally), so
+          // the command topic keeps accepting the same payload.
+          automatic: 'Self Consumption',
           manual: 'Manual',
           trading: 'Trading',
           ai: 'AI',

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -1000,10 +1000,13 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         icon: 'mdi:cog',
         command: 'working-mode',
         valueMappings: {
-          // `wor_m=0` is the self-consumption mode. The internal value stays
-          // `automatic` (which is also what Marstek calls it internally), so
-          // the command topic keeps accepting the same payload.
-          automatic: 'Self Consumption',
+          // `wor_m=0` is the self-consumption mode, which the Marstek app shows
+          // as "Self Consumption". The option is left as "Automatic" because it
+          // is what an entity in this select reports as its state: renaming it
+          // would break automations that set or compare the mode by name, for
+          // no functional gain. Marstek's own internal name for the mode is
+          // "Auto".
+          automatic: 'Automatic',
           manual: 'Manual',
           trading: 'Trading',
           ai: 'AI',

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -176,6 +176,32 @@ describe('MQTT Message Parser', () => {
     expect((without['data'] as B2500V2DeviceData).wifiSignalStrength).toBeUndefined();
   });
 
+  test('should drop the CT sensor no-reading sentinel from the power fields', () => {
+    const base = 'pe=75,kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0';
+    const ctInfo = (fields: string) =>
+      (parseMessage(`${base},${fields}`, 'HMA-1', '12345')['data'] as B2500V2DeviceData).ctInfo;
+
+    // Real readings pass through unscaled, including negative ones.
+    const real = ctInfo('st=120,m0=230,m1=-45,m2=0,m3=310');
+    expect(real).toHaveProperty('transmittedPower', 120);
+    expect(real).toHaveProperty('phase1', 230);
+    expect(real).toHaveProperty('phase2', -45);
+    expect(real).toHaveProperty('phase3', 0);
+    expect(real).toHaveProperty('microInverterPower', 310);
+
+    // 65535 means "no reading", and the app's cut-off is 60000, so anything
+    // from there up is dropped rather than published as a real power value.
+    const sentinel = ctInfo('st=65535,m0=65535,m1=60000,m2=65535,m3=65535');
+    expect(sentinel?.transmittedPower).toBeUndefined();
+    expect(sentinel?.phase1).toBeUndefined();
+    expect(sentinel?.phase2).toBeUndefined();
+    expect(sentinel?.phase3).toBeUndefined();
+    expect(sentinel?.microInverterPower).toBeUndefined();
+
+    // Just below the cut-off is still a valid reading.
+    expect(ctInfo('st=59999')).toHaveProperty('transmittedPower', 59999);
+  });
+
   test('should drop out-of-range state of charge readings (issue #97)', () => {
     const base = 'pe=75,kn=500,lv=300,e1=0:0,do=90,p1=0,p2=0,w1=0,w2=0,vv=224,o1=0,o2=0,g1=0,g2=0';
     const soc = (keys: string) =>

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -643,7 +643,7 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('timestamp');
 
     // Energy statistics
-    expect(result).toHaveProperty('dailyChargingCapacity', 3.49);
+    expect(result).toHaveProperty('dailyPowerGeneration', 3.49);
     expect(result).toHaveProperty('monthlyChargingCapacity', 21.93);
     expect(result).toHaveProperty('yearlyChargingCapacity', 0);
     expect(result).toHaveProperty('dailyDischargeCapacity', 2.85);

--- a/src/types.ts
+++ b/src/types.ts
@@ -673,7 +673,10 @@ export function isValidJupiterRechargeMode(mode: string): mode is JupiterRecharg
 }
 
 export interface JupiterDeviceData extends BaseDeviceData {
-  dailyChargingCapacity?: number; // ele_d
+  // `ele_d` is the day's solar production, not energy charged into the battery.
+  // The monthly and yearly counters below are almost certainly the same
+  // quantity, but that could not be established, so they keep their old names.
+  dailyPowerGeneration?: number; // ele_d
   monthlyChargingCapacity?: number; // ele_m
   yearlyChargingCapacity?: number; // ele_y
   pv1Power?: number; // pv1_p


### PR DESCRIPTION
## What changed

Two corrections to B2500 and Jupiter entities, each aligning hm2mqtt with the behaviour and naming of the Marstek app.

### Fix: B2500 CT sensors published the "no reading" value as a real measurement

The CT clamp reports `65535` when it has nothing valid to measure. hm2mqtt forwarded that verbatim on five sensors that all carry `state_class: measurement`, so Home Assistant recorded 65535 W spikes into long-term statistics, permanently skewing any average or maximum derived from them.

The Marstek app treats a CT power reading of 60000 or above as invalid and does not display it. The same cut-off now applies to the five CT power fields the app guards — `st`, `m0`, `m1`, `m2` and `m3` — which back *CT Transmitted Power*, *CT Clip Power 1-3* and *Micro Inverter Power*.

Two deliberate choices:

- **`sp` is left alone.** It sits in the same CT block and looks like it should be guarded, but the app does not guard it.
- **Readings are dropped, not replaced with 0.** This follows the existing `inRange` convention in this repo (`ws`, state of charge), so a sensor keeps its last real value rather than reporting a fabricated 0 W that is indistinguishable from a genuine one.

### Rename: Jupiter *Daily Charging Capacity* → *Daily Power Generation*

`ele_d` counts the energy the panels produced today — what the Marstek app presents as the day's power generation. It is not energy charged into the battery. Anyone who wired the old entity into the Energy Dashboard as a battery input has been recording solar production.

The scale (`÷100`, kWh) and the Home Assistant metadata were already correct; only the identity was wrong. `daily_charging_capacity` becomes `daily_power_generation`.

The monthly and yearly siblings (`ele_m`, `ele_y`) are very likely the same quantity, but that could not be established with the same confidence, so they keep their current names rather than being renamed on a guess.

## Breaking change

The Jupiter rename is user-visible and is called out under `### Changed` in the changelog: the entity id changes, existing recorded history stays with the old entity, and Energy Dashboard users need to move it from a battery entry to *Solar production*.

## Considered and rejected

Venus `wor_m=0` is the self-consumption mode, and the Marstek app labels it *Self Consumption*. Renaming the *Working Mode* option to match was tried and reverted: a Home Assistant select reports its option label as the entity state, so the rename would break automations that set the mode by name or compare its state to `Automatic`, for no functional gain. A code comment now records what the app calls the mode. Marstek's own internal name for it is `Auto`.

## Validation

```
npm run lint             # clean
npm run format:check     # clean
npm test -- --runInBand  # 482 passed
npm run build            # clean
```

New test covers the CT sentinel: real readings including negatives, the 60000 boundary, and the sentinel itself. The Jupiter parser test was updated for the renamed field.

No configuration options changed, so no add-on config, `run.sh`, or translation updates are involved.

## Not included

Two further discrepancies are known but left out to keep this focused, and because they need decisions rather than mechanical fixes:

- Jupiter's time-period power number allows 0-29 W, where the app enforces a 30 W minimum.
- Jupiter's `cd=3` time-period write derives `md=` from the current working mode, where the app always sends `md=2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid B2500 CT power readings, including `65535 W`, are now ignored and the previous valid value is retained.
  * Boundary and negative sensor readings are handled more reliably.

* **Improvements**
  * Jupiter’s sensor is now labeled **Daily Power Generation**, accurately representing daily solar production instead of battery charging capacity.
  * Updated documentation clarifies Venus “Self Consumption” mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->