### PR TITLE
B2500: send UTC clock fields with sync-time again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Fixed
 
+- B2500 V2/V3: Fix *Sync Time* sending the local wall-clock time, which made every discharge timer fire early by the local UTC offset — two hours in CEST, one in CET. The device's clock is UTC and it applies the separately stored `wy` offset itself when it evaluates a timer, whose start and end are configured in local time. `cd=08` therefore takes UTC clock fields paired with the local offset, which is what is sent again now
 - Venus & Jupiter: Fix the tens digit of the minutes being dropped when setting a *Time Period X Time From/To* before 10:00. Setting `02:43` made the device store `02:03` and report that back to Home Assistant, and any later change to the same period (power, weekday, enabled) re-applied the mangled time (fixes #184, PR #401)
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
 - B2500 V2/V3: *Recharge Mode* was affected the same way and got the same fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Fixed
 
-- B2500 V2/V3: Fix *Sync Time* sending the local wall-clock time, which made every discharge timer fire early by the local UTC offset — two hours in CEST, one in CET. The device's clock is UTC and it applies the separately stored `wy` offset itself when it evaluates a timer, whose start and end are configured in local time. `cd=08` therefore takes UTC clock fields paired with the local offset, which is what is sent again now
+- B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)
 - Venus & Jupiter: Fix the tens digit of the minutes being dropped when setting a *Time Period X Time From/To* before 10:00. Setting `02:43` made the device store `02:03` and report that back to Home Assistant, and any later change to the same period (power, weekday, enabled) re-applied the mangled time (fixes #184, PR #401)
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
 - B2500 V2/V3: *Recharge Mode* was affected the same way and got the same fix

--- a/docs/b2500.md
+++ b/docs/b2500.md
@@ -675,13 +675,21 @@ cd=08,wy=60,yy=124,mm=0,rr=15,hh=10,mn=30,ss=0
 | `yy` | Year minus 1900 (e.g. `124` for 2024) |
 | `mm` | Month, 0-indexed (0 = January, 11 = December) |
 | `rr` | Day of month (1–31) |
-| `hh` | Hour (0–23) |
+| `hh` | Hour, UTC (0–23) |
 | `mn` | Minute (0–59) |
 | `ss` | Second (0–59) |
 
-> **Note:** `yy`–`ss` are **local** wall-clock values, paired with the offset of
-> that same zone in `wy` — not UTC. Sending UTC components with a non-zero `wy`
-> leaves the device clock wrong by the offset.
+> **Note:** `yy`–`ss` are **UTC** values, paired with the local offset in `wy`.
+> The device stores the clock as sent and keeps the offset separately. It applies
+> the offset itself when it evaluates a discharge timer: the timer's start and
+> end are configured in local time and are converted into the clock's frame
+> before the comparison. Sending local wall-clock values therefore makes every
+> schedule fire `wy` minutes early, and a device that never received an offset
+> runs its schedule on UTC.
+>
+> The offset is only accepted if it is within ±720 minutes **and** a whole
+> multiple of 10; otherwise it is discarded and the previous value kept. That
+> excludes Kathmandu (+345), Chatham (+765/+825) and anything past UTC+12.
 
 ---
 

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -272,8 +272,9 @@ describe('ControlHandler', () => {
       // Simulate UTC+5:30 at 2023-12-31T23:59:58Z, which is local 2024-01-01
       // 05:29:58 — every field except the seconds differs between the two zones,
       // so a regression to any single local getter changes the payload. The
-      // local getters are stubbed rather than setting process.env.TZ, which Node
-      // does not re-read once the process has started.
+      // local getters are stubbed rather than setting process.env.TZ, to keep
+      // the zone confined to this test instead of mutating process-wide state
+      // the rest of the suite shares.
       jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2023, 11, 31, 23, 59, 58)));
       jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330);
       jest.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2024);

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -267,27 +267,22 @@ describe('ControlHandler', () => {
       jest.useRealTimers();
     });
 
-    test('should sync the local wall-clock time, not UTC', () => {
-      // The device expects the local date/time fields alongside the matching UTC
-      // offset. Simulate UTC+9, where 2023-01-01T12:30:45Z is local 21:30:45 on
-      // the same day: the payload must carry the local hour, not the UTC one.
-      // The local getters are stubbed rather than setting process.env.TZ, which
-      // Node does not re-read once the process has started.
+    test('should sync UTC clock fields together with the local offset', () => {
+      // The device's clock is UTC; `wy` tells it how far local time is ahead.
+      // Simulate UTC+9, where 2023-01-01T12:30:45Z is local 21:30:45 on the same
+      // day: the payload must carry the UTC hour (12), not the local one (21),
+      // paired with wy=540. The local getters are stubbed rather than setting
+      // process.env.TZ, which Node does not re-read once the process has started.
       jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2023, 0, 1, 12, 30, 45)));
       jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-540);
-      jest.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2023);
-      jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0);
-      jest.spyOn(Date.prototype, 'getDate').mockReturnValue(1);
       jest.spyOn(Date.prototype, 'getHours').mockReturnValue(21);
-      jest.spyOn(Date.prototype, 'getMinutes').mockReturnValue(30);
-      jest.spyOn(Date.prototype, 'getSeconds').mockReturnValue(45);
 
       try {
         handleControlTopic(testDeviceV2, 'sync-time', 'PRESS');
 
         expect(publishCallback).toHaveBeenCalledWith(
           testDeviceV2,
-          expect.stringContaining('cd=8,wy=540,yy=123,mm=0,rr=1,hh=21,mn=30,ss=45'),
+          expect.stringContaining('cd=8,wy=540,yy=123,mm=0,rr=1,hh=12,mn=30,ss=45'),
         );
       } finally {
         jest.useRealTimers();

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -269,20 +269,26 @@ describe('ControlHandler', () => {
 
     test('should sync UTC clock fields together with the local offset', () => {
       // The device's clock is UTC; `wy` tells it how far local time is ahead.
-      // Simulate UTC+9, where 2023-01-01T12:30:45Z is local 21:30:45 on the same
-      // day: the payload must carry the UTC hour (12), not the local one (21),
-      // paired with wy=540. The local getters are stubbed rather than setting
-      // process.env.TZ, which Node does not re-read once the process has started.
-      jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2023, 0, 1, 12, 30, 45)));
-      jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-540);
-      jest.spyOn(Date.prototype, 'getHours').mockReturnValue(21);
+      // Simulate UTC+5:30 at 2023-12-31T23:59:58Z, which is local 2024-01-01
+      // 05:29:58 — every field except the seconds differs between the two zones,
+      // so a regression to any single local getter changes the payload. The
+      // local getters are stubbed rather than setting process.env.TZ, which Node
+      // does not re-read once the process has started.
+      jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2023, 11, 31, 23, 59, 58)));
+      jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330);
+      jest.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2024);
+      jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0);
+      jest.spyOn(Date.prototype, 'getDate').mockReturnValue(1);
+      jest.spyOn(Date.prototype, 'getHours').mockReturnValue(5);
+      jest.spyOn(Date.prototype, 'getMinutes').mockReturnValue(29);
+      jest.spyOn(Date.prototype, 'getSeconds').mockReturnValue(58);
 
       try {
         handleControlTopic(testDeviceV2, 'sync-time', 'PRESS');
 
         expect(publishCallback).toHaveBeenCalledWith(
           testDeviceV2,
-          expect.stringContaining('cd=8,wy=540,yy=123,mm=0,rr=1,hh=12,mn=30,ss=45'),
+          expect.stringContaining('cd=8,wy=330,yy=123,mm=11,rr=31,hh=23,mn=59,ss=58'),
         );
       } finally {
         jest.useRealTimers();

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -740,8 +740,19 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
             // are configured in local time — so sending local wall-clock time
             // makes every schedule fire `wy` minutes early.
             // `mm` is 0-based and `yy` is the year minus 1900.
+            const wy = -now.getTimezoneOffset();
+            if (Math.abs(wy) > 720 || wy % 10 !== 0) {
+              // The device only stores offsets within ±720 minutes that are a
+              // whole multiple of 10; it drops anything else and keeps the one
+              // it already had. The clock fields are still accepted, so sync
+              // them anyway rather than letting the clock drift as well.
+              logger.warn(
+                'Timezone offset not supported by the device, it will keep its previous offset and the discharge timers may run at the wrong time:',
+                wy,
+              );
+            }
             const timeData = {
-              wy: -now.getTimezoneOffset(),
+              wy,
               yy: now.getUTCFullYear() - 1900,
               mm: now.getUTCMonth(),
               rr: now.getUTCDate(),

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -734,18 +734,20 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
           // If the message is "PRESS" or similar from Home Assistant button, generate current time
           if (message === 'PRESS' || message === 'press' || message === 'true' || message === '1') {
             const now = new Date();
-            // `cd=08` takes the local wall-clock time together with the offset
-            // of that same zone in `wy` — not UTC. Sending UTC components with
-            // a local `wy` left the device clock wrong by the offset. `mm` is
-            // 0-based and `yy` is the year minus 1900.
+            // `cd=08` takes UTC clock fields together with the local offset in
+            // `wy`. The device stores the clock as sent and applies the offset
+            // itself when it evaluates a discharge timer, whose start and end
+            // are configured in local time — so sending local wall-clock time
+            // makes every schedule fire `wy` minutes early.
+            // `mm` is 0-based and `yy` is the year minus 1900.
             const timeData = {
               wy: -now.getTimezoneOffset(),
-              yy: now.getFullYear() - 1900,
-              mm: now.getMonth(),
-              rr: now.getDate(),
-              hh: now.getHours(),
-              mn: now.getMinutes(),
-              ss: now.getSeconds(),
+              yy: now.getUTCFullYear() - 1900,
+              mm: now.getUTCMonth(),
+              rr: now.getUTCDate(),
+              hh: now.getUTCHours(),
+              mn: now.getUTCMinutes(),
+              ss: now.getUTCSeconds(),
             };
             publishCallback(
               processCommand(CommandType.SYNC_TIME, timeData, deviceState.useFlashCommands),


### PR DESCRIPTION
## Summary

`sync-time` has been sending the **local wall-clock time** since #383 (1.9.0). That makes the device's clock local, and the device then applies the timezone offset to every timer window a second time — so **all discharge timers fire early by the local UTC offset**: two hours in CEST, one in CET.

This restores the UTC getters. It is *not* a revert of #383 — everything else in that PR is correct and stays, including the presence-based JSON validation (`== null`) that ships alongside, since `0` is a legal value for every time field.

## Why UTC

The device keeps its clock in UTC and stores the local offset (`wy`) separately. It applies that offset itself when it decides whether a discharge timer is currently active: the timer's start and end are configured in local time and get converted into the clock's frame before the comparison. Sending local wall-clock values therefore shifts every window by the offset, and a device that never received an offset at all runs its schedule on UTC.

This also matches the official app, which pairs UTC clock fields with the local offset in both its MQTT and Bluetooth time commands.

Consistent with the reports behind #98, where the timers were observed running offset from the configured schedule.

## Also documented

The device accepts the offset only if it is within ±720 minutes **and** a whole multiple of 10 — otherwise it is discarded and the previous value kept. That excludes Kathmandu (+345), Chatham (+765/+825) and anything past UTC+12.

## Validation

- `npm run lint` — clean
- `npm run format:check` — clean
- `npm test -- --runInBand` — 482 passed, 14 suites
- `npm run build` — clean

The `sync-time` test now stubs `getHours()` to the *local* hour (21) while asserting `hh=12`, so a regression back to the local getters fails the test rather than passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzcnD5UBsCoDpTF2SnV8Wg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed B2500 V2/V3 time synchronization to send UTC clock values with the local timezone offset.
  * Improved timer accuracy by aligning synchronization with the device’s UTC clock and timer evaluation behavior.
  * Added warnings for unsupported timezone offsets while continuing to synchronize clock values.

* **Documentation**
  * Clarified UTC time requirements, timezone-offset limits, accepted offset increments, and behavior when an offset is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->