### PR TITLE
Add cell balancing diagnostics for B2500 and Venus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Next]
 
+### Added
+
+- B2500 & Venus: New *Cell Balancing Diagnostics* option. The existing *Cell Voltage Difference* sensor is easy to misread: after a full charge it collapses overnight from tens of millivolts to one or two, which looks like the pack balancing itself but usually is not. At 100% with nothing to export the unit disconnects its solar input and runs off the battery, so every cell drains equally and slides off the steep top of the lithium-iron curve onto its flat middle, where the same imbalance shows up as a much smaller gap. Nothing was corrected. Switching the option on adds sensors that tell the two apart, including *Mean Cell Voltage Drift*, *Balance Conditions Met*, *Minutes Above 3400 mV Today* and — the ones worth comparing between days — *Cell Spread at 3450 mV* and *Rested Cell Spread*. Everything is inferred from voltage and current, since no device reports whether its balancer is actually on. Needs *Enable Cell Data*, and the day-to-day sensors need somewhere to store their history: the add-on has that already, under Docker mount a volume at `/data`
+
 ### Fixed
 
 - Settings in a `.env` file were ignored; only real environment variables took effect. Manual installations only (PR #414)
@@ -21,6 +25,8 @@
 
 ### Changed
 
+- Settings in a `.env` file were being ignored. Only real environment variables took effect, so anyone following the manual-installation instructions and setting *Enable Cell Data* or the polling interval there saw no effect and no error. Docker and Home Assistant App users were never affected
+- hm2mqtt now shuts down cleanly when stopped by Home Assistant or Docker, rather than only on Ctrl-C
 - Jupiter: *Daily Charging Capacity* reports today's solar production, not the energy charged into the battery, and is now called *Daily Power Generation*. If you added it to the Energy Dashboard, move it from a battery entry to *Solar production* (PR #403)
 
 ## [1.9.1] - 2026-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- B2500, Greensolar & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that show whether the pack is really balancing or just drifting down the discharge curve. Requires *Enable Cell Data*. See the README for what each sensor means (PR #411)
+- B2500, Greensolar & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that measure the cell spread at the same point of every charge, so it can be compared between days. Requires *Enable Cell Data*. See the README for what each sensor means (PR #411)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- B2500 & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that distinguish real balancing from a pack simply drifting down the discharge curve: *Cell Spread*, *Cell Voltage Standard Deviation*, *Mean Cell Voltage*, *Mean Cell Voltage Drift*, *Balance Conditions Met*, *Minutes Above 3400/3500 mV Today*, *Cell Spread at 3450 mV* and *Rested Cell Spread*. Requires *Enable Cell Data*; the last two also need a persistent data directory, which the add-on already has. See the README for which sensors to compare (PR #411)
+- B2500, Greensolar & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that show whether the pack is really balancing or just drifting down the discharge curve. Requires *Enable Cell Data*. See the README for what each sensor means (PR #411)
 
 ### Fixed
 
@@ -12,7 +12,6 @@
 - Devices were polled more often than the configured *Polling Interval* (PR #414)
 - *Enable Cell Data*, *Enable Calibration Data* and *Enable Extra Battery Data* said B2500 only. All three also cover Greensolar storage, and *Enable Cell Data* also Venus and Jupiter (PR #414)
 - Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values
-- Settings in a `.env` file were ignored; only real environment variables took effect. Affects manual installations only (PR #411)
 - B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)
 - Venus & Jupiter: Fix the tens digit of the minutes being dropped when setting a *Time Period X Time From/To* before 10:00. Setting `02:43` made the device store `02:03` and report that back to Home Assistant, and any later change to the same period (power, weekday, enabled) re-applied the mangled time (fixes #184, PR #401)
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
@@ -25,7 +24,6 @@
 
 ### Changed
 
-- hm2mqtt now shuts down cleanly when stopped by Home Assistant or Docker, not just on Ctrl-C
 - Jupiter: *Daily Charging Capacity* reports today's solar production, not the energy charged into the battery, and is now called *Daily Power Generation*. If you added it to the Energy Dashboard, move it from a battery entry to *Solar production* (PR #403)
 
 ## [1.9.1] - 2026-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- B2500 & Venus: New *Cell Balancing Diagnostics* option. The existing *Cell Voltage Difference* sensor is easy to misread: after a full charge it collapses overnight from tens of millivolts to one or two, which looks like the pack balancing itself but usually is not. At 100% with nothing to export the unit disconnects its solar input and runs off the battery, so every cell drains equally and slides off the steep top of the lithium-iron curve onto its flat middle, where the same imbalance shows up as a much smaller gap. Nothing was corrected. Switching the option on adds sensors that tell the two apart, including *Mean Cell Voltage Drift*, *Balance Conditions Met*, *Minutes Above 3400 mV Today* and — the ones worth comparing between days — *Cell Spread at 3450 mV* and *Rested Cell Spread*. Everything is inferred from voltage and current, since no device reports whether its balancer is actually on. Needs *Enable Cell Data*, and the day-to-day sensors need somewhere to store their history: the add-on has that already, under Docker mount a volume at `/data`
+- B2500 & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that distinguish real balancing from a pack simply drifting down the discharge curve: *Cell Spread*, *Cell Voltage Standard Deviation*, *Mean Cell Voltage*, *Mean Cell Voltage Drift*, *Balance Conditions Met*, *Minutes Above 3400/3500 mV Today*, *Cell Spread at 3450 mV* and *Rested Cell Spread*. Requires *Enable Cell Data*; the last two also need a persistent data directory, which the add-on already has. See the README for which sensors to compare (PR #411)
 
 ### Fixed
 
@@ -12,7 +12,7 @@
 - Devices were polled more often than the configured *Polling Interval* (PR #414)
 - *Enable Cell Data*, *Enable Calibration Data* and *Enable Extra Battery Data* said B2500 only. All three also cover Greensolar storage, and *Enable Cell Data* also Venus and Jupiter (PR #414)
 - Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values
-
+- Settings in a `.env` file were ignored; only real environment variables took effect. Affects manual installations only (PR #411)
 - B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)
 - Venus & Jupiter: Fix the tens digit of the minutes being dropped when setting a *Time Period X Time From/To* before 10:00. Setting `02:43` made the device store `02:03` and report that back to Home Assistant, and any later change to the same period (power, weekday, enabled) re-applied the mangled time (fixes #184, PR #401)
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)
@@ -25,8 +25,7 @@
 
 ### Changed
 
-- Settings in a `.env` file were being ignored. Only real environment variables took effect, so anyone following the manual-installation instructions and setting *Enable Cell Data* or the polling interval there saw no effect and no error. Docker and Home Assistant App users were never affected
-- hm2mqtt now shuts down cleanly when stopped by Home Assistant or Docker, rather than only on Ctrl-C
+- hm2mqtt now shuts down cleanly when stopped by Home Assistant or Docker, not just on Ctrl-C
 - Jupiter: *Daily Charging Capacity* reports today's solar production, not the energy charged into the battery, and is now called *Daily Power Generation*. If you added it to the Energy Dashboard, move it from a battery entry to *Solar production* (PR #403)
 
 ## [1.9.1] - 2026-07-29

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ services:
 | `POLL_CELL_DATA` | Enable cell-level battery data: individual cell voltages and temperatures, plus detailed per-pack BMS data on Venus. B2500, Greensolar, Venus and Jupiter | false |
 | `POLL_EXTRA_BATTERY_DATA` | Enable extra battery data reporting (B2500 and Greensolar storage only) | false |
 | `POLL_CALIBRATION_DATA` | Enable calibration data reporting (B2500 and Greensolar storage only) | false |
-| `CELL_BALANCING_DIAGNOSTICS` | Enable the cell balancing diagnostics (B2500 and Venus; requires `POLL_CELL_DATA`) | false |
+| `CELL_BALANCING_DIAGNOSTICS` | Enable the cell balancing diagnostics (B2500, Greensolar and Venus; requires `POLL_CELL_DATA`) | false |
 | `HM2MQTT_DATA_DIR` | Directory for data that must survive a restart, currently the cell balancing charge-cycle history | `/data` |
 | `DEVICE_n` | Device configuration in format `{type}:{mac}` | -                       |
 | `MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS` | Number of consecutive timeouts before a device is marked offline | `3` |
@@ -416,7 +416,7 @@ services:
 
 ### Cell Balancing Diagnostics
 
-Available on B2500 and Venus. Set `CELL_BALANCING_DIAGNOSTICS=true` (add-on:
+Available on B2500, Greensolar storage and Venus. Set `CELL_BALANCING_DIAGNOSTICS=true` (add-on:
 *Enable Cell Balancing Diagnostics*). Requires `POLL_CELL_DATA=true`.
 
 *Cell Voltage Difference* — the gap between the highest and lowest cell — is easy

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ services:
 | `POLL_CELL_DATA` | Enable cell-level battery data: individual cell voltages and temperatures, plus detailed per-pack BMS data on Venus. B2500, Greensolar, Venus and Jupiter | false |
 | `POLL_EXTRA_BATTERY_DATA` | Enable extra battery data reporting (B2500 and Greensolar storage only) | false |
 | `POLL_CALIBRATION_DATA` | Enable calibration data reporting (B2500 and Greensolar storage only) | false |
+| `CELL_BALANCING_DIAGNOSTICS` | Enable the cell balancing diagnostics (B2500 and Venus; requires `POLL_CELL_DATA`) | false |
+| `HM2MQTT_DATA_DIR` | Directory for data that must survive a restart, currently the cell balancing charge-cycle history | `/data` |
 | `DEVICE_n` | Device configuration in format `{type}:{mac}` | -                       |
 | `MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS` | Number of consecutive timeouts before a device is marked offline | `3` |
 | `MQTT_PROXY_ENABLED` | Enable MQTT proxy server for B2500 client ID conflict resolution | `false` |
@@ -411,6 +413,47 @@ services:
 ```
 
 > **📖 Background**: This issue was first reported in [GitHub Issue #41](https://github.com/tomquist/hm2mqtt/issues/41) where users experienced problems with multiple B2500 devices after firmware update 226.5.
+
+### Cell Balancing Diagnostics
+
+Available on B2500 and Venus. Set `CELL_BALANCING_DIAGNOSTICS=true` (add-on:
+*Enable Cell Balancing Diagnostics*). Requires `POLL_CELL_DATA=true`.
+
+*Cell Voltage Difference* — the gap between the highest and lowest cell — is easy
+to misread. Watch it after a full charge and it collapses from tens of millivolts
+to one or two overnight, which looks like the pack balancing itself. Usually it
+isn't. At 100% with nothing to export, the unit disconnects its solar input and
+runs off the battery. Every cell drains equally and slides off the steep top of
+the lithium-iron curve onto its flat middle, where the same imbalance simply
+shows up as a much smaller voltage gap. Nothing was corrected; the ruler changed.
+
+These sensors are meant to tell the two apart:
+
+| Entity | What it tells you |
+|---|---|
+| *Cell Spread*, *Cell Voltage Standard Deviation* | Spread, plus a measure that is not at the mercy of one flaky cell |
+| *Mean Cell Voltage Drift* | How fast the pack is sagging. Falling means it is running off the battery; flat while full means it is genuinely being held there |
+| *Balance Conditions Met* | Cells high enough for the balancer to do something, with charge still going in |
+| *Minutes Above 3400 mV / 3500 mV Today* | How long those conditions held. Reported separately because an hour just over the line achieves far less than an hour well above it |
+| *Cell Spread at 3450 mV* | The number to compare between days. Always sampled at the same point of the charge, so it is not distorted by when charging happened to stop |
+| *Rested Cell Spread* | Spread an hour after charging stopped, with no load skewing it |
+
+Real balancing shows up as *Cell Spread at 3450 mV* and *Rested Cell Spread*
+falling over successive days. A spread that only shrinks overnight and returns to
+its old value on the next charge is the illusion described above.
+
+The published state also carries `normalisedDeviations`, each cell's share of the
+spread. When the whole stack drifts together these stay put while the spread
+shrinks; when a cell is genuinely brought back into line, its share moves toward
+zero. That is the clearest signal of the two, and it is the one to check before
+concluding anything.
+
+Two caveats. Everything here is inferred from voltage and current — no Marstek
+device reports whether its balancer is switched on. And the day-to-day sensors
+need somewhere to keep their history: the add-on has this already, while under
+Docker you need a volume mounted at `/data` (or `HM2MQTT_DATA_DIR` pointing
+somewhere that survives a restart). Without it those entities are not created and
+the log says why.
 
 ## Frequently Asked Questions (FAQ)
 

--- a/README.md
+++ b/README.md
@@ -416,50 +416,37 @@ services:
 
 ### Cell Balancing Diagnostics
 
-Available on B2500, Greensolar storage and Venus. Set `CELL_BALANCING_DIAGNOSTICS=true` (add-on:
-*Enable Cell Balancing Diagnostics*). Also requires `POLL_CELL_DATA=true` (add-on: *Enable Cell
-Data*) — that is what supplies the cell readings, and with it off no diagnostic entities are
-created and the log says why.
+B2500, Greensolar storage and Venus. Set `CELL_BALANCING_DIAGNOSTICS=true` and
+`POLL_CELL_DATA=true` (add-on: *Enable Cell Balancing Diagnostics* and *Enable Cell Data*).
+Without the second one there are no cell readings to work from, so no entities are created
+and the log says why.
 
-*Cell Voltage Difference* — the gap between the highest and lowest cell — is easy
-to misread. Watch it after a full charge and it collapses from tens of millivolts
-to one or two overnight, which looks like the pack balancing itself. Usually it
-isn't. At 100% with nothing to export, the unit disconnects its solar input and
-runs off the battery. Every cell drains equally and slides off the steep top of
-the lithium-iron curve onto its flat middle, where the same imbalance simply
-shows up as a much smaller voltage gap. Nothing was corrected; the ruler changed.
+*Cell Voltage Difference* collapses from tens of millivolts to one or two overnight after a
+full charge, which looks like the pack balancing itself. Usually it isn't: at 100% with
+nothing to export the unit runs off its own battery, and the whole stack slides off the steep
+top of the lithium-iron curve onto the flat middle, where the same imbalance shows a smaller
+gap.
 
-These sensors are meant to tell the two apart:
-
-| Entity | What it tells you |
+| Entity | Meaning |
 |---|---|
-| *Cell Spread*, *Cell Voltage Standard Deviation* | Spread, plus a measure that is not at the mercy of one flaky cell |
-| *Mean Cell Voltage* | Where on the curve the pack is sitting, which is what makes the spread readable |
-| *Highest Cell Share of Spread* | How much of the spread the highest cell owns. The sharpest signal here — see below |
-| *Mean Cell Voltage Drift* | How fast the pack is sagging. Falling means it is running off the battery; flat while full means it is genuinely being held there |
-| *Balance Conditions Met* | Cells high enough for the balancer to do something, with charge still going in |
-| *Minutes Above 3400 mV / 3500 mV Today* | How long those conditions held. Reported separately because an hour just over the line achieves far less than an hour well above it |
-| *Cell Spread at 3450 mV* | The number to compare between days. Always sampled at the same point of the charge, so it is not distorted by when charging happened to stop |
+| *Cell Spread* | Highest cell minus lowest |
+| *Cell Voltage Standard Deviation* | Spread that one flaky cell cannot dominate |
+| *Mean Cell Voltage* | Where on the curve the pack is sitting |
+| *Highest Cell Share of Spread* | The highest cell's share of the spread. Steady while *Cell Spread* falls means the stack is drifting; falling means that cell is being brought back into line |
+| *Mean Cell Voltage Drift* | How fast the pack is sagging, in mV/h |
+| *Balance Conditions Met* | Cells above 3400 mV with charge still going in |
+| *Minutes Above 3400 mV / 3500 mV Today* | How long those conditions held. Counted separately because an hour just over the line achieves far less than an hour well above it |
+| *Cell Spread at 3450 mV* | Spread at a fixed point of the charge, so it is comparable between days |
 | *Rested Cell Spread* | Spread an hour after charging stopped, with no load skewing it |
 
-Real balancing shows up as *Cell Spread at 3450 mV* and *Rested Cell Spread*
-falling over successive days. A spread that only shrinks overnight and returns to
-its old value on the next charge is the illusion described above.
+Real balancing shows as *Cell Spread at 3450 mV* and *Rested Cell Spread* falling over
+successive days. The per-cell vector is published as `normalisedDeviations`, with *Highest
+Cell* naming the outlier.
 
-*Highest Cell Share of Spread* deserves particular attention. When the whole
-stack drifts down together, every cell keeps its share of the spread even as the
-spread itself collapses — so a share that holds steady while *Cell Spread* falls
-is the illusion, plainly visible. A share that falls is a cell genuinely being
-brought back into line, which drifting cannot produce. Check it before concluding
-anything. The full per-cell vector is in the published state as
-`normalisedDeviations`, alongside *Highest Cell* naming the culprit.
-
-Two caveats. Everything here is inferred from voltage and current — no Marstek
-device reports whether its balancer is switched on. And the day-to-day sensors
-need somewhere to keep their history: the add-on has this already, while under
-Docker you need a volume mounted at `/data` (or `HM2MQTT_DATA_DIR` pointing
-somewhere that survives a restart). Without it those entities are not created and
-the log says why.
+No Marstek device reports whether its balancer is running, so all of this is inferred from
+voltage and current. The two day-to-day sensors also need storage that survives a restart:
+the add-on has it, under Docker mount a volume at `/data` or point `HM2MQTT_DATA_DIR`
+somewhere else.
 
 ## Frequently Asked Questions (FAQ)
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,9 @@ services:
 B2500, Greensolar storage and Venus. Set `CELL_BALANCING_DIAGNOSTICS=true` and
 `POLL_CELL_DATA=true` (add-on: *Enable Cell Balancing Diagnostics* and *Enable Cell Data*).
 Without the second one there are no cell readings to work from, so no entities are created
-and the log says why.
+and the log says why. On B2500 and Greensolar, also set `POLL_EXTRA_BATTERY_DATA=true`
+(*Enable Extra Battery Data*): that poll carries the pack current, and without it *Rested
+Cell Spread* never latches. B2500 V1 does not report a pack current at all.
 
 *Cell Voltage Difference* collapses from tens of millivolts to one or two overnight after a
 full charge, which looks like the pack balancing itself. Usually it isn't: at 100% with

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ These sensors are meant to tell the two apart:
 | Entity | What it tells you |
 |---|---|
 | *Cell Spread*, *Cell Voltage Standard Deviation* | Spread, plus a measure that is not at the mercy of one flaky cell |
+| *Highest Cell Share of Spread* | How much of the spread the highest cell owns. The sharpest signal here — see below |
 | *Mean Cell Voltage Drift* | How fast the pack is sagging. Falling means it is running off the battery; flat while full means it is genuinely being held there |
 | *Balance Conditions Met* | Cells high enough for the balancer to do something, with charge still going in |
 | *Minutes Above 3400 mV / 3500 mV Today* | How long those conditions held. Reported separately because an hour just over the line achieves far less than an hour well above it |
@@ -442,11 +443,13 @@ Real balancing shows up as *Cell Spread at 3450 mV* and *Rested Cell Spread*
 falling over successive days. A spread that only shrinks overnight and returns to
 its old value on the next charge is the illusion described above.
 
-The published state also carries `normalisedDeviations`, each cell's share of the
-spread. When the whole stack drifts together these stay put while the spread
-shrinks; when a cell is genuinely brought back into line, its share moves toward
-zero. That is the clearest signal of the two, and it is the one to check before
-concluding anything.
+*Highest Cell Share of Spread* deserves particular attention. When the whole
+stack drifts down together, every cell keeps its share of the spread even as the
+spread itself collapses — so a share that holds steady while *Cell Spread* falls
+is the illusion, plainly visible. A share that falls is a cell genuinely being
+brought back into line, which drifting cannot produce. Check it before concluding
+anything. The full per-cell vector is in the published state as
+`normalisedDeviations`, alongside *Highest Cell* naming the culprit.
 
 Two caveats. Everything here is inferred from voltage and current — no Marstek
 device reports whether its balancer is switched on. And the day-to-day sensors

--- a/README.md
+++ b/README.md
@@ -417,7 +417,9 @@ services:
 ### Cell Balancing Diagnostics
 
 Available on B2500, Greensolar storage and Venus. Set `CELL_BALANCING_DIAGNOSTICS=true` (add-on:
-*Enable Cell Balancing Diagnostics*). Requires `POLL_CELL_DATA=true`.
+*Enable Cell Balancing Diagnostics*). Also requires `POLL_CELL_DATA=true` (add-on: *Enable Cell
+Data*) — that is what supplies the cell readings, and with it off no diagnostic entities are
+created and the log says why.
 
 *Cell Voltage Difference* — the gap between the highest and lowest cell — is easy
 to misread. Watch it after a full charge and it collapses from tens of millivolts
@@ -432,6 +434,7 @@ These sensors are meant to tell the two apart:
 | Entity | What it tells you |
 |---|---|
 | *Cell Spread*, *Cell Voltage Standard Deviation* | Spread, plus a measure that is not at the mercy of one flaky cell |
+| *Mean Cell Voltage* | Where on the curve the pack is sitting, which is what makes the spread readable |
 | *Highest Cell Share of Spread* | How much of the spread the highest cell owns. The sharpest signal here — see below |
 | *Mean Cell Voltage Drift* | How fast the pack is sagging. Falling means it is running off the battery; flat while full means it is genuinely being held there |
 | *Balance Conditions Met* | Cells high enough for the balancer to do something, with charge still going in |

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -23,6 +23,7 @@ options:
   enableCellData: false
   enableCalibrationData: false
   enableExtraBatteryData: false
+  enableCellBalancingDiagnostics: false
   allowedConsecutiveTimeouts: 3
   topicPrefix: hm2mqtt
   mqttProxyEnabled: false
@@ -37,6 +38,7 @@ schema:
   enableCellData: bool
   enableCalibrationData: bool
   enableExtraBatteryData: bool
+  enableCellBalancingDiagnostics: bool
   allowedConsecutiveTimeouts: int?
   topicPrefix: str?
   autodiscoveryTopicPrefix: str?

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -13,7 +13,7 @@ start_application() {
 output_env_for_testing() {
     bashio::log.info "Running in test mode, outputting environment variables"
     # Output all environment variables that start with MQTT_ or DEVICE_
-    env | grep -E "^(MQTT_|AUTODISCOVERY_|DEVICE_|POLL_|DEBUG=|LOG_LEVEL=)" | sort
+    env | grep -E "^(MQTT_|AUTODISCOVERY_|DEVICE_|POLL_|CELL_|DEBUG=|LOG_LEVEL=)" | sort
 }
 
 # Function to manually parse options.json
@@ -111,6 +111,7 @@ export MQTT_RESPONSE_TIMEOUT=$(bashio::config 'responseTimeout' "30")
 export POLL_CELL_DATA=$(bashio::config 'enableCellData' "false")
 export POLL_CALIBRATION_DATA=$(bashio::config 'enableCalibrationData' "false")
 export POLL_EXTRA_BATTERY_DATA=$(bashio::config 'enableExtraBatteryData' "false")
+export CELL_BALANCING_DIAGNOSTICS=$(bashio::config 'enableCellBalancingDiagnostics' "false")
 export DEBUG=$(bashio::config 'debug' "false")
 export MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS=$(bashio::config 'allowedConsecutiveTimeouts' "3")
 export MQTT_TOPIC_PREFIX=$(bashio::config 'topicPrefix' "hm2mqtt")

--- a/ha_addon/test_env.sh
+++ b/ha_addon/test_env.sh
@@ -125,6 +125,7 @@ run_test "Additional configuration options" \
         "enableCellData": true,
         "enableCalibrationData": true,
         "enableExtraBatteryData": true,
+        "enableCellBalancingDiagnostics": true,
         "topicPrefix": "custom",
         "log_level": "debug",
         "devices": [
@@ -141,6 +142,7 @@ MQTT_RESPONSE_TIMEOUT=15
 POLL_CELL_DATA=true
 POLL_EXTRA_BATTERY_DATA=true
 POLL_CALIBRATION_DATA=true
+CELL_BALANCING_DIAGNOSTICS=true
 LOG_LEVEL=debug
 DEVICE_0=HMA-1:001a2b3c4d5e"
 

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -16,7 +16,7 @@ configuration:
     description: "Aktiviere Abruf zusätzlicher Batteriedaten (nur B2500 und Greensolar)"
   enableCellBalancingDiagnostics:
     name: "Balancing-Diagnose"
-    description: "Zeigt an, ob der Speicher tatsächlich balanciert, statt nur die Entladekurve hinunterzuwandern. Benötigt Zellspannungen (nur B2500 und Venus)"
+    description: "Zeigt an, ob der Speicher tatsächlich balanciert, statt nur die Entladekurve hinunterzuwandern. Benötigt Zellspannungen (B2500, Greensolar und Venus)"
   allowedConsecutiveTimeouts:
     name: Maximale aufeinanderfolgende Timeouts
     description: "Anzahl aufeinanderfolgender Timeouts, bevor ein Gerät als offline markiert wird (Standard: 3)"

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -16,7 +16,7 @@ configuration:
     description: "Aktiviere Abruf zusätzlicher Batteriedaten (nur B2500 und Greensolar)"
   enableCellBalancingDiagnostics:
     name: "Balancing-Diagnose"
-    description: "Zeigt an, ob der Speicher tatsächlich balanciert, statt nur die Entladekurve hinunterzuwandern. Benötigt Zellspannungen (B2500, Greensolar und Venus)"
+    description: "Aktiviere die Balancing-Analyse, die die Zellspannungsspreizung an einem festen Punkt jeder Ladung misst und so über Tage vergleichbar macht. Benötigt Zellspannungen (B2500, Greensolar und Venus)"
   allowedConsecutiveTimeouts:
     name: Maximale aufeinanderfolgende Timeouts
     description: "Anzahl aufeinanderfolgender Timeouts, bevor ein Gerät als offline markiert wird (Standard: 3)"

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -14,6 +14,9 @@ configuration:
   enableExtraBatteryData:
     name: "Zusätzliche Batteriedaten"
     description: "Aktiviere Abruf zusätzlicher Batteriedaten (nur B2500 und Greensolar)"
+  enableCellBalancingDiagnostics:
+    name: "Balancing-Diagnose"
+    description: "Zeigt an, ob der Speicher tatsächlich balanciert, statt nur die Entladekurve hinunterzuwandern. Benötigt Zellspannungen (nur B2500 und Venus)"
   allowedConsecutiveTimeouts:
     name: Maximale aufeinanderfolgende Timeouts
     description: "Anzahl aufeinanderfolgender Timeouts, bevor ein Gerät als offline markiert wird (Standard: 3)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -14,6 +14,9 @@ configuration:
   enableExtraBatteryData:
     name: Enable Extra Battery Data
     description: "Enable extra battery data reporting (B2500 and Greensolar storage only)"
+  enableCellBalancingDiagnostics:
+    name: Enable Cell Balancing Diagnostics
+    description: "Report whether the pack is really balancing, rather than just drifting down the discharge curve. Requires cell data (B2500 and Venus only)"
   allowedConsecutiveTimeouts:
     name: Allowed Consecutive Timeouts
     description: "Number of consecutive timeouts before a device is marked offline (default: 3)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -16,7 +16,7 @@ configuration:
     description: "Enable extra battery data reporting (B2500 and Greensolar storage only)"
   enableCellBalancingDiagnostics:
     name: Enable Cell Balancing Diagnostics
-    description: "Report whether the pack is really balancing, rather than just drifting down the discharge curve. Requires cell data (B2500, Greensolar and Venus)"
+    description: "Enable cell balancing analysis, measuring the cell spread at the same point of every charge so it can be compared between days. Requires cell data (B2500, Greensolar and Venus)"
   allowedConsecutiveTimeouts:
     name: Allowed Consecutive Timeouts
     description: "Number of consecutive timeouts before a device is marked offline (default: 3)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -16,7 +16,7 @@ configuration:
     description: "Enable extra battery data reporting (B2500 and Greensolar storage only)"
   enableCellBalancingDiagnostics:
     name: Enable Cell Balancing Diagnostics
-    description: "Report whether the pack is really balancing, rather than just drifting down the discharge curve. Requires cell data (B2500 and Venus only)"
+    description: "Report whether the pack is really balancing, rather than just drifting down the discharge curve. Requires cell data (B2500, Greensolar and Venus)"
   allowedConsecutiveTimeouts:
     name: Allowed Consecutive Timeouts
     description: "Number of consecutive timeouts before a device is marked offline (default: 3)"

--- a/src/cellBalancing.test.ts
+++ b/src/cellBalancing.test.ts
@@ -5,6 +5,7 @@ import {
   CellSample,
   computeCellStats,
   computeDrift,
+  CycleRecord,
   extractB2500Sample,
   extractVenusSample,
   initialBalancingState,
@@ -180,8 +181,8 @@ describe('balancing state machine', () => {
     state: BalancingState,
     samples: CellSample[],
     localDate = '2026-08-06',
-  ): { state: BalancingState; cycles: any[] } => {
-    const cycles: any[] = [];
+  ): { state: BalancingState; cycles: CycleRecord[] } => {
+    const cycles: CycleRecord[] = [];
     let current = state;
     for (const s of samples) {
       const result = advanceBalancingState(current, s, localDate);

--- a/src/cellBalancing.test.ts
+++ b/src/cellBalancing.test.ts
@@ -48,6 +48,16 @@ describe('computeCellStats', () => {
     expect(stats.meanMv).toBe(3305);
   });
 
+  it('remembers where the surviving cells sat in the original array', () => {
+    // A dropped reading in the middle shifts every later position, so the offset
+    // within the filtered array is not a cell number.
+    const stats = computeCellStats([3300, 0, 3310, 3305])!;
+    expect(stats.indices).toEqual([0, 2, 3]);
+    // The highest reading is the third physical cell, at filtered position 1.
+    const highest = Math.max(...stats.normalisedDeviations);
+    expect(stats.indices[stats.normalisedDeviations.indexOf(highest)]).toBe(2);
+  });
+
   it('returns undefined when fewer than two cells survive', () => {
     expect(computeCellStats([3300, 0, 0])).toBeUndefined();
     expect(computeCellStats([])).toBeUndefined();
@@ -413,9 +423,8 @@ describe('family adapters', () => {
 
     it('reports how stale the cross-message inputs are', () => {
       const cells = { ...cellState(), timestamp: '2026-08-06T12:00:00.000Z' };
-      const data = { timestamp: '2026-08-05T11:59:00.000Z' } as any;
       const withData = extractB2500Sample(
-        { cells, data: { ...data, timestamp: '2026-08-06T11:59:00.000Z' } },
+        { cells, data: { timestamp: '2026-08-06T11:59:00.000Z' } },
         clock,
       )!;
       expect(withData.staleMs).toBe(60000);

--- a/src/cellBalancing.test.ts
+++ b/src/cellBalancing.test.ts
@@ -208,6 +208,29 @@ describe('balancing state machine', () => {
     expect(state.msAboveHighThreshold).toBe(2 * MINUTE);
   });
 
+  it('does not credit a high resting pack, only one with charge going in', () => {
+    // The exact shape of the artifact: cells sitting above the threshold after
+    // a charge, with nothing going in. A passive balancer needs current, so
+    // this time must not be booked as balancing.
+    const idle = (monotonicAt: number) =>
+      sample({
+        cellsMv: [3520, 3520, 3520, 3520],
+        chargingIn: false,
+        monotonicAt,
+        packCurrentA: -0.1,
+      });
+    const { state } = feed(initialBalancingState(), [idle(0), idle(MINUTE), idle(2 * MINUTE)]);
+    expect(state.msAboveThreshold).toBe(0);
+    expect(state.msAboveHighThreshold).toBe(0);
+
+    // And with the same voltages the moment current resumes, it is booked.
+    const { state: charged } = feed(state, [
+      charging(3 * MINUTE, [3520, 3520, 3520, 3520]),
+      charging(4 * MINUTE, [3520, 3520, 3520, 3520]),
+    ]);
+    expect(charged.msAboveThreshold).toBe(2 * MINUTE);
+  });
+
   it('books only observed time, not an outage', () => {
     // Device charging at the threshold, then off the network for ten hours.
     const samples = [

--- a/src/cellBalancing.test.ts
+++ b/src/cellBalancing.test.ts
@@ -135,10 +135,24 @@ describe('computeDrift', () => {
   });
 
   it('rejects a single outlier rather than letting it bend the fit', () => {
+    // Near an endpoint, where an outlier has real leverage on the slope. In the
+    // middle of the window it sits at the mean and barely moves the fit at all,
+    // so a spike placed there would pass with the rejection removed entirely.
     const noise = Array.from({ length: 30 }, () => 0);
-    noise[15] = 3; // a brief load step between two samples
-    const drift = computeDrift(window(30, -4, { noise }));
-    expect(drift).toBeCloseTo(-4, 1);
+    noise[2] = 3;
+    const points = window(30, -4, { noise });
+    expect(computeDrift(points)).toBeCloseTo(-4, 1);
+
+    // Guard against the test going vacuous again: an independent plain fit of
+    // the same window, with no rejection, has to be visibly off. Otherwise
+    // deleting the rejection branch would leave the assertion above green.
+    const n = points.length;
+    const meanT = points.reduce((a, p) => a + p.t, 0) / n;
+    const meanY = points.reduce((a, p) => a + p.meanMv, 0) / n;
+    const sxy = points.reduce((a, p) => a + (p.t - meanT) * (p.meanMv - meanY), 0);
+    const sxx = points.reduce((a, p) => a + (p.t - meanT) ** 2, 0);
+    const unrejected = (sxy / sxx) * 3600000;
+    expect(Math.abs(unrejected + 4)).toBeGreaterThan(0.3);
   });
 
   it('refuses a window that is not moving linearly', () => {
@@ -238,18 +252,18 @@ describe('balancing state machine', () => {
     expect(state.crossing).toBeUndefined();
   });
 
-  it('latches the rested spread and emits a cycle', () => {
-    const chargeUp = [
-      charging(0, [3430, 3450, 3440, 3440]),
-      charging(MINUTE, [3440, 3480, 3460, 3460]),
-      charging(2 * MINUTE, [3440, 3480, 3460, 3460]),
-    ];
-
-    // Then the pack sits idle. Samples every minute so the gap guard is happy.
-    const restStart = 3 * MINUTE;
-    const restSamples: CellSample[] = [];
-    for (let t = restStart; t <= restStart + REST_LATCH_DELAY_MS + 5 * MINUTE; t += MINUTE) {
-      restSamples.push(
+  // A charge that crosses 3450 mV and then stops. The rest clock only starts on
+  // that transition, so every rest test needs it.
+  const restStart = 3 * MINUTE;
+  const chargeThenStop = (): CellSample[] => [
+    charging(0, [3430, 3450, 3440, 3440]),
+    charging(MINUTE, [3440, 3480, 3460, 3460]),
+    charging(2 * MINUTE, [3440, 3480, 3460, 3460]),
+  ];
+  const restingFor = (durationMs: number): CellSample[] => {
+    const out: CellSample[] = [];
+    for (let t = restStart; t <= restStart + durationMs; t += MINUTE) {
+      out.push(
         sample({
           cellsMv: [3299, 3301, 3300, 3300],
           chargingIn: false,
@@ -259,8 +273,14 @@ describe('balancing state machine', () => {
         }),
       );
     }
+    return out;
+  };
 
-    const { state, cycles } = feed(initialBalancingState(), [...chargeUp, ...restSamples]);
+  it('latches the rested spread and emits a cycle', () => {
+    const { state, cycles } = feed(initialBalancingState(), [
+      ...chargeThenStop(),
+      ...restingFor(REST_LATCH_DELAY_MS + 5 * MINUTE),
+    ]);
     expect(cycles).toHaveLength(1);
     expect(state.rested).toBeDefined();
     expect(cycles[0].restedSpreadMv).toBe(2);
@@ -270,30 +290,75 @@ describe('balancing state machine', () => {
   });
 
   it('takes the median at a latch so one corrupt reading cannot be recorded', () => {
-    const restStart = 0;
-    const restSamples: CellSample[] = [];
-    for (let t = restStart; t <= REST_LATCH_DELAY_MS + 5 * MINUTE; t += MINUTE) {
-      restSamples.push(
+    // The corrupt sample has to land on the latch itself. Placed after it, the
+    // latch has already fired and the assertion proves nothing.
+    const corruptAt = restStart + REST_LATCH_DELAY_MS;
+    const samples = [...chargeThenStop(), ...restingFor(REST_LATCH_DELAY_MS + 5 * MINUTE)].map(s =>
+      s.monotonicAt === corruptAt ? sample({ ...s, cellsMv: [3000, 3900, 3300, 3300] }) : s,
+    );
+
+    const { cycles } = feed(initialBalancingState(), samples);
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].restedSpreadMv).toBe(2);
+    // The whole record comes from one clean sample, so the shape stored beside
+    // the spread cannot be the corrupt one either.
+    expect(cycles[0].restedNormalisedDeviations).toHaveLength(4);
+    expect(Math.max(...(cycles[0].restedNormalisedDeviations as number[]))).toBeLessThan(0.6);
+    expect(LATCH_MEDIAN_SAMPLES).toBeGreaterThan(2);
+  });
+
+  it('does not latch a rested spread without a charge before it', () => {
+    // An evening discharge that ends leaves the pack idle at low state of
+    // charge. Latching there would record the flat middle of the curve — the
+    // exact artifact this feature exists to expose — every single night.
+    const idle: CellSample[] = [];
+    for (let t = 0; t <= REST_LATCH_DELAY_MS + 10 * MINUTE; t += MINUTE) {
+      idle.push(
         sample({
-          cellsMv: [3299, 3301, 3300, 3300],
+          cellsMv: [3199, 3201, 3200, 3200],
           chargingIn: false,
           packCurrentA: 0,
           monotonicAt: t,
         }),
       );
     }
-    // One wild sample right at the latch instant.
-    restSamples[restSamples.length - 2] = sample({
-      cellsMv: [3000, 3900, 3300, 3300],
-      chargingIn: false,
-      packCurrentA: 0,
-      monotonicAt: restSamples[restSamples.length - 2].monotonicAt,
-    });
+    const { state, cycles } = feed(initialBalancingState(), idle);
+    expect(cycles).toHaveLength(0);
+    expect(state.rested).toBeUndefined();
+  });
 
-    const { cycles } = feed(initialBalancingState(), restSamples);
-    expect(cycles).toHaveLength(1);
-    expect(cycles[0].restedSpreadMv).toBe(2);
-    expect(LATCH_MEDIAN_SAMPLES).toBeGreaterThan(2);
+  it('abandons the rest window if the pack starts supplying the house', () => {
+    const interrupted = [...chargeThenStop()];
+    for (let t = restStart; t <= restStart + REST_LATCH_DELAY_MS + 10 * MINUTE; t += MINUTE) {
+      // Twenty minutes in, a 900 W load comes on and never goes away.
+      const current = t >= restStart + 20 * MINUTE ? -18 : -0.1;
+      interrupted.push(
+        sample({
+          cellsMv: [3299, 3301, 3300, 3300],
+          chargingIn: false,
+          packCurrentA: current,
+          monotonicAt: t,
+        }),
+      );
+    }
+    const { state, cycles } = feed(initialBalancingState(), interrupted);
+    expect(cycles).toHaveLength(0);
+    expect(state.rested).toBeUndefined();
+  });
+
+  it('never latches a rested spread when the family reports no current', () => {
+    // B2500 V1 has no pack current at all, so "idle" and "discharging into the
+    // house at 800 W" are indistinguishable. Publishing nothing beats
+    // publishing a spread measured under load.
+    const noCurrent = [...chargeThenStop()].map(s => sample({ ...s, packCurrentA: undefined }));
+    for (let t = restStart; t <= restStart + REST_LATCH_DELAY_MS + 10 * MINUTE; t += MINUTE) {
+      noCurrent.push(
+        sample({ cellsMv: [3299, 3301, 3300, 3300], chargingIn: false, monotonicAt: t }),
+      );
+    }
+    const { state, cycles } = feed(initialBalancingState(), noCurrent);
+    expect(cycles).toHaveLength(0);
+    expect(state.rested).toBeUndefined();
   });
 
   it('survives a backwards wall clock without producing negative durations', () => {

--- a/src/cellBalancing.test.ts
+++ b/src/cellBalancing.test.ts
@@ -391,6 +391,24 @@ describe('family adapters', () => {
       expect(extractVenusSample({ bms: bmsState() }, clock)!.staleMs).toBe(0);
     });
 
+    it('reads current from the payload, not from the sensor field', () => {
+      // The parsed `bms.current` field drives a sensor, and its scale is a
+      // presentation decision that can be corrected independently. If this read
+      // the field instead of the raw value, such a correction would silently
+      // rescale the current gate and the charging threshold.
+      const state = bmsState() as any;
+      state.bms.current = -9.4; // as if the sensor had been rescaled to amps
+      expect(extractVenusSample({ bms: state }, clock)!.packCurrentA).toBeCloseTo(-9.4, 6);
+    });
+
+    it('leaves current unknown when the payload does not carry it', () => {
+      const state = bmsState() as any;
+      delete state.values.b_cur;
+      const sampleOut = extractVenusSample({ bms: state }, clock)!;
+      expect(sampleOut.packCurrentA).toBeUndefined();
+      expect(sampleOut.chargingIn).toBeUndefined();
+    });
+
     it('picks up state of charge and the warmest cell temperature', () => {
       const sampleOut = extractVenusSample({ bms: bmsState() }, clock)!;
       expect(sampleOut.socPct).toBe(65); // b_soc

--- a/src/cellBalancing.test.ts
+++ b/src/cellBalancing.test.ts
@@ -1,0 +1,404 @@
+import './device/registry.js';
+import {
+  advanceBalancingState,
+  BalancingState,
+  CellSample,
+  computeCellStats,
+  computeDrift,
+  extractB2500Sample,
+  extractVenusSample,
+  initialBalancingState,
+  plausibleCells,
+} from './cellBalancing.js';
+import { parseMessage } from './parser.js';
+import {
+  CELL_KNEE_CROSSING_MV,
+  CELL_SAMPLE_MAX_GAP_MS,
+  DRIFT_WINDOW_MS,
+  LATCH_MEDIAN_SAMPLES,
+  REST_LATCH_DELAY_MS,
+} from './constants.js';
+
+const MINUTE = 60000;
+
+function sample(overrides: Partial<CellSample> & { cellsMv: number[] }): CellSample {
+  return {
+    at: 1_700_000_000_000,
+    monotonicAt: 0,
+    staleMs: 0,
+    ...overrides,
+  };
+}
+
+describe('computeCellStats', () => {
+  it('reports spread, sigma and deviations', () => {
+    const stats = computeCellStats([3300, 3310, 3290, 3300])!;
+    expect(stats.count).toBe(4);
+    expect(stats.meanMv).toBe(3300);
+    expect(stats.spreadMv).toBe(20);
+    expect(stats.sigmaMv).toBeCloseTo(Math.sqrt(50), 6);
+    expect(stats.deviationsMv).toEqual([0, 10, -10, 0]);
+  });
+
+  it('drops empty slots and implausible readings', () => {
+    // Unused slots on a short pack read exactly 0.
+    expect(plausibleCells([3300, 0, 3310, 65535])).toEqual([3300, 3310]);
+    const stats = computeCellStats([3300, 0, 3310])!;
+    expect(stats.count).toBe(2);
+    expect(stats.meanMv).toBe(3305);
+  });
+
+  it('returns undefined when fewer than two cells survive', () => {
+    expect(computeCellStats([3300, 0, 0])).toBeUndefined();
+    expect(computeCellStats([])).toBeUndefined();
+  });
+});
+
+describe('normalised deviations discriminate the slide from balancing', () => {
+  // This is the reason the feature exists. A pack sliding down the flat part of
+  // the LFP curve keeps every cell's *share* of the spread identical while the
+  // spread itself collapses; balancing changes the share.
+  const atKnee = [3450, 3470, 3455, 3445];
+
+  it('is unchanged when the whole stack slides down together', () => {
+    const before = computeCellStats(atKnee)!;
+    // Same relative positions, spread scaled by a quarter, mean much lower.
+    const mean = before.meanMv;
+    const slid = atKnee.map(mv => 3300 + (mv - mean) * 0.25);
+    const after = computeCellStats(slid)!;
+
+    expect(after.spreadMv).toBeCloseTo(before.spreadMv * 0.25, 6);
+    expect(after.meanMv).toBeLessThan(before.meanMv - 100);
+    after.normalisedDeviations.forEach((d, i) => {
+      expect(d).toBeCloseTo(before.normalisedDeviations[i], 6);
+    });
+  });
+
+  it('moves the outlier toward zero when the outlier is actually bled down', () => {
+    const before = computeCellStats(atKnee)!;
+    // Only the high cell comes down; the others stay put.
+    const after = computeCellStats([3450, 3458, 3455, 3445])!;
+
+    const outlier = 1;
+    expect(Math.abs(after.normalisedDeviations[outlier])).toBeLessThan(
+      Math.abs(before.normalisedDeviations[outlier]),
+    );
+  });
+});
+
+describe('computeDrift', () => {
+  const window = (
+    count: number,
+    slopeMvPerHour: number,
+    extra: { currentA?: number; cellCount?: number; noise?: number[] } = {},
+  ) =>
+    Array.from({ length: count }, (_, i) => {
+      const t = (i * DRIFT_WINDOW_MS) / (count - 1);
+      return {
+        t,
+        meanMv: 3300 + (slopeMvPerHour * t) / 3600000 + (extra.noise?.[i] ?? 0),
+        currentA: extra.currentA,
+        cellCount: extra.cellCount ?? 16,
+      };
+    });
+
+  it('recovers a known slope', () => {
+    expect(computeDrift(window(30, -4))).toBeCloseTo(-4, 6);
+  });
+
+  it('needs enough samples and enough span', () => {
+    expect(computeDrift(window(3, -4))).toBeUndefined();
+    const tooShort = window(30, -4).map(p => ({
+      t: p.t / 10,
+      meanMv: p.meanMv,
+      currentA: p.currentA,
+      cellCount: p.cellCount,
+    }));
+    expect(computeDrift(tooShort)).toBeUndefined();
+  });
+
+  it('suppresses the reading when the pack was not at rest', () => {
+    expect(computeDrift(window(30, -4, { currentA: 6 }))).toBeUndefined();
+    expect(computeDrift(window(30, -4, { currentA: 0.2 }))).toBeCloseTo(-4, 6);
+  });
+
+  it('still reports when no current is available at all', () => {
+    // B2500 V1 reports no pack current; a gated-off metric would be useless
+    // there, so an ungated slope is the best available.
+    expect(computeDrift(window(30, -4, { currentA: undefined }))).toBeCloseTo(-4, 6);
+  });
+
+  it('discards a window whose cell count changed', () => {
+    const points = window(30, -4);
+    points[10].cellCount = 15;
+    expect(computeDrift(points)).toBeUndefined();
+  });
+
+  it('rejects a single outlier rather than letting it bend the fit', () => {
+    const noise = Array.from({ length: 30 }, () => 0);
+    noise[15] = 3; // a brief load step between two samples
+    const drift = computeDrift(window(30, -4, { noise }));
+    expect(drift).toBeCloseTo(-4, 1);
+  });
+
+  it('refuses a window that is not moving linearly', () => {
+    // Post-charge relaxation: fast decay, not a straight line.
+    const points = Array.from({ length: 30 }, (_, i) => {
+      const t = (i * DRIFT_WINDOW_MS) / 29;
+      return { t, meanMv: 3300 + 80 * Math.exp(-t / 300000), cellCount: 16 };
+    });
+    expect(computeDrift(points)).toBeUndefined();
+  });
+});
+
+describe('balancing state machine', () => {
+  const feed = (
+    state: BalancingState,
+    samples: CellSample[],
+    localDate = '2026-08-06',
+  ): { state: BalancingState; cycles: any[] } => {
+    const cycles: any[] = [];
+    let current = state;
+    for (const s of samples) {
+      const result = advanceBalancingState(current, s, localDate);
+      current = result.state;
+      if (result.cycle) cycles.push(result.cycle);
+    }
+    return { state: current, cycles };
+  };
+
+  const charging = (monotonicAt: number, cellsMv: number[]) =>
+    sample({ cellsMv, chargingIn: true, monotonicAt, packCurrentA: 5 });
+
+  it('accumulates time above the two thresholds separately', () => {
+    const samples = [
+      charging(0, [3420, 3420, 3420, 3420]),
+      charging(MINUTE, [3420, 3420, 3420, 3420]),
+      charging(2 * MINUTE, [3520, 3520, 3520, 3520]),
+      charging(3 * MINUTE, [3520, 3520, 3520, 3520]),
+    ];
+    const { state } = feed(initialBalancingState(), samples);
+    // Each interval is credited according to the state at its end, so the two
+    // intervals ending on a 3520 sample count toward the high threshold.
+    expect(state.msAboveThreshold).toBe(3 * MINUTE);
+    expect(state.msAboveHighThreshold).toBe(2 * MINUTE);
+  });
+
+  it('books only observed time, not an outage', () => {
+    // Device charging at the threshold, then off the network for ten hours.
+    const samples = [
+      charging(0, [3420, 3420, 3420, 3420]),
+      charging(MINUTE, [3420, 3420, 3420, 3420]),
+      charging(600 * MINUTE, [3420, 3420, 3420, 3420]),
+      charging(601 * MINUTE, [3420, 3420, 3420, 3420]),
+    ];
+    const { state } = feed(initialBalancingState(), samples);
+    // One minute before the gap and one after it — never the gap itself.
+    expect(state.msAboveThreshold).toBe(2 * MINUTE);
+    expect(state.msAboveThreshold).toBeLessThan(CELL_SAMPLE_MAX_GAP_MS * 2);
+  });
+
+  it('resets the daily counters when the local date rolls over', () => {
+    let { state } = feed(initialBalancingState(), [
+      charging(0, [3420, 3420, 3420, 3420]),
+      charging(MINUTE, [3420, 3420, 3420, 3420]),
+    ]);
+    expect(state.msAboveThreshold).toBe(MINUTE);
+
+    ({ state } = feed(state, [charging(2 * MINUTE, [3420, 3420, 3420, 3420])], '2026-08-07'));
+    // Yesterday's minute is gone; only the interval straddling midnight, which
+    // is credited to the day it ended in, remains.
+    expect(state.msAboveThreshold).toBe(MINUTE);
+    expect(state.localDate).toBe('2026-08-07');
+  });
+
+  it('latches the spread interpolated at the crossing voltage', () => {
+    // Mean steps 3440 -> 3460, so the crossing at 3450 sits exactly halfway;
+    // the spread differs between the two samples so interpolation is visible.
+    const below = [3430, 3450, 3440, 3440]; // mean 3440, spread 20
+    const above = [3440, 3480, 3460, 3460]; // mean 3460, spread 40
+    const { state } = feed(initialBalancingState(), [
+      charging(0, below),
+      charging(MINUTE, above),
+      charging(2 * MINUTE, above), // confirmation
+    ]);
+    expect(state.crossing).toBeDefined();
+    expect(state.crossing!.meanMv).toBe(CELL_KNEE_CROSSING_MV);
+    expect(state.crossing!.spreadMv).toBeCloseTo(30, 6);
+  });
+
+  it('does not latch on a single spike that immediately falls back', () => {
+    const below = [3430, 3450, 3440, 3440];
+    const spike = [3440, 3480, 3460, 3460];
+    const { state } = feed(initialBalancingState(), [
+      charging(0, below),
+      charging(MINUTE, spike),
+      charging(2 * MINUTE, below), // not confirmed
+    ]);
+    expect(state.crossing).toBeUndefined();
+  });
+
+  it('latches the rested spread and emits a cycle', () => {
+    const chargeUp = [
+      charging(0, [3430, 3450, 3440, 3440]),
+      charging(MINUTE, [3440, 3480, 3460, 3460]),
+      charging(2 * MINUTE, [3440, 3480, 3460, 3460]),
+    ];
+
+    // Then the pack sits idle. Samples every minute so the gap guard is happy.
+    const restStart = 3 * MINUTE;
+    const restSamples: CellSample[] = [];
+    for (let t = restStart; t <= restStart + REST_LATCH_DELAY_MS + 5 * MINUTE; t += MINUTE) {
+      restSamples.push(
+        sample({
+          cellsMv: [3299, 3301, 3300, 3300],
+          chargingIn: false,
+          packCurrentA: -0.1,
+          monotonicAt: t,
+          socPct: 100,
+        }),
+      );
+    }
+
+    const { state, cycles } = feed(initialBalancingState(), [...chargeUp, ...restSamples]);
+    expect(cycles).toHaveLength(1);
+    expect(state.rested).toBeDefined();
+    expect(cycles[0].restedSpreadMv).toBe(2);
+    // The comparable knee number survives into the record.
+    expect(cycles[0].crossingSpreadMv).toBeCloseTo(30, 6);
+    expect(cycles[0].minSocPct).toBe(100);
+  });
+
+  it('takes the median at a latch so one corrupt reading cannot be recorded', () => {
+    const restStart = 0;
+    const restSamples: CellSample[] = [];
+    for (let t = restStart; t <= REST_LATCH_DELAY_MS + 5 * MINUTE; t += MINUTE) {
+      restSamples.push(
+        sample({
+          cellsMv: [3299, 3301, 3300, 3300],
+          chargingIn: false,
+          packCurrentA: 0,
+          monotonicAt: t,
+        }),
+      );
+    }
+    // One wild sample right at the latch instant.
+    restSamples[restSamples.length - 2] = sample({
+      cellsMv: [3000, 3900, 3300, 3300],
+      chargingIn: false,
+      packCurrentA: 0,
+      monotonicAt: restSamples[restSamples.length - 2].monotonicAt,
+    });
+
+    const { cycles } = feed(initialBalancingState(), restSamples);
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].restedSpreadMv).toBe(2);
+    expect(LATCH_MEDIAN_SAMPLES).toBeGreaterThan(2);
+  });
+
+  it('survives a backwards wall clock without producing negative durations', () => {
+    // Monotonic time keeps advancing even as the wall clock jumps back a year.
+    const samples = [
+      charging(0, [3420, 3420, 3420, 3420]),
+      { ...charging(MINUTE, [3420, 3420, 3420, 3420]), at: 1_600_000_000_000 },
+    ];
+    const { state } = feed(initialBalancingState(), samples);
+    expect(state.msAboveThreshold).toBe(MINUTE);
+  });
+
+  it('ignores samples with no usable cells', () => {
+    const before = initialBalancingState();
+    const { state } = feed(before, [sample({ cellsMv: [0, 0, 0], chargingIn: true })]);
+    expect(state).toBe(before);
+  });
+});
+
+describe('family adapters', () => {
+  const clock = { at: 1_700_000_000_000, monotonicAt: 0 };
+
+  describe('B2500', () => {
+    // cd=13, real shape: a0-af in mV, 14 populated and two empty slots.
+    const cellPayload =
+      'a0=3301,a1=3302,a2=3300,a3=3303,a4=3299,a5=3301,a6=3302,a7=3300,' +
+      'a8=3301,a9=3300,aa=3302,ab=3301,ac=3300,ad=3303,ae=0,af=0';
+
+    const cellState = () => parseMessage(cellPayload, 'HMA-1', 'dev')['cells'];
+
+    it('converts volts back to millivolts and drops the empty slots', () => {
+      const sampleOut = extractB2500Sample({ cells: cellState() }, clock)!;
+      const stats = computeCellStats(sampleOut.cellsMv)!;
+      expect(stats.count).toBe(14);
+      expect(stats.minMv).toBeCloseTo(3299, 6);
+      expect(stats.maxMv).toBeCloseTo(3303, 6);
+    });
+
+    it('prefers the pack status flag for charging state', () => {
+      const data = { packStatus: { host: { charging: true } }, solarInputStatus: {} };
+      expect(extractB2500Sample({ cells: cellState(), data }, clock)!.chargingIn).toBe(true);
+    });
+
+    it('falls back to solar input state on firmware without l0', () => {
+      const data = { solarInputStatus: { input1Charging: false, input2Charging: true } };
+      expect(extractB2500Sample({ cells: cellState(), data }, clock)!.chargingIn).toBe(true);
+    });
+
+    it('leaves charging unknown when neither source is present', () => {
+      expect(extractB2500Sample({ cells: cellState() }, clock)!.chargingIn).toBeUndefined();
+    });
+
+    it('reports how stale the cross-message inputs are', () => {
+      const cells = { ...cellState(), timestamp: '2026-08-06T12:00:00.000Z' };
+      const data = { timestamp: '2026-08-05T11:59:00.000Z' } as any;
+      const withData = extractB2500Sample(
+        { cells, data: { ...data, timestamp: '2026-08-06T11:59:00.000Z' } },
+        clock,
+      )!;
+      expect(withData.staleMs).toBe(60000);
+    });
+
+    it('returns nothing when no cell data has arrived', () => {
+      expect(extractB2500Sample({}, clock)).toBeUndefined();
+    });
+  });
+
+  describe('Venus', () => {
+    // cd=14 sample straight from the firmware, cells already in mV.
+    const bmsPayload =
+      'b_ver=212,b_chv=571,b_rci=1000,b_rdi=1000,b_soc=65,b_soh=100,b_cap=5120,b_vol=5223,' +
+      'b_cur=-94,b_tem=250,b_chf=192,b_slf=0,b_cpc=332,b_err=0,b_war=0,b_ret=102482070,' +
+      'b_ent=0,b_mot=23,b_tp1=18,b_tp2=19,b_tp3=18,b_tp4=19,' +
+      'b_vo1=3265,b_vo2=3265,b_vo3=3265,b_vo4=3265,b_vo5=3264,b_vo6=3264,b_vo7=3265,b_vo8=3265,' +
+      'b_vo9=3264,b_vo10=3265,b_vo11=3264,b_vo12=3265,b_vo13=3265,b_vo14=3265,b_vo15=3264,b_vo16=3262';
+
+    const bmsState = () => parseMessage(bmsPayload, 'VNSE3-0', 'dev')['bms'];
+
+    it('takes cell voltages as millivolts unchanged', () => {
+      const sampleOut = extractVenusSample({ bms: bmsState() }, clock)!;
+      const stats = computeCellStats(sampleOut.cellsMv)!;
+      expect(stats.count).toBe(16);
+      expect(stats.minMv).toBe(3262);
+      expect(stats.maxMv).toBe(3265);
+      expect(stats.spreadMv).toBe(3);
+    });
+
+    it('reads b_cur as deci-amps and infers discharge', () => {
+      const sampleOut = extractVenusSample({ bms: bmsState() }, clock)!;
+      expect(sampleOut.packCurrentA).toBeCloseTo(-9.4, 6);
+      expect(sampleOut.chargingIn).toBe(false);
+    });
+
+    it('carries no staleness, because everything is in one message', () => {
+      expect(extractVenusSample({ bms: bmsState() }, clock)!.staleMs).toBe(0);
+    });
+
+    it('picks up state of charge and the warmest cell temperature', () => {
+      const sampleOut = extractVenusSample({ bms: bmsState() }, clock)!;
+      expect(sampleOut.socPct).toBe(65); // b_soc
+      expect(sampleOut.tempC).toBe(19); // max of b_tp1-b_tp4
+    });
+
+    it('returns nothing when no BMS data has arrived', () => {
+      expect(extractVenusSample({}, clock)).toBeUndefined();
+    });
+  });
+});

--- a/src/cellBalancing.ts
+++ b/src/cellBalancing.ts
@@ -152,13 +152,18 @@ export function extractVenusSample(
     return undefined;
   }
 
-  // `b_cur` is published as milliamps by the BMS sensor, but that label is
-  // almost certainly wrong: -72 while discharging at night would be 3.7 W on a
-  // 51 V pack. Read as deci-amps it is -7.2 A, an ordinary night discharge, and
-  // Jupiter's identical key already uses that scale. Correcting the shipped
-  // sensor is a user-visible change and is handled separately; the diagnostics
-  // use the scale that makes physical sense.
-  const packCurrentA = typeof bms?.current === 'number' ? bms.current / 10 : undefined;
+  // Taken from the raw payload rather than the parsed `bms.current` field on
+  // purpose. That field exists to drive a sensor, and its scale is a
+  // presentation decision that can be corrected independently of this code —
+  // reading it here would silently change what the diagnostics mean the moment
+  // it was. b_cur is deci-amps, signed negative while discharging.
+  const rawCurrent = bmsState?.values?.['b_cur'];
+  const packCurrentA =
+    typeof rawCurrent === 'string' &&
+    rawCurrent.trim() !== '' &&
+    Number.isFinite(Number(rawCurrent))
+      ? Number(rawCurrent) / 10
+      : undefined;
 
   const temperatures = Array.isArray(bmsState?.cells?.temperatures)
     ? bmsState.cells.temperatures.filter((t: unknown): t is number => typeof t === 'number')

--- a/src/cellBalancing.ts
+++ b/src/cellBalancing.ts
@@ -2,6 +2,7 @@ import {
   BALANCE_SESSION_END_GRACE_MS,
   CELL_BALANCE_HIGH_THRESHOLD_MV,
   CELL_BALANCE_THRESHOLD_MV,
+  CHARGE_DETECT_MIN_A,
   CELL_KNEE_CROSSING_MV,
   CELL_KNEE_REARM_HYSTERESIS_MV,
   CELL_PLAUSIBLE_MAX_MV,
@@ -173,7 +174,7 @@ export function extractVenusSample(
     cellsMv,
     // Same message as the cells, so this cannot lag them — unlike the working
     // status in the runtime message, which can be a poll interval behind.
-    chargingIn: packCurrentA != null ? packCurrentA > 0.2 : undefined,
+    chargingIn: packCurrentA != null ? packCurrentA > CHARGE_DETECT_MIN_A : undefined,
     socPct: bms?.soc,
     packCurrentA,
     tempC: temperatures.length > 0 ? Math.max(...temperatures) : undefined,
@@ -185,6 +186,12 @@ export function extractVenusSample(
 
 export interface CellStats {
   count: number;
+  /**
+   * Where each surviving cell sat in the original array. Implausible readings
+   * are dropped from anywhere in the pack, so a position in `deviationsMv` is
+   * not a cell number — this maps back.
+   */
+  indices: number[];
   minMv: number;
   maxMv: number;
   meanMv: number;
@@ -284,17 +291,24 @@ export function initialBalancingState(): BalancingState {
  * permanently.
  */
 export function plausibleCells(cellsMv: number[]): number[] {
-  return cellsMv.filter(
-    mv => Number.isFinite(mv) && mv >= CELL_PLAUSIBLE_MIN_MV && mv <= CELL_PLAUSIBLE_MAX_MV,
-  );
+  return plausibleCellsWithIndices(cellsMv).map(c => c.mv);
+}
+
+function plausibleCellsWithIndices(cellsMv: number[]): { mv: number; index: number }[] {
+  return cellsMv
+    .map((mv, index) => ({ mv, index }))
+    .filter(
+      ({ mv }) => Number.isFinite(mv) && mv >= CELL_PLAUSIBLE_MIN_MV && mv <= CELL_PLAUSIBLE_MAX_MV,
+    );
 }
 
 export function computeCellStats(rawCellsMv: number[]): CellStats | undefined {
-  const cellsMv = plausibleCells(rawCellsMv);
-  if (cellsMv.length < 2) {
+  const present = plausibleCellsWithIndices(rawCellsMv);
+  if (present.length < 2) {
     return undefined;
   }
 
+  const cellsMv = present.map(c => c.mv);
   const count = cellsMv.length;
   const minMv = Math.min(...cellsMv);
   const maxMv = Math.max(...cellsMv);
@@ -305,6 +319,7 @@ export function computeCellStats(rawCellsMv: number[]): CellStats | undefined {
 
   return {
     count,
+    indices: present.map(c => c.index),
     minMv,
     maxMv,
     meanMv,

--- a/src/cellBalancing.ts
+++ b/src/cellBalancing.ts
@@ -225,7 +225,7 @@ interface DriftPoint {
   cellCount: number;
 }
 
-interface LatchCandidate {
+export interface LatchCandidate {
   spreadMv: number;
   sigmaMv: number;
   meanMv: number;
@@ -241,6 +241,7 @@ export interface BalancingState {
   lastMonotonicAt?: number;
   lastMeanMv?: number;
   lastCandidate?: LatchCandidate;
+  lastChargingIn?: boolean;
 
   msAboveThreshold: number;
   msAboveHighThreshold: number;
@@ -314,12 +315,6 @@ export function computeCellStats(rawCellsMv: number[]): CellStats | undefined {
     // rather than dividing by zero.
     normalisedDeviations: deviationsMv.map(d => (spreadMv > 0 ? d / spreadMv : 0)),
   };
-}
-
-function median(values: number[]): number {
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
 }
 
 function leastSquaresSlope(points: DriftPoint[]): { slope: number; residualRms: number } {
@@ -438,14 +433,17 @@ function interpolateCandidate(
   };
 }
 
-function medianCandidate(candidates: LatchCandidate[]): LatchCandidate {
-  const last = candidates[candidates.length - 1];
-  return {
-    ...last,
-    spreadMv: median(candidates.map(c => c.spreadMv)),
-    sigmaMv: median(candidates.map(c => c.sigmaMv)),
-    meanMv: median(candidates.map(c => c.meanMv)),
-  };
+/**
+ * The candidate with the median spread, returned whole.
+ *
+ * Taking a median of each field separately would mix values from different
+ * samples, so a corrupt reading could still contribute the temperature or the
+ * deviation shape recorded next to a clean spread. Picking one real sample keeps
+ * the stored record internally consistent.
+ */
+function medoidCandidate(candidates: LatchCandidate[]): LatchCandidate {
+  const sorted = [...candidates].sort((a, b) => a.spreadMv - b.spreadMv);
+  return sorted[Math.floor(sorted.length / 2)];
 }
 
 /**
@@ -459,10 +457,10 @@ export function advanceBalancingState(
   state: BalancingState,
   sample: CellSample,
   localDate: string,
-): { state: BalancingState; cycle?: CycleRecord } {
+): { state: BalancingState; cycle?: CycleRecord; conditionsMet: boolean } {
   const stats = computeCellStats(sample.cellsMv);
   if (!stats) {
-    return { state };
+    return { state, conditionsMet: false };
   }
 
   const next: BalancingState = {
@@ -514,6 +512,7 @@ export function advanceBalancingState(
     next.conditionsUnmetSinceMonotonic ??= sample.monotonicAt;
     if (sample.monotonicAt - next.conditionsUnmetSinceMonotonic >= BALANCE_SESSION_END_GRACE_MS) {
       next.sessionActive = false;
+      next.sessionMs = 0;
       next.conditionsUnmetSinceMonotonic = undefined;
     }
   }
@@ -562,21 +561,40 @@ export function advanceBalancingState(
     next.crossingArmed = true;
   }
 
-  // Rested latch: an hour after charging stopped, with the pack actually idle.
-  const resting =
-    !charging &&
-    (sample.packCurrentA == null || Math.abs(sample.packCurrentA) <= REST_CURRENT_MAX_A);
-  if (resting) {
-    next.restingSinceMonotonic ??= sample.monotonicAt;
-    next.restCandidates.push(candidate);
-    if (next.restCandidates.length > LATCH_MEDIAN_SAMPLES) {
-      next.restCandidates.shift();
-    }
-  } else {
+  // Rested latch.
+  //
+  // The clock starts when charging *stops*, not whenever the pack happens to be
+  // idle. Starting it on idleness would fire an hour into every evening, at
+  // whatever state of charge the discharge left behind — the flat middle of the
+  // curve, which is the very artifact this feature exists to expose — and would
+  // even fire on a device that had never charged at all.
+  //
+  // The pack must also be measurably idle. With no current reading there is no
+  // way to tell resting from discharging into the house, so a family that does
+  // not report one never latches rather than latching something meaningless.
+  const idle = sample.packCurrentA != null && Math.abs(sample.packCurrentA) <= REST_CURRENT_MAX_A;
+
+  if (charging) {
+    // A new charge invalidates whatever the previous rest measured.
     next.restingSinceMonotonic = undefined;
     next.restCandidates = [];
-    if (charging) {
-      next.restedLatched = false;
+    next.restedLatched = false;
+  } else if (state.lastChargingIn === true && observedGap) {
+    // Charging has just stopped: this is where the rest period begins.
+    next.restingSinceMonotonic = sample.monotonicAt;
+    next.restCandidates = [];
+  } else if (next.restingSinceMonotonic != null) {
+    if (idle) {
+      next.restCandidates.push(candidate);
+      if (next.restCandidates.length > LATCH_MEDIAN_SAMPLES) {
+        next.restCandidates.shift();
+      }
+    } else {
+      // Something drew from the pack, so it was not resting after all. Wait for
+      // the next charge rather than restarting the clock, which would put the
+      // measurement at an arbitrary point on the curve.
+      next.restingSinceMonotonic = undefined;
+      next.restCandidates = [];
     }
   }
 
@@ -587,7 +605,7 @@ export function advanceBalancingState(
     sample.monotonicAt - next.restingSinceMonotonic >= REST_LATCH_DELAY_MS &&
     next.restCandidates.length >= LATCH_MEDIAN_SAMPLES
   ) {
-    next.rested = medianCandidate(next.restCandidates);
+    next.rested = medoidCandidate(next.restCandidates);
     next.restedLatched = true;
 
     cycle = {
@@ -613,6 +631,7 @@ export function advanceBalancingState(
   next.lastMonotonicAt = sample.monotonicAt;
   next.lastMeanMv = stats.meanMv;
   next.lastCandidate = candidate;
+  next.lastChargingIn = charging;
 
-  return { state: next, cycle };
+  return { state: next, cycle, conditionsMet };
 }

--- a/src/cellBalancing.ts
+++ b/src/cellBalancing.ts
@@ -1,0 +1,613 @@
+import {
+  BALANCE_SESSION_END_GRACE_MS,
+  CELL_BALANCE_HIGH_THRESHOLD_MV,
+  CELL_BALANCE_THRESHOLD_MV,
+  CELL_KNEE_CROSSING_MV,
+  CELL_KNEE_REARM_HYSTERESIS_MV,
+  CELL_PLAUSIBLE_MAX_MV,
+  CELL_PLAUSIBLE_MIN_MV,
+  CELL_SAMPLE_MAX_GAP_MS,
+  CYCLE_HISTORY_LENGTH,
+  DRIFT_CURRENT_GATE_A,
+  DRIFT_MAX_RESIDUAL_MV,
+  DRIFT_MIN_SAMPLES,
+  DRIFT_WINDOW_MS,
+  LATCH_MEDIAN_SAMPLES,
+  REST_CURRENT_MAX_A,
+  REST_LATCH_DELAY_MS,
+} from './constants.js';
+
+/**
+ * Cell balancing diagnostics.
+ *
+ * The problem this addresses: at 100% state of charge with no export the MPPT
+ * disconnects and the unit's own electronics drain the pack. Every cell slides
+ * equally out of the steep top of the LFP curve into the flat plateau, so the
+ * max-minus-min spread collapses from tens of millivolts to one or two — with no
+ * change whatsoever in the cells' relative state of charge. It looks exactly
+ * like successful balancing and is nothing of the sort.
+ *
+ * Everything here is inference from voltage and current. No device in this
+ * project reports whether its balancer is actually switched on.
+ */
+
+/**
+ * One observation of a pack, normalised across device families: cell voltages
+ * always in millivolts, current always in amps and signed positive for charge.
+ */
+export interface CellSample {
+  cellsMv: number[];
+  /** Undefined when the family gives us nothing to infer it from. */
+  chargingIn?: boolean;
+  socPct?: number;
+  packCurrentA?: number;
+  tempC?: number;
+  /** Wall clock, for stamping records only. */
+  at: number;
+  /**
+   * Monotonic clock, for measuring durations. A Pi without a real-time clock
+   * jumps when NTP first syncs, which would otherwise produce negative or
+   * absurd session lengths.
+   */
+  monotonicAt: number;
+  /**
+   * Age of the oldest cross-message input in this sample. On B2500 the current
+   * and charging flag come from a different message than the cell voltages, so
+   * they can be a poll interval old — worst exactly at the top of charge, where
+   * current is collapsing fastest.
+   */
+  staleMs: number;
+}
+
+/** Per-publishPath device state, as held by DeviceManager. */
+export type StateByPath = Record<string, any>;
+
+export interface SampleClock {
+  /** Wall clock, for stamps. */
+  at: number;
+  /** Monotonic clock, for durations. */
+  monotonicAt: number;
+}
+
+function timestampMs(state: any): number | undefined {
+  const parsed = state?.timestamp != null ? Date.parse(state.timestamp) : NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * How far behind the cell reading the supporting inputs are. Anything sourced
+ * from another message can be a whole poll interval old, which matters most at
+ * the top of charge where the current is collapsing fastest.
+ */
+function stalenessMs(cellState: any, supporting: any[]): number {
+  const cellTs = timestampMs(cellState);
+  if (cellTs == null) {
+    return 0;
+  }
+  return supporting.reduce((worst, state) => {
+    const ts = timestampMs(state);
+    return ts == null ? worst : Math.max(worst, Math.abs(cellTs - ts));
+  }, 0);
+}
+
+/**
+ * B2500. The worst case of the two: cell voltages, charging state and pack
+ * current live in three different messages, and only the V2 reports a current
+ * at all.
+ */
+export function extractB2500Sample(
+  stateByPath: StateByPath,
+  clock: SampleClock,
+): CellSample | undefined {
+  const cellState = stateByPath['cells'];
+  const cells = cellState?.cellVoltage?.host?.cells;
+  if (!Array.isArray(cells)) {
+    return undefined;
+  }
+
+  const data = stateByPath['data'];
+  const extra = stateByPath['extraBatteryData'];
+
+  // Prefer the per-pack status flag; fall back to the solar input state on
+  // firmware older than 212.17, which does not report l0/l1 at all.
+  const packCharging = data?.packStatus?.host?.charging;
+  const solarCharging =
+    data?.solarInputStatus?.input1Charging === true ||
+    data?.solarInputStatus?.input2Charging === true;
+  const chargingIn =
+    packCharging != null
+      ? packCharging
+      : data?.solarInputStatus != null
+        ? solarCharging
+        : undefined;
+
+  return {
+    // State is in volts here, unlike Venus.
+    cellsMv: cells.map((v: unknown) => (typeof v === 'number' ? v * 1000 : NaN)),
+    chargingIn,
+    socPct: data?.batteryPercentage,
+    packCurrentA: extra?.batteryData?.host?.current,
+    tempC: data?.temperature?.max,
+    at: clock.at,
+    monotonicAt: clock.monotonicAt,
+    staleMs: stalenessMs(cellState, [data, extra]),
+  };
+}
+
+/**
+ * Venus. Cell voltages, pack current, temperature and state of charge all
+ * arrive in the same cd=14 payload, so the sample is internally consistent and
+ * carries no staleness at all.
+ */
+export function extractVenusSample(
+  stateByPath: StateByPath,
+  clock: SampleClock,
+): CellSample | undefined {
+  // The `bms` publishPath nests its scalar fields under a further `bms` key,
+  // alongside the `cells` block.
+  const bmsState = stateByPath['bms'];
+  const bms = bmsState?.bms;
+  const cellsMv = bmsState?.cells?.voltages;
+  if (!Array.isArray(cellsMv)) {
+    return undefined;
+  }
+
+  // `b_cur` is published as milliamps by the BMS sensor, but that label is
+  // almost certainly wrong: -72 while discharging at night would be 3.7 W on a
+  // 51 V pack. Read as deci-amps it is -7.2 A, an ordinary night discharge, and
+  // Jupiter's identical key already uses that scale. Correcting the shipped
+  // sensor is a user-visible change and is handled separately; the diagnostics
+  // use the scale that makes physical sense.
+  const packCurrentA = typeof bms?.current === 'number' ? bms.current / 10 : undefined;
+
+  const temperatures = Array.isArray(bmsState?.cells?.temperatures)
+    ? bmsState.cells.temperatures.filter((t: unknown): t is number => typeof t === 'number')
+    : [];
+
+  return {
+    cellsMv,
+    // Same message as the cells, so this cannot lag them — unlike the working
+    // status in the runtime message, which can be a poll interval behind.
+    chargingIn: packCurrentA != null ? packCurrentA > 0.2 : undefined,
+    socPct: bms?.soc,
+    packCurrentA,
+    tempC: temperatures.length > 0 ? Math.max(...temperatures) : undefined,
+    at: clock.at,
+    monotonicAt: clock.monotonicAt,
+    staleMs: 0,
+  };
+}
+
+export interface CellStats {
+  count: number;
+  minMv: number;
+  maxMv: number;
+  meanMv: number;
+  spreadMv: number;
+  sigmaMv: number;
+  deviationsMv: number[];
+  /**
+   * Each cell's deviation as a fraction of the spread. This is the direct test
+   * for the artifact described above: a pack sliding down the curve keeps these
+   * constant while the spread collapses, whereas balancing moves the outlier's
+   * share toward zero.
+   */
+  normalisedDeviations: number[];
+}
+
+export interface CycleRecord {
+  endedAt: string;
+  /** Spread at the fixed mean-voltage crossing during the preceding charge. */
+  crossingSpreadMv?: number;
+  crossingSigmaMv?: number;
+  crossingCurrentA?: number;
+  crossingTempC?: number;
+  crossingNormalisedDeviations?: number[];
+  /** Spread after an hour at rest — no IR contamination at all. */
+  restedSpreadMv?: number;
+  restedSigmaMv?: number;
+  restedTempC?: number;
+  restedNormalisedDeviations?: number[];
+  minutesAboveThreshold: number;
+  minutesAboveHighThreshold: number;
+  minSocPct?: number;
+}
+
+interface DriftPoint {
+  t: number;
+  meanMv: number;
+  currentA?: number;
+  cellCount: number;
+}
+
+interface LatchCandidate {
+  spreadMv: number;
+  sigmaMv: number;
+  meanMv: number;
+  tempC?: number;
+  currentA?: number;
+  normalisedDeviations: number[];
+}
+
+export interface BalancingState {
+  driftPoints: DriftPoint[];
+  restCandidates: LatchCandidate[];
+
+  lastMonotonicAt?: number;
+  lastMeanMv?: number;
+  lastCandidate?: LatchCandidate;
+
+  msAboveThreshold: number;
+  msAboveHighThreshold: number;
+  localDate?: string;
+
+  sessionMs: number;
+  sessionActive: boolean;
+  conditionsUnmetSinceMonotonic?: number;
+
+  crossingArmed: boolean;
+  pendingCrossing?: LatchCandidate;
+  crossing?: LatchCandidate;
+
+  restingSinceMonotonic?: number;
+  restedLatched: boolean;
+  rested?: LatchCandidate;
+
+  minSocPct?: number;
+  cycles: CycleRecord[];
+}
+
+export function initialBalancingState(): BalancingState {
+  return {
+    driftPoints: [],
+    restCandidates: [],
+    msAboveThreshold: 0,
+    msAboveHighThreshold: 0,
+    sessionMs: 0,
+    sessionActive: false,
+    crossingArmed: true,
+    restedLatched: false,
+    cycles: [],
+  };
+}
+
+/**
+ * Reject readings that cannot be a real cell. Empty slots on short packs read
+ * exactly 0, and this project has a long history of devices emitting nonsense
+ * values under load; one of those landing at a latch instant would be recorded
+ * permanently.
+ */
+export function plausibleCells(cellsMv: number[]): number[] {
+  return cellsMv.filter(
+    mv => Number.isFinite(mv) && mv >= CELL_PLAUSIBLE_MIN_MV && mv <= CELL_PLAUSIBLE_MAX_MV,
+  );
+}
+
+export function computeCellStats(rawCellsMv: number[]): CellStats | undefined {
+  const cellsMv = plausibleCells(rawCellsMv);
+  if (cellsMv.length < 2) {
+    return undefined;
+  }
+
+  const count = cellsMv.length;
+  const minMv = Math.min(...cellsMv);
+  const maxMv = Math.max(...cellsMv);
+  const meanMv = cellsMv.reduce((a, b) => a + b, 0) / count;
+  const spreadMv = maxMv - minMv;
+  const variance = cellsMv.reduce((acc, mv) => acc + (mv - meanMv) ** 2, 0) / count;
+  const deviationsMv = cellsMv.map(mv => mv - meanMv);
+
+  return {
+    count,
+    minMv,
+    maxMv,
+    meanMv,
+    spreadMv,
+    sigmaMv: Math.sqrt(variance),
+    deviationsMv,
+    // A dead-flat pack has no meaningful shape to normalise; report zeroes
+    // rather than dividing by zero.
+    normalisedDeviations: deviationsMv.map(d => (spreadMv > 0 ? d / spreadMv : 0)),
+  };
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function leastSquaresSlope(points: DriftPoint[]): { slope: number; residualRms: number } {
+  const n = points.length;
+  const meanT = points.reduce((a, p) => a + p.t, 0) / n;
+  const meanY = points.reduce((a, p) => a + p.meanMv, 0) / n;
+  let sxx = 0;
+  let sxy = 0;
+  for (const p of points) {
+    sxx += (p.t - meanT) ** 2;
+    sxy += (p.t - meanT) * (p.meanMv - meanY);
+  }
+  const slope = sxx === 0 ? 0 : sxy / sxx;
+  const intercept = meanY - slope * meanT;
+  const residualRms = Math.sqrt(
+    points.reduce((a, p) => a + (p.meanMv - (slope * p.t + intercept)) ** 2, 0) / n,
+  );
+  return { slope, residualRms };
+}
+
+/**
+ * Rate of change of the mean cell voltage, in mV/h.
+ *
+ * Negative while the electronics are eating the pack, flat while it is genuinely
+ * being held at the top of charge — which is the whole point. Returns undefined
+ * rather than a contaminated number whenever the window cannot support a slope.
+ */
+export function computeDrift(points: DriftPoint[]): number | undefined {
+  if (points.length < DRIFT_MIN_SAMPLES) {
+    return undefined;
+  }
+
+  // A changing cell count moves the mean by (mean - v_i)/(n-1) on its own — up
+  // to a few mV, which dwarfs the signal. Discard rather than explain it away.
+  if (points.some(p => p.cellCount !== points[0].cellCount)) {
+    return undefined;
+  }
+
+  const span = points[points.length - 1].t - points[0].t;
+  if (span < DRIFT_WINDOW_MS / 2) {
+    return undefined;
+  }
+
+  // Only points that actually carry a current can be gated. Where no family
+  // reports one at all (B2500 V1) this is vacuously true and the slope is
+  // published ungated — still better than nothing there.
+  if (points.some(p => p.currentA != null && Math.abs(p.currentA) > DRIFT_CURRENT_GATE_A)) {
+    return undefined;
+  }
+
+  let fit = leastSquaresSlope(points);
+
+  // A brief load step between two samples is invisible to the current gate but
+  // obvious in the residuals, and it barely moves a fit this size once dropped.
+  if (fit.residualRms > 0) {
+    const meanT = points.reduce((a, p) => a + p.t, 0) / points.length;
+    const meanY = points.reduce((a, p) => a + p.meanMv, 0) / points.length;
+    const intercept = meanY - fit.slope * meanT;
+    const worst = points.reduce(
+      (acc, p) => {
+        const residual = Math.abs(p.meanMv - (fit.slope * p.t + intercept));
+        return residual > acc.residual ? { p, residual } : acc;
+      },
+      { p: points[0], residual: 0 },
+    );
+
+    if (worst.residual > 3 * fit.residualRms && points.length - 1 >= DRIFT_MIN_SAMPLES) {
+      fit = leastSquaresSlope(points.filter(p => p !== worst.p));
+    }
+  }
+
+  // Not moving linearly — usually the post-charge relaxation transient, where a
+  // single slope would be meaningless.
+  if (fit.residualRms > DRIFT_MAX_RESIDUAL_MV) {
+    return undefined;
+  }
+
+  return fit.slope * 3600000;
+}
+
+function toCandidate(stats: CellStats, sample: CellSample): LatchCandidate {
+  return {
+    spreadMv: stats.spreadMv,
+    sigmaMv: stats.sigmaMv,
+    meanMv: stats.meanMv,
+    tempC: sample.tempC,
+    currentA: sample.packCurrentA,
+    normalisedDeviations: stats.normalisedDeviations,
+  };
+}
+
+/**
+ * Interpolate between the two samples bracketing the crossing, so the latched
+ * spread is the one at exactly `CELL_KNEE_CROSSING_MV` rather than at whichever
+ * side of it the poll happened to land on. This is what makes the sampling rate
+ * affect only interpolation error and never which point is measured.
+ */
+function interpolateCandidate(
+  below: LatchCandidate,
+  above: LatchCandidate,
+  targetMv: number,
+): LatchCandidate {
+  const span = above.meanMv - below.meanMv;
+  const f = span === 0 ? 0 : (targetMv - below.meanMv) / span;
+  const lerp = (a: number, b: number) => a + f * (b - a);
+  return {
+    meanMv: targetMv,
+    spreadMv: lerp(below.spreadMv, above.spreadMv),
+    sigmaMv: lerp(below.sigmaMv, above.sigmaMv),
+    tempC: above.tempC ?? below.tempC,
+    currentA: above.currentA ?? below.currentA,
+    // The shape is taken from the sample above the crossing rather than blended:
+    // averaging two normalised vectors of possibly different length is not
+    // meaningful, and the upper sample is the one at the higher voltage.
+    normalisedDeviations: above.normalisedDeviations,
+  };
+}
+
+function medianCandidate(candidates: LatchCandidate[]): LatchCandidate {
+  const last = candidates[candidates.length - 1];
+  return {
+    ...last,
+    spreadMv: median(candidates.map(c => c.spreadMv)),
+    sigmaMv: median(candidates.map(c => c.sigmaMv)),
+    meanMv: median(candidates.map(c => c.meanMv)),
+  };
+}
+
+/**
+ * Fold one sample into the running state, returning the new state and a
+ * completed charge cycle if this sample finished one.
+ *
+ * Pure: all clock values arrive on the sample, so the whole state machine is
+ * testable without faking timers.
+ */
+export function advanceBalancingState(
+  state: BalancingState,
+  sample: CellSample,
+  localDate: string,
+): { state: BalancingState; cycle?: CycleRecord } {
+  const stats = computeCellStats(sample.cellsMv);
+  if (!stats) {
+    return { state };
+  }
+
+  const next: BalancingState = {
+    ...state,
+    driftPoints: [...state.driftPoints],
+    restCandidates: [...state.restCandidates],
+    cycles: state.cycles,
+  };
+
+  // Time only accrues between two samples we actually saw. A longer gap means
+  // the device was unreachable, and we have no idea what it did meanwhile.
+  const rawDelta =
+    state.lastMonotonicAt != null ? sample.monotonicAt - state.lastMonotonicAt : undefined;
+  const observedGap = rawDelta != null && rawDelta >= 0 && rawDelta <= CELL_SAMPLE_MAX_GAP_MS;
+  const deltaMs = observedGap ? (rawDelta as number) : 0;
+
+  if (!observedGap && state.lastMonotonicAt != null) {
+    // Unobserved gap: drop everything whose meaning depends on continuity.
+    next.driftPoints = [];
+    next.restCandidates = [];
+    next.sessionActive = false;
+    next.sessionMs = 0;
+    next.restingSinceMonotonic = undefined;
+    next.pendingCrossing = undefined;
+  }
+
+  if (state.localDate !== localDate) {
+    next.localDate = localDate;
+    next.msAboveThreshold = 0;
+    next.msAboveHighThreshold = 0;
+  }
+
+  const charging = sample.chargingIn === true;
+  const conditionsMet = charging && stats.maxMv >= CELL_BALANCE_THRESHOLD_MV;
+
+  // The interval between two samples is credited according to the state at the
+  // end of it. Either end is defensible; the error is bounded by one poll
+  // interval, which is negligible against sessions measured in hours.
+
+  if (conditionsMet) {
+    next.msAboveThreshold += deltaMs;
+    if (stats.maxMv >= CELL_BALANCE_HIGH_THRESHOLD_MV) {
+      next.msAboveHighThreshold += deltaMs;
+    }
+    next.sessionMs = next.sessionActive ? next.sessionMs + deltaMs : 0;
+    next.sessionActive = true;
+    next.conditionsUnmetSinceMonotonic = undefined;
+  } else if (next.sessionActive) {
+    next.conditionsUnmetSinceMonotonic ??= sample.monotonicAt;
+    if (sample.monotonicAt - next.conditionsUnmetSinceMonotonic >= BALANCE_SESSION_END_GRACE_MS) {
+      next.sessionActive = false;
+      next.conditionsUnmetSinceMonotonic = undefined;
+    }
+  }
+
+  next.driftPoints.push({
+    t: sample.monotonicAt,
+    meanMv: stats.meanMv,
+    currentA: sample.packCurrentA,
+    cellCount: stats.count,
+  });
+  next.driftPoints = next.driftPoints.filter(p => sample.monotonicAt - p.t <= DRIFT_WINDOW_MS);
+
+  if (sample.socPct != null) {
+    next.minSocPct =
+      next.minSocPct == null ? sample.socPct : Math.min(next.minSocPct, sample.socPct);
+  }
+
+  // Crossing latch: interpolate the spread at a fixed mean voltage on the way
+  // up. Confirmed by the following sample so a single spike cannot latch.
+  const previousMean = state.lastMeanMv;
+  const candidate = toCandidate(stats, sample);
+  if (
+    next.crossingArmed &&
+    charging &&
+    previousMean != null &&
+    state.lastCandidate != null &&
+    previousMean < CELL_KNEE_CROSSING_MV &&
+    stats.meanMv >= CELL_KNEE_CROSSING_MV &&
+    observedGap &&
+    sample.staleMs <= CELL_SAMPLE_MAX_GAP_MS
+  ) {
+    next.pendingCrossing = interpolateCandidate(
+      state.lastCandidate,
+      candidate,
+      CELL_KNEE_CROSSING_MV,
+    );
+  } else if (next.pendingCrossing && stats.meanMv >= CELL_KNEE_CROSSING_MV) {
+    next.crossing = next.pendingCrossing;
+    next.pendingCrossing = undefined;
+    next.crossingArmed = false;
+  } else if (next.pendingCrossing) {
+    next.pendingCrossing = undefined;
+  }
+
+  if (stats.meanMv < CELL_KNEE_CROSSING_MV - CELL_KNEE_REARM_HYSTERESIS_MV) {
+    next.crossingArmed = true;
+  }
+
+  // Rested latch: an hour after charging stopped, with the pack actually idle.
+  const resting =
+    !charging &&
+    (sample.packCurrentA == null || Math.abs(sample.packCurrentA) <= REST_CURRENT_MAX_A);
+  if (resting) {
+    next.restingSinceMonotonic ??= sample.monotonicAt;
+    next.restCandidates.push(candidate);
+    if (next.restCandidates.length > LATCH_MEDIAN_SAMPLES) {
+      next.restCandidates.shift();
+    }
+  } else {
+    next.restingSinceMonotonic = undefined;
+    next.restCandidates = [];
+    if (charging) {
+      next.restedLatched = false;
+    }
+  }
+
+  let cycle: CycleRecord | undefined;
+  if (
+    !next.restedLatched &&
+    next.restingSinceMonotonic != null &&
+    sample.monotonicAt - next.restingSinceMonotonic >= REST_LATCH_DELAY_MS &&
+    next.restCandidates.length >= LATCH_MEDIAN_SAMPLES
+  ) {
+    next.rested = medianCandidate(next.restCandidates);
+    next.restedLatched = true;
+
+    cycle = {
+      endedAt: new Date(sample.at).toISOString(),
+      crossingSpreadMv: next.crossing?.spreadMv,
+      crossingSigmaMv: next.crossing?.sigmaMv,
+      crossingCurrentA: next.crossing?.currentA,
+      crossingTempC: next.crossing?.tempC,
+      crossingNormalisedDeviations: next.crossing?.normalisedDeviations,
+      restedSpreadMv: next.rested.spreadMv,
+      restedSigmaMv: next.rested.sigmaMv,
+      restedTempC: next.rested.tempC,
+      restedNormalisedDeviations: next.rested.normalisedDeviations,
+      minutesAboveThreshold: next.msAboveThreshold / 60000,
+      minutesAboveHighThreshold: next.msAboveHighThreshold / 60000,
+      minSocPct: next.minSocPct,
+    };
+
+    next.cycles = [...next.cycles, cycle].slice(-CYCLE_HISTORY_LENGTH);
+    next.minSocPct = undefined;
+  }
+
+  next.lastMonotonicAt = sample.monotonicAt;
+  next.lastMeanMv = stats.meanMv;
+  next.lastCandidate = candidate;
+
+  return { state: next, cycle };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -96,6 +96,13 @@ export const BALANCE_SESSION_END_GRACE_MS = 600000;
 /** How long the pack must have been resting before the rested spread is taken. */
 export const REST_LATCH_DELAY_MS = 3600000;
 
+/**
+ * Pack current above which the pack counts as charging, for families that infer
+ * it from the current rather than a status flag. Above the noise floor of a
+ * reading that is quantised in deci-amps, below any real charge.
+ */
+export const CHARGE_DETECT_MIN_A = 0.2;
+
 /** Pack current below which the pack counts as resting. */
 export const REST_CURRENT_MAX_A = 0.5;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,85 @@ export const MIN_PHASE_ENERGY_POLL_INTERVAL_MS = 300000;
  * finish well inside it for the clean shutdown to be worth anything.
  */
 export const SHUTDOWN_STEP_TIMEOUT_MS = 3000;
+
+/**
+ * Cell voltage above which a passive balancer is assumed to be able to do
+ * something. Typical LFP balance-start thresholds sit at 3.40-3.45 V, well up
+ * the steep part of the curve; these packs charge to roughly 3.55 V/cell.
+ */
+export const CELL_BALANCE_THRESHOLD_MV = 3400;
+
+/**
+ * Second, higher threshold. At 3.40 V the OCV-SoC slope is only ~10 mV per
+ * percent, so an hour of bleed moves a cell barely half a millivolt; at 3.50 V
+ * the same charge moves it several times further. Time spent above the two
+ * thresholds is reported separately because an hour at each is not equivalent.
+ */
+export const CELL_BALANCE_HIGH_THRESHOLD_MV = 3500;
+
+/**
+ * Mean cell voltage at which the comparable end-of-charge spread is sampled.
+ * Latching at a fixed voltage rather than at charge termination gives an
+ * iso-SoC point on the steep part of the curve: it does not move with when
+ * charging happens to stop, nor with the poll phase.
+ */
+export const CELL_KNEE_CROSSING_MV = 3450;
+
+/** Re-arm the crossing latch once the pack has fallen this far back below it. */
+export const CELL_KNEE_REARM_HYSTERESIS_MV = 50;
+
+/** Readings outside this range are rejected before entering any statistic. */
+export const CELL_PLAUSIBLE_MIN_MV = 2000;
+export const CELL_PLAUSIBLE_MAX_MV = 4000;
+
+/**
+ * Window for the mean-cell-voltage drift regression. Widening the window beats
+ * shortening the poll interval: at 60 s sampling the slope error is ~0.26 mV/h
+ * over 15 minutes but ~0.09 mV/h over 30, which matches 5 s sampling over 15
+ * minutes at a twelfth of the traffic.
+ */
+export const DRIFT_WINDOW_MS = 1800000;
+
+/** Minimum samples before a slope is reported at all. */
+export const DRIFT_MIN_SAMPLES = 5;
+
+/**
+ * Drift is suppressed when the pack current moved beyond this. A step from
+ * 0.4 A to 6 A shifts every cell about 3 mV by IR alone — around 12 mV/h of
+ * slope, several times the real signal. In the situation this feature is for
+ * (full, MPPT disconnected, no export) the pack is at rest, so the gate is
+ * satisfied exactly when it matters.
+ */
+export const DRIFT_CURRENT_GATE_A = 1;
+
+/**
+ * Largest RMS residual a drift window may have. Above this the mean is not
+ * moving linearly — typically the post-charge relaxation transient — and a
+ * single slope would misrepresent it.
+ */
+export const DRIFT_MAX_RESIDUAL_MV = 1.5;
+
+/** Below this magnitude a drift reading is indistinguishable from zero. */
+export const DRIFT_NOISE_FLOOR_MV_PER_H = 2;
+
+/**
+ * A gap longer than this between two cell samples is treated as an observation
+ * gap rather than elapsed time. Without it a device that drops off the network
+ * mid-session comes back and books the entire outage as balancing.
+ */
+export const CELL_SAMPLE_MAX_GAP_MS = 240000;
+
+/** Conditions must stay unmet this long before a balancing session is closed. */
+export const BALANCE_SESSION_END_GRACE_MS = 600000;
+
+/** How long the pack must have been resting before the rested spread is taken. */
+export const REST_LATCH_DELAY_MS = 3600000;
+
+/** Pack current below which the pack counts as resting. */
+export const REST_CURRENT_MAX_A = 0.5;
+
+/** Samples used for the median at a latch, so one bad reading cannot be recorded. */
+export const LATCH_MEDIAN_SAMPLES = 5;
+
+/** Charge cycles kept in the persisted history. */
+export const CYCLE_HISTORY_LENGTH = 20;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,9 +83,6 @@ export const DRIFT_CURRENT_GATE_A = 1;
  */
 export const DRIFT_MAX_RESIDUAL_MV = 1.5;
 
-/** Below this magnitude a drift reading is indistinguishable from zero. */
-export const DRIFT_NOISE_FLOOR_MV_PER_H = 2;
-
 /**
  * A gap longer than this between two cell samples is treated as an observation
  * gap rather than elapsed time. Without it a device that drops off the network

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -107,3 +107,13 @@ export const LATCH_MEDIAN_SAMPLES = 5;
 
 /** Charge cycles kept in the persisted history. */
 export const CYCLE_HISTORY_LENGTH = 20;
+
+/**
+ * Least often the running counters are written to disk. Completed charge cycles
+ * bypass this and are written straight away; the counters change on every poll,
+ * and most add-on installs run from an SD card.
+ */
+export const PERSIST_THROTTLE_MS = 900000;
+
+/** Bumped whenever the stored record's shape changes incompatibly. */
+export const PERSIST_SCHEMA_VERSION = 1;

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -4,6 +4,8 @@ import {
   BuildMessageFn,
 } from '../deviceDefinition.js';
 import logger from '../logger.js';
+import { extractB2500Sample } from '../cellBalancing.js';
+import { registerCellBalancingMessage } from './cellBalancingMessage.js';
 import {
   B2500BaseDeviceData,
   B2500CalibrationData,
@@ -766,6 +768,17 @@ function isB2500CellDataMessage(values: Record<string, string>) {
   return Array.from({ length: CELL_DETECT_COUNT }, (_, i) => `a${i.toString(16)}`).every(
     key => key in values,
   );
+}
+
+/**
+ * Cell balancing diagnostics for B2500. Registered next to the cell data
+ * message it consumes; it produces no traffic of its own.
+ */
+export function registerB2500CellBalancingMessage(message: BuildMessageFn) {
+  registerCellBalancingMessage(message, {
+    cellPath: 'cells',
+    extract: extractB2500Sample,
+  });
 }
 
 export function registerCellDataMessage(message: BuildMessageFn) {

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -773,12 +773,49 @@ function isB2500CellDataMessage(values: Record<string, string>) {
 /**
  * Cell balancing diagnostics for B2500. Registered next to the cell data
  * message it consumes; it produces no traffic of its own.
+ *
+ * `hasPackCurrent` is false on V1, which has no message carrying a pack
+ * current at all.
  */
-export function registerB2500CellBalancingMessage(message: BuildMessageFn) {
+export function registerB2500CellBalancingMessage(
+  message: BuildMessageFn,
+  { hasPackCurrent }: { hasPackCurrent: boolean },
+) {
   registerCellBalancingMessage(message, {
     cellPath: 'cells',
     extract: extractB2500Sample,
+    warnIfIncomplete: () => warnAboutB2500PackCurrent(hasPackCurrent),
   });
+}
+
+let warnedAboutPackCurrent = false;
+
+/**
+ * The rested spread is measured an hour after charging stops, and "stopped"
+ * has to be confirmed by a current near zero — otherwise the pack could be
+ * quietly discharging into the house. B2500 only reports one in the cd=16
+ * payload, so without that poll the rested spread never latches and no charge
+ * cycle is ever recorded. Everything else still works, which is exactly why
+ * this is worth saying out loud.
+ */
+function warnAboutB2500PackCurrent(hasPackCurrent: boolean) {
+  if (warnedAboutPackCurrent) {
+    return;
+  }
+  if (hasPackCurrent && process.env.POLL_EXTRA_BATTERY_DATA === 'true') {
+    return;
+  }
+  warnedAboutPackCurrent = true;
+  logger.warn(
+    hasPackCurrent
+      ? 'Cell balancing diagnostics on B2500 also need POLL_EXTRA_BATTERY_DATA=true ' +
+          '(add-on: "Enable Extra Battery Data") for the pack current. Without it the ' +
+          'rested cell spread never latches and no charge cycle is recorded; the live ' +
+          'metrics are unaffected.'
+      : 'B2500 V1 does not report a pack current, so the cell balancing diagnostics ' +
+          'cannot latch a rested cell spread or record charge cycles on it. The live ' +
+          'metrics work as normal.',
+  );
 }
 
 export function registerCellDataMessage(message: BuildMessageFn) {

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -110,6 +110,33 @@ export function registerBaseMessage({
       state_class: 'measurement',
     }),
   );
+  // Per-pack status bitmasks (firmware >= 212.17; absent on older firmware, in
+  // which case these fields simply stay unset).
+  //
+  // `l0` carries the host pack, `l1` both extras packed into one byte: bits 0-3
+  // are extra2 and bits 4-7 extra1, each using the same layout as `l0`.
+  // See docs/b2500.md.
+  const packStatusFlags = [
+    { flag: 'discharging', bit: 0 },
+    { flag: 'charging', bit: 1 },
+    { flag: 'dodReached', bit: 2 },
+    { flag: 'undervoltage', bit: 3 },
+  ] as const;
+  const packStatusSources = [
+    { key: 'l0', battery: 'host', bitOffset: 0 },
+    { key: 'l1', battery: 'extra2', bitOffset: 0 },
+    { key: 'l1', battery: 'extra1', bitOffset: 4 },
+  ] as const;
+  for (const { key, battery, bitOffset } of packStatusSources) {
+    for (const { flag, bit } of packStatusFlags) {
+      field({
+        key,
+        path: ['packStatus', battery, flag],
+        transform: bitBoolean(bitOffset + bit),
+      });
+    }
+  }
+
   field({
     key: 'do',
     path: ['dischargeDepth'],

--- a/src/device/b2500Base.ts
+++ b/src/device/b2500Base.ts
@@ -784,11 +784,10 @@ export function registerB2500CellBalancingMessage(
   registerCellBalancingMessage(message, {
     cellPath: 'cells',
     extract: extractB2500Sample,
-    warnIfIncomplete: () => warnAboutB2500PackCurrent(hasPackCurrent),
+    warnIfIncomplete: (deviceType, deviceId) =>
+      warnAboutB2500PackCurrent(hasPackCurrent, `${deviceType} ${deviceId}`),
   });
 }
-
-let warnedAboutPackCurrent = false;
 
 /**
  * The rested spread is measured an hour after charging stops, and "stopped"
@@ -798,21 +797,17 @@ let warnedAboutPackCurrent = false;
  * cycle is ever recorded. Everything else still works, which is exactly why
  * this is worth saying out loud.
  */
-function warnAboutB2500PackCurrent(hasPackCurrent: boolean) {
-  if (warnedAboutPackCurrent) {
-    return;
-  }
+function warnAboutB2500PackCurrent(hasPackCurrent: boolean, device: string) {
   if (hasPackCurrent && process.env.POLL_EXTRA_BATTERY_DATA === 'true') {
     return;
   }
-  warnedAboutPackCurrent = true;
   logger.warn(
     hasPackCurrent
-      ? 'Cell balancing diagnostics on B2500 also need POLL_EXTRA_BATTERY_DATA=true ' +
+      ? `Cell balancing diagnostics on ${device} also need POLL_EXTRA_BATTERY_DATA=true ` +
           '(add-on: "Enable Extra Battery Data") for the pack current. Without it the ' +
           'rested cell spread never latches and no charge cycle is recorded; the live ' +
           'metrics are unaffected.'
-      : 'B2500 V1 does not report a pack current, so the cell balancing diagnostics ' +
+      : `${device} does not report a pack current, so the cell balancing diagnostics ` +
           'cannot latch a rested cell spread or record charge cycles on it. The live ' +
           'metrics work as normal.',
   );

--- a/src/device/b2500V1.ts
+++ b/src/device/b2500V1.ts
@@ -12,6 +12,7 @@ import {
   registerBaseMessage,
   registerCalibrationDataMessage,
   registerCellDataMessage,
+  registerB2500CellBalancingMessage,
 } from './b2500Base.js';
 import logger from '../logger.js';
 import {
@@ -30,6 +31,7 @@ registerDeviceDefinition(
     registerRuntimeInfoMessage(message);
     registerExtraBatteryData(message);
     registerCellDataMessage(message);
+    registerB2500CellBalancingMessage(message);
     registerCalibrationDataMessage(message);
   },
 );

--- a/src/device/b2500V1.ts
+++ b/src/device/b2500V1.ts
@@ -31,7 +31,7 @@ registerDeviceDefinition(
     registerRuntimeInfoMessage(message);
     registerExtraBatteryData(message);
     registerCellDataMessage(message);
-    registerB2500CellBalancingMessage(message);
+    registerB2500CellBalancingMessage(message, { hasPackCurrent: false });
     registerCalibrationDataMessage(message);
   },
 );

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -20,6 +20,7 @@ import {
   registerBaseMessage,
   registerCalibrationDataMessage,
   registerCellDataMessage,
+  registerB2500CellBalancingMessage,
 } from './b2500Base.js';
 import {
   BuildMessageFn,
@@ -185,6 +186,7 @@ registerDeviceDefinition(
     registerRuntimeInfoMessage(message);
     registerExtraBatteryData(message);
     registerCellDataMessage(message);
+    registerB2500CellBalancingMessage(message);
     registerCalibrationDataMessage(message);
   },
 );

--- a/src/device/b2500V2.ts
+++ b/src/device/b2500V2.ts
@@ -186,7 +186,7 @@ registerDeviceDefinition(
     registerRuntimeInfoMessage(message);
     registerExtraBatteryData(message);
     registerCellDataMessage(message);
-    registerB2500CellBalancingMessage(message);
+    registerB2500CellBalancingMessage(message, { hasPackCurrent: true });
     registerCalibrationDataMessage(message);
   },
 );

--- a/src/device/cellBalancingMessage.test.ts
+++ b/src/device/cellBalancingMessage.test.ts
@@ -1,0 +1,242 @@
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * The diagnostics are gated by an environment variable read while the device
+ * modules are imported, so every test here has to load the registry itself with
+ * the flag already set.
+ */
+async function loadWithDiagnostics() {
+  jest.resetModules();
+  process.env.CELL_BALANCING_DIAGNOSTICS = 'true';
+  process.env.POLL_CELL_DATA = 'true';
+
+  await import('./registry.js');
+  return {
+    generateDiscoveryConfigs: (await import('../generateDiscoveryConfigs.js'))
+      .generateDiscoveryConfigs,
+    DeviceManager: (await import('../deviceManager.js')).DeviceManager,
+    parseMessage: (await import('../parser.js')).parseMessage,
+    persistence: await import('../persistence.js'),
+    cellBalancingMessage: await import('./cellBalancingMessage.js'),
+  };
+}
+
+const topics = {
+  deviceTopicOld: 'hame_energy/VNSD-0/device/venus1/ctrl',
+  deviceTopicNew: 'marstek_energy/VNSD-0/device/venus1/ctrl',
+  publishTopic: 'hm2mqtt/VNSD-0/device/venus1',
+  deviceControlTopicOld: 'hame_energy/VNSD-0/App/venus1/ctrl',
+  deviceControlTopicNew: 'marstek_energy/VNSD-0/App/venus1/ctrl',
+  controlSubscriptionTopic: 'hm2mqtt/VNSD-0/control/venus1',
+  availabilityTopic: 'hm2mqtt/VNSD-0/availability/venus1',
+};
+
+const device = { deviceType: 'VNSD-0', deviceId: 'venus1' };
+
+function bmsPayload(cells: number[], current: number): string {
+  const voltages = cells.map((mv, i) => `b_vo${i + 1}=${mv}`).join(',');
+  return (
+    `b_ver=212,b_chv=571,b_soc=99,b_soh=100,b_cap=5120,b_vol=5223,b_cur=${current},` +
+    `b_tem=250,b_tp1=18,b_tp2=19,b_tp3=18,b_tp4=19,${voltages}`
+  );
+}
+
+describe('cell balancing discovery', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('advertises the live entities but withholds the cross-cycle ones without storage', async () => {
+    const { generateDiscoveryConfigs, persistence } = await loadWithDiagnostics();
+    persistence.resetPersistenceProbe({ available: false, reason: 'test' });
+
+    const configs = generateDiscoveryConfigs(device, topics as any, {}, 'hm2mqtt', 'homeassistant');
+    const published = configs.filter(c => c.config != null).map(c => c.topic);
+    const removed = configs.filter(c => c.config == null).map(c => c.topic);
+
+    expect(published.some(t => t.includes('cell_spread/'))).toBe(true);
+    expect(published.some(t => t.includes('cell_mean_voltage_drift'))).toBe(true);
+    expect(published.some(t => t.includes('balance_conditions_met'))).toBe(true);
+
+    // Comparing spreads across days is meaningless if the history cannot
+    // survive a restart, so those entities are removed rather than left stale.
+    expect(removed.some(t => t.includes('cell_spread_at_crossing'))).toBe(true);
+    expect(removed.some(t => t.includes('rested_cell_spread'))).toBe(true);
+  });
+
+  it('advertises the cross-cycle entities once storage is available', async () => {
+    const { generateDiscoveryConfigs, persistence } = await loadWithDiagnostics();
+    persistence.resetPersistenceProbe({
+      available: true,
+      dir: fs.mkdtempSync(path.join(os.tmpdir(), 'hm2mqtt-disc-')),
+    });
+
+    const configs = generateDiscoveryConfigs(device, topics as any, {}, 'hm2mqtt', 'homeassistant');
+    const published = configs.filter(c => c.config != null).map(c => c.topic);
+
+    expect(published.some(t => t.includes('cell_spread_at_crossing'))).toBe(true);
+    expect(published.some(t => t.includes('rested_cell_spread'))).toBe(true);
+  });
+
+  it('removes every diagnostic entity when the feature is off', async () => {
+    jest.resetModules();
+    delete process.env.CELL_BALANCING_DIAGNOSTICS;
+    process.env.POLL_CELL_DATA = 'true';
+    await import('./registry.js');
+    const { generateDiscoveryConfigs } = await import('../generateDiscoveryConfigs.js');
+
+    const configs = generateDiscoveryConfigs(device, topics as any, {}, 'hm2mqtt', 'homeassistant');
+    const published = configs.filter(c => c.config != null).map(c => c.topic);
+
+    expect(published.some(t => t.includes('cell_spread/'))).toBe(false);
+    expect(published.some(t => t.includes('balance_conditions_met'))).toBe(false);
+  });
+});
+
+describe('cell balancing end to end', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('publishes derived state once per cell reading, and not per message', async () => {
+    const { DeviceManager, parseMessage, persistence, cellBalancingMessage } =
+      await loadWithDiagnostics();
+    persistence.resetPersistenceProbe({ available: false, reason: 'test' });
+    cellBalancingMessage.resetCellBalancingState();
+
+    const onUpdate = jest.fn();
+    const dm = new DeviceManager(
+      {
+        brokerUrl: 'mqtt://localhost',
+        clientId: 'test',
+        topicPrefix: 'hm2mqtt',
+        autodiscoveryTopicPrefix: 'homeassistant',
+        devices: [device],
+      },
+      onUpdate as any,
+    );
+
+    const applyBms = (cells: number[], current: number) => {
+      const parsed = parseMessage(bmsPayload(cells, current), device.deviceType, device.deviceId);
+      for (const [publishPath, state] of Object.entries(parsed)) {
+        dm.updateDeviceState(device, publishPath, () => state as any);
+      }
+    };
+
+    applyBms([3300, 3302, 3301, 3300], 50);
+
+    const derivedCalls = onUpdate.mock.calls.filter((c: any[]) => c[1] === 'cellBalancing');
+    expect(derivedCalls).toHaveLength(1);
+    const state = derivedCalls[0][2] as any;
+    expect(state.cellBalancing.spreadMv).toBe(2);
+    expect(state.cellBalancing.meanMv).toBeCloseTo(3300.75, 6);
+    // b_cur=50 read as deci-amps is 5 A in, so it is charging — but 3302 mV is
+    // nowhere near the balance threshold.
+    expect(state.cellBalancing.balanceConditionsMet).toBe(false);
+
+    // A second, unrelated message must not republish the derived state.
+    onUpdate.mockClear();
+    dm.updateDeviceState(device, 'data', () => ({ batterySoc: 99 }) as any);
+    expect(onUpdate.mock.calls.filter((c: any[]) => c[1] === 'cellBalancing')).toHaveLength(0);
+  });
+
+  it('reports the conditions met near the top of charge', async () => {
+    const { DeviceManager, parseMessage, persistence, cellBalancingMessage } =
+      await loadWithDiagnostics();
+    persistence.resetPersistenceProbe({ available: false, reason: 'test' });
+    cellBalancingMessage.resetCellBalancingState();
+
+    const onUpdate = jest.fn();
+    const dm = new DeviceManager(
+      {
+        brokerUrl: 'mqtt://localhost',
+        clientId: 'test',
+        topicPrefix: 'hm2mqtt',
+        autodiscoveryTopicPrefix: 'homeassistant',
+        devices: [device],
+      },
+      onUpdate as any,
+    );
+
+    const parsed = parseMessage(
+      bmsPayload([3520, 3560, 3540, 3530], 20),
+      device.deviceType,
+      device.deviceId,
+    );
+    for (const [publishPath, state] of Object.entries(parsed)) {
+      dm.updateDeviceState(device, publishPath, () => state as any);
+    }
+
+    const derived = onUpdate.mock.calls.filter((c: any[]) => c[1] === 'cellBalancing');
+    const state = derived[derived.length - 1][2] as any;
+    expect(state.cellBalancing.balanceConditionsMet).toBe(true);
+    expect(state.cellBalancing.spreadMv).toBe(40);
+    // Normalised: the 3560 cell owns most of the spread.
+    const shares = state.cellBalancing.normalisedDeviations as number[];
+    expect(Math.max(...shares)).toBeCloseTo((3560 - 3537.5) / 40, 6);
+  });
+
+  it('restores the cycle history from disk on restart', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hm2mqtt-e2e-'));
+    const { DeviceManager, parseMessage, persistence, cellBalancingMessage } =
+      await loadWithDiagnostics();
+    persistence.resetPersistenceProbe({ available: true, dir });
+    cellBalancingMessage.resetCellBalancingState();
+
+    persistence.saveRecord(
+      device.deviceType,
+      device.deviceId,
+      {
+        schemaVersion: 1,
+        cycles: [
+          {
+            endedAt: '2026-08-05T20:00:00.000Z',
+            minutesAboveThreshold: 120,
+            minutesAboveHighThreshold: 30,
+            restedSpreadMv: 7,
+          },
+        ],
+        msAboveThreshold: 7_200_000,
+        msAboveHighThreshold: 1_800_000,
+        localDate: new Date().toLocaleDateString('en-CA'),
+        savedAt: '2026-08-05T20:00:00.000Z',
+      },
+      { immediate: true },
+    );
+
+    const onUpdate = jest.fn();
+    const dm = new DeviceManager(
+      {
+        brokerUrl: 'mqtt://localhost',
+        clientId: 'test',
+        topicPrefix: 'hm2mqtt',
+        autodiscoveryTopicPrefix: 'homeassistant',
+        devices: [device],
+      },
+      onUpdate as any,
+    );
+
+    const parsed = parseMessage(
+      bmsPayload([3300, 3302, 3301, 3300], 0),
+      device.deviceType,
+      device.deviceId,
+    );
+    for (const [publishPath, state] of Object.entries(parsed)) {
+      dm.updateDeviceState(device, publishPath, () => state as any);
+    }
+
+    const derived = onUpdate.mock.calls.filter((c: any[]) => c[1] === 'cellBalancing');
+    const state = derived[derived.length - 1][2] as any;
+    expect(state.cellBalancing.cycleCount).toBe(1);
+    expect(state.cellBalancing.lastCycleEndedAt).toBe('2026-08-05T20:00:00.000Z');
+    // Counters carry over; the same-day record is still today's.
+    expect(state.cellBalancing.minutesAboveThreshold).toBe(120);
+  });
+});

--- a/src/device/cellBalancingMessage.test.ts
+++ b/src/device/cellBalancingMessage.test.ts
@@ -8,13 +8,30 @@ import path from 'path';
  * modules are imported, so every test here has to load the registry itself with
  * the flag already set.
  */
-async function loadWithDiagnostics() {
+async function loadWithDiagnostics(env: NodeJS.ProcessEnv = {}) {
   jest.resetModules();
   process.env.CELL_BALANCING_DIAGNOSTICS = 'true';
   process.env.POLL_CELL_DATA = 'true';
+  for (const [key, value] of Object.entries(env)) {
+    if (value === '') {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  // Captured from before the registry is imported: that import registers every
+  // device type there is, owned or not, so anything warned at that point has to
+  // be visible to a test that cares whether it was warned at all.
+  const logger = (await import('../logger.js')).default;
+  const warnings: string[] = [];
+  jest.spyOn(logger, 'warn').mockImplementation((...args: unknown[]) => {
+    warnings.push(String(args[0]));
+  });
 
   await import('./registry.js');
   return {
+    warnings,
     generateDiscoveryConfigs: (await import('../generateDiscoveryConfigs.js'))
       .generateDiscoveryConfigs,
     DeviceManager: (await import('../deviceManager.js')).DeviceManager,
@@ -195,6 +212,80 @@ describe('cell balancing end to end', () => {
     // Normalised: the 3560 cell owns most of the spread.
     const shares = state.cellBalancing.normalisedDeviations as number[];
     expect(Math.max(...shares)).toBeCloseTo((3560 - 3537.5) / 40, 6);
+  });
+
+  it('warns about a missing input only for a device that actually reported', async () => {
+    // Every device type is registered on every start, so a warning emitted at
+    // registration would tell this Venus owner what to configure on a B2500
+    // they do not own — and, with one shared warn-once flag, would also
+    // suppress the warning for someone who does.
+    const { DeviceManager, parseMessage, persistence, cellBalancingMessage, warnings } =
+      await loadWithDiagnostics({ POLL_EXTRA_BATTERY_DATA: '' });
+    persistence.resetPersistenceProbe({ available: false, reason: 'test' });
+    cellBalancingMessage.resetCellBalancingState();
+
+    const dm = new DeviceManager(
+      {
+        brokerUrl: 'mqtt://localhost',
+        clientId: 'test',
+        topicPrefix: 'hm2mqtt',
+        autodiscoveryTopicPrefix: 'homeassistant',
+        devices: [device],
+      },
+      jest.fn() as any,
+    );
+
+    const parsed = parseMessage(
+      bmsPayload([3300, 3302, 3301, 3300], 0),
+      device.deviceType,
+      device.deviceId,
+    );
+    for (const [publishPath, state] of Object.entries(parsed)) {
+      dm.updateDeviceState(device, publishPath, () => state as any);
+    }
+
+    expect(warnings.some(m => m.includes('POLL_EXTRA_BATTERY_DATA'))).toBe(false);
+    expect(warnings.some(m => m.includes('pack current'))).toBe(false);
+  });
+
+  it('does warn the B2500 owner whose pack current is not being polled', async () => {
+    const { DeviceManager, parseMessage, persistence, cellBalancingMessage, warnings } =
+      await loadWithDiagnostics({ POLL_EXTRA_BATTERY_DATA: '' });
+    persistence.resetPersistenceProbe({ available: false, reason: 'test' });
+    cellBalancingMessage.resetCellBalancingState();
+
+    const b2500 = { deviceType: 'HMA-1', deviceId: 'b2500a' };
+    const cells = (prefix: string, mv: number) =>
+      Array.from({ length: 16 }, (_, i) => `${prefix}${i.toString(16)}=${mv + i}`).join(',');
+
+    const dm = new DeviceManager(
+      {
+        brokerUrl: 'mqtt://localhost',
+        clientId: 'test',
+        topicPrefix: 'hm2mqtt',
+        autodiscoveryTopicPrefix: 'homeassistant',
+        devices: [b2500],
+      },
+      jest.fn() as any,
+    );
+
+    const apply = (mv: number) => {
+      const parsed = parseMessage(
+        [cells('a', mv), cells('b', 0), cells('c', 0)].join(','),
+        b2500.deviceType,
+        b2500.deviceId,
+      );
+      for (const [publishPath, state] of Object.entries(parsed)) {
+        dm.updateDeviceState(b2500, publishPath, () => state as any);
+      }
+    };
+    apply(3300);
+    // A second reading must not repeat it.
+    apply(3310);
+
+    const matching = warnings.filter(m => m.includes('POLL_EXTRA_BATTERY_DATA'));
+    expect(matching).toHaveLength(1);
+    expect(matching[0]).toContain('HMA-1 b2500a');
   });
 
   it('gives every optional key a default so discovery cannot outrun the payload', async () => {

--- a/src/device/cellBalancingMessage.test.ts
+++ b/src/device/cellBalancingMessage.test.ts
@@ -197,6 +197,68 @@ describe('cell balancing end to end', () => {
     expect(Math.max(...shares)).toBeCloseTo((3560 - 3537.5) / 40, 6);
   });
 
+  it('gives every optional key a default so discovery cannot outrun the payload', async () => {
+    const { DeviceManager, parseMessage, persistence, cellBalancingMessage } =
+      await loadWithDiagnostics();
+    const { generateDiscoveryConfigs } = await import('../generateDiscoveryConfigs.js');
+    persistence.resetPersistenceProbe({ available: true, dir: tempDir() });
+    cellBalancingMessage.resetCellBalancingState();
+
+    const onUpdate = jest.fn();
+    const dm = new DeviceManager(
+      {
+        brokerUrl: 'mqtt://localhost',
+        clientId: 'test',
+        topicPrefix: 'hm2mqtt',
+        autodiscoveryTopicPrefix: 'homeassistant',
+        devices: [device],
+      },
+      onUpdate as any,
+    );
+
+    const parsed = parseMessage(
+      bmsPayload([3300, 3302, 3301, 3300], 0),
+      device.deviceType,
+      device.deviceId,
+    );
+    for (const [publishPath, state] of Object.entries(parsed)) {
+      dm.updateDeviceState(device, publishPath, () => state as any);
+    }
+    const derived = onUpdate.mock.calls.filter((c: any[]) => c[1] === 'cellBalancing');
+    // Round-trip through JSON: what reaches the broker is not the object the
+    // derivation returned, because stringify silently drops undefined keys.
+    const payload = JSON.parse(
+      JSON.stringify((derived[derived.length - 1][2] as any).cellBalancing),
+    );
+
+    // The values that need a full quiet window or a completed charge before
+    // they exist. If one of these ever becomes unconditional the assertion
+    // below still holds, but this list is the reason it is worth having.
+    for (const key of [
+      'driftMvPerHour',
+      'crossingSpreadMv',
+      'crossingSigmaMv',
+      'restedSpreadMv',
+      'restedSigmaMv',
+      'lastCycleEndedAt',
+    ]) {
+      expect(payload).not.toHaveProperty(key);
+    }
+
+    const configs = generateDiscoveryConfigs(device, topics as any, {}, 'hm2mqtt', 'homeassistant');
+    const advertised = configs
+      .map(entry => (entry.config as any)?.value_template)
+      .filter((template): template is string => typeof template === 'string')
+      .map(template => ({ template, key: /value_json\.cellBalancing\.(\w+)/.exec(template)?.[1] }))
+      .filter((entry): entry is { template: string; key: string } => entry.key != null);
+
+    expect(advertised.length).toBeGreaterThan(10);
+    const missingDefault = advertised
+      .filter(({ key, template }) => !(key in payload) && !template.includes('| default('))
+      .map(({ key }) => key);
+    expect(missingDefault).toEqual([]);
+  });
+
   it('restores the cycle history from disk on restart', async () => {
     const dir = tempDir();
     const { DeviceManager, parseMessage, persistence, cellBalancingMessage } =

--- a/src/device/cellBalancingMessage.test.ts
+++ b/src/device/cellBalancingMessage.test.ts
@@ -36,6 +36,20 @@ const topics = {
 
 const device = { deviceType: 'VNSD-0', deviceId: 'venus1' };
 
+const createdDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hm2mqtt-disc-'));
+  createdDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function bmsPayload(cells: number[], current: number): string {
   const voltages = cells.map((mv, i) => `b_vo${i + 1}=${mv}`).join(',');
   return (
@@ -73,7 +87,7 @@ describe('cell balancing discovery', () => {
     const { generateDiscoveryConfigs, persistence } = await loadWithDiagnostics();
     persistence.resetPersistenceProbe({
       available: true,
-      dir: fs.mkdtempSync(path.join(os.tmpdir(), 'hm2mqtt-disc-')),
+      dir: tempDir(),
     });
 
     const configs = generateDiscoveryConfigs(device, topics as any, {}, 'hm2mqtt', 'homeassistant');
@@ -184,7 +198,7 @@ describe('cell balancing end to end', () => {
   });
 
   it('restores the cycle history from disk on restart', async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hm2mqtt-e2e-'));
+    const dir = tempDir();
     const { DeviceManager, parseMessage, persistence, cellBalancingMessage } =
       await loadWithDiagnostics();
     persistence.resetPersistenceProbe({ available: true, dir });

--- a/src/device/cellBalancingMessage.ts
+++ b/src/device/cellBalancingMessage.ts
@@ -137,7 +137,6 @@ export function registerCellBalancingMessage(
         if (timestamp == null || lastCellTimestamps.get(key) === timestamp) {
           return undefined;
         }
-        lastCellTimestamps.set(key, timestamp);
 
         const sample = source.extract(stateByPath, { at, monotonicAt });
         if (sample == null) {
@@ -147,6 +146,10 @@ export function registerCellBalancingMessage(
         if (stats == null) {
           return undefined;
         }
+        // Only now, once the reading turned out to be usable. Marking it
+        // consumed any earlier would discard a sample whose other inputs are
+        // still on their way, rather than reconsidering it on the next update.
+        lastCellTimestamps.set(key, timestamp);
 
         const previousState = stateFor(key, deviceType, deviceId);
         const { state, cycle, conditionsMet } = advanceBalancingState(

--- a/src/device/cellBalancingMessage.ts
+++ b/src/device/cellBalancingMessage.ts
@@ -1,4 +1,5 @@
 import { BuildMessageFn } from '../deviceDefinition.js';
+import logger from '../logger.js';
 import { binarySensorComponent, sensorComponent } from '../homeAssistantDiscovery.js';
 import { CellBalancingData } from '../types.js';
 import {
@@ -37,6 +38,27 @@ export interface CellBalancingSource {
 
 const states = new Map<string, BalancingState>();
 const lastCellTimestamps = new Map<string, string>();
+
+let warnedAboutCellData = false;
+
+/**
+ * The diagnostics need their own flag *and* the cell data they are computed
+ * from. Asking for one without the other is a configuration mistake that would
+ * otherwise present as entities that never leave unknown, so say so once.
+ */
+function cellBalancingEnabled(): boolean {
+  const requested = process.env.CELL_BALANCING_DIAGNOSTICS === 'true';
+  const haveCellData = process.env.POLL_CELL_DATA === 'true';
+  if (requested && !haveCellData && !warnedAboutCellData) {
+    warnedAboutCellData = true;
+    logger.warn(
+      'Cell balancing diagnostics are enabled but cell data polling is not. ' +
+        'Set POLL_CELL_DATA=true (add-on: "Enable Cell Data") — without it there ' +
+        'are no cell readings to analyse, so no diagnostic entities are created.',
+    );
+  }
+  return requested && haveCellData;
+}
 
 /** Test seam; production never needs to forget a device. */
 export function resetCellBalancingState(): void {
@@ -102,7 +124,10 @@ export function registerCellBalancingMessage(
       pollInterval: 60000,
       controlsDeviceAvailability: false,
       polled: false,
-      enabled: process.env.CELL_BALANCING_DIAGNOSTICS === 'true',
+      // Both flags are required. The diagnostics are computed from the cell
+      // message, so with POLL_CELL_DATA off nothing is ever polled to feed them
+      // and every entity would sit at unknown forever.
+      enabled: cellBalancingEnabled(),
       derive: ({ stateByPath, deviceType, deviceId, at, monotonicAt }) => {
         const key = `${deviceType}:${deviceId}`;
 
@@ -154,7 +179,9 @@ export function registerCellBalancingMessage(
         // The full vector goes in the payload, but a graph needs a scalar: the
         // share owned by the highest cell is the one a passive balancer acts on.
         const highestShare = Math.max(...stats.normalisedDeviations);
-        const highestIndex = stats.normalisedDeviations.indexOf(highestShare);
+        // Map back through `indices`: a dropped reading mid-pack shifts every
+        // later position, so the array offset is not the cell number.
+        const highestIndex = stats.indices[stats.normalisedDeviations.indexOf(highestShare)];
 
         return {
           cellBalancing: {

--- a/src/device/cellBalancingMessage.ts
+++ b/src/device/cellBalancingMessage.ts
@@ -37,13 +37,11 @@ export interface CellBalancingSource {
 
 const states = new Map<string, BalancingState>();
 const lastCellTimestamps = new Map<string, string>();
-const restored = new Set<string>();
 
 /** Test seam; production never needs to forget a device. */
 export function resetCellBalancingState(): void {
   states.clear();
   lastCellTimestamps.clear();
-  restored.clear();
 }
 
 function stateFor(key: string, deviceType: string, deviceId: string): BalancingState {
@@ -58,16 +56,23 @@ function stateFor(key: string, deviceType: string, deviceId: string): BalancingS
   // drift window are deliberately not persisted: we have no idea what the pack
   // did while we were not running, and a slope measured across the downtime
   // would be meaningless.
-  if (!restored.has(key)) {
-    restored.add(key);
-    const stored = loadRecord(deviceType, deviceId);
-    if (stored != null) {
-      state.cycles = stored.cycles;
-      state.msAboveThreshold = stored.msAboveThreshold;
-      state.msAboveHighThreshold = stored.msAboveHighThreshold;
-      state.localDate = stored.localDate;
-      state.minSocPct = stored.minSocPct;
-    }
+  //
+  // The latched values are restored, though. They are the whole reason the file
+  // exists — leaving them out would send the very sensors that are gated on
+  // durable storage to unknown on every restart, until the next full charge.
+  const stored = loadRecord(deviceType, deviceId);
+  if (stored != null) {
+    state.cycles = stored.cycles;
+    state.msAboveThreshold = stored.msAboveThreshold;
+    state.msAboveHighThreshold = stored.msAboveHighThreshold;
+    state.localDate = stored.localDate;
+    state.minSocPct = stored.minSocPct;
+    state.crossing = stored.crossing;
+    state.rested = stored.rested;
+    // A restored crossing belongs to a charge that already finished, so the
+    // latch must not fire again for it.
+    state.crossingArmed = stored.crossing == null;
+    state.restedLatched = stored.rested != null;
   }
 
   states.set(key, state);
@@ -119,7 +124,11 @@ export function registerCellBalancingMessage(
         }
 
         const previousState = stateFor(key, deviceType, deviceId);
-        const { state, cycle } = advanceBalancingState(previousState, sample, localDateOf(at));
+        const { state, cycle, conditionsMet } = advanceBalancingState(
+          previousState,
+          sample,
+          localDateOf(at),
+        );
         states.set(key, state);
 
         saveRecord(
@@ -132,6 +141,8 @@ export function registerCellBalancingMessage(
             msAboveHighThreshold: state.msAboveHighThreshold,
             localDate: state.localDate,
             minSocPct: state.minSocPct,
+            crossing: state.crossing,
+            rested: state.rested,
             savedAt: new Date(at).toISOString(),
           },
           // A completed cycle is the thing worth keeping; the running counters
@@ -140,15 +151,21 @@ export function registerCellBalancingMessage(
         );
 
         const lastCycle = state.cycles[state.cycles.length - 1];
+        // The full vector goes in the payload, but a graph needs a scalar: the
+        // share owned by the highest cell is the one a passive balancer acts on.
+        const highestShare = Math.max(...stats.normalisedDeviations);
+        const highestIndex = stats.normalisedDeviations.indexOf(highestShare);
+
         return {
           cellBalancing: {
             spreadMv: stats.spreadMv,
             sigmaMv: stats.sigmaMv,
             meanMv: stats.meanMv,
             normalisedDeviations: stats.normalisedDeviations,
+            highestCellSharePct: highestShare * 100,
+            highestCell: highestIndex + 1,
             driftMvPerHour: computeDrift(state.driftPoints),
-            balanceConditionsMet:
-              sample.chargingIn === true && stats.maxMv >= CELL_BALANCE_THRESHOLD_MV,
+            balanceConditionsMet: conditionsMet,
             minutesAboveThreshold: state.msAboveThreshold / 60000,
             minutesAboveHighThreshold: state.msAboveHighThreshold / 60000,
             sessionMinutes: state.sessionMs / 60000,
@@ -191,6 +208,30 @@ export function registerCellBalancingMessage(
           device_class: 'voltage',
           unit_of_measurement: 'mV',
           state_class: 'measurement',
+        }),
+      );
+      // The sharpest of the lot. The slide artifact leaves every cell's share of
+      // the spread untouched while the spread itself collapses, so a falling
+      // share is the one thing that cannot be explained by the pack drifting
+      // down the curve.
+      advertise(
+        ['cellBalancing', 'highestCellSharePct'],
+        sensorComponent<number>({
+          id: 'highest_cell_share',
+          name: 'Highest Cell Share of Spread',
+          unit_of_measurement: '%',
+          state_class: 'measurement',
+          icon: 'mdi:chart-donut',
+        }),
+      );
+      advertise(
+        ['cellBalancing', 'highestCell'],
+        sensorComponent<number>({
+          id: 'highest_cell',
+          name: 'Highest Cell',
+          state_class: 'measurement',
+          icon: 'mdi:battery-high',
+          enabled_by_default: false,
         }),
       );
       advertise(

--- a/src/device/cellBalancingMessage.ts
+++ b/src/device/cellBalancingMessage.ts
@@ -34,6 +34,12 @@ export interface CellBalancingSource {
   /** publishPath carrying the cell voltages; a new timestamp there is one sample. */
   cellPath: string;
   extract: (stateByPath: StateByPath, clock: SampleClock) => CellSample | undefined;
+  /**
+   * Called once at registration, and only when the diagnostics are actually
+   * on, so a family can point out that it is missing an input the flag alone
+   * cannot supply.
+   */
+  warnIfIncomplete?: () => void;
 }
 
 const states = new Map<string, BalancingState>();
@@ -110,6 +116,10 @@ export function registerCellBalancingMessage(
   message: BuildMessageFn,
   source: CellBalancingSource,
 ): void {
+  const enabled = cellBalancingEnabled();
+  if (enabled) {
+    source.warnIfIncomplete?.();
+  }
   message<CellBalancingData>(
     {
       // Never sent and never matched: this message is computed, not requested.
@@ -127,7 +137,7 @@ export function registerCellBalancingMessage(
       // Both flags are required. The diagnostics are computed from the cell
       // message, so with POLL_CELL_DATA off nothing is ever polled to feed them
       // and every entity would sit at unknown forever.
-      enabled: cellBalancingEnabled(),
+      enabled,
       derive: ({ stateByPath, deviceType, deviceId, at, monotonicAt }) => {
         const key = `${deviceType}:${deviceId}`;
 
@@ -264,6 +274,14 @@ export function registerCellBalancingMessage(
           enabled_by_default: false,
         }),
       );
+      // A drift slope needs a full quiet window before it means anything, and
+      // the latched values below do not exist until the pack has been through a
+      // charge. Those keys are therefore absent from the payload rather than
+      // null, so every one of them needs a default: without it Home Assistant
+      // renders the value template against a payload that has no such key and
+      // logs a `'dict object' has no attribute …` warning on every publish.
+      // `None` is the payload Home Assistant reads as "state unknown", which is
+      // exactly what these are until they have something to report.
       advertise(
         ['cellBalancing', 'driftMvPerHour'],
         sensorComponent<number>({
@@ -272,6 +290,7 @@ export function registerCellBalancingMessage(
           unit_of_measurement: 'mV/h',
           state_class: 'measurement',
           icon: 'mdi:trending-down',
+          defaultValue: 'None',
         }),
       );
       advertise(
@@ -329,6 +348,7 @@ export function registerCellBalancingMessage(
           device_class: 'voltage',
           unit_of_measurement: 'mV',
           state_class: 'measurement',
+          defaultValue: 'None',
         }),
         withPersistence,
       );
@@ -341,6 +361,7 @@ export function registerCellBalancingMessage(
           unit_of_measurement: 'mV',
           state_class: 'measurement',
           enabled_by_default: false,
+          defaultValue: 'None',
         }),
         withPersistence,
       );
@@ -352,6 +373,7 @@ export function registerCellBalancingMessage(
           device_class: 'voltage',
           unit_of_measurement: 'mV',
           state_class: 'measurement',
+          defaultValue: 'None',
         }),
         withPersistence,
       );
@@ -364,6 +386,7 @@ export function registerCellBalancingMessage(
           unit_of_measurement: 'mV',
           state_class: 'measurement',
           enabled_by_default: false,
+          defaultValue: 'None',
         }),
         withPersistence,
       );
@@ -375,6 +398,7 @@ export function registerCellBalancingMessage(
           device_class: 'timestamp',
           icon: 'mdi:calendar-clock',
           enabled_by_default: false,
+          defaultValue: 'None',
         }),
         withPersistence,
       );

--- a/src/device/cellBalancingMessage.ts
+++ b/src/device/cellBalancingMessage.ts
@@ -1,0 +1,312 @@
+import { BuildMessageFn } from '../deviceDefinition.js';
+import { binarySensorComponent, sensorComponent } from '../homeAssistantDiscovery.js';
+import { CellBalancingData } from '../types.js';
+import {
+  advanceBalancingState,
+  BalancingState,
+  CellSample,
+  computeCellStats,
+  computeDrift,
+  initialBalancingState,
+  SampleClock,
+  StateByPath,
+} from '../cellBalancing.js';
+import { isPersistenceAvailable, loadRecord, saveRecord } from '../persistence.js';
+import {
+  CELL_BALANCE_HIGH_THRESHOLD_MV,
+  CELL_BALANCE_THRESHOLD_MV,
+  CELL_KNEE_CROSSING_MV,
+  PERSIST_SCHEMA_VERSION,
+} from '../constants.js';
+
+/**
+ * Registers the derived cell balancing message shared by every family that
+ * reports individual cell voltages.
+ *
+ * The metrics answer a question the existing *Cell Voltage Difference* sensor
+ * cannot: a pack whose spread collapsed overnight has almost certainly just
+ * slid down the flat part of the LFP curve under its own standby draw, with no
+ * change in the cells' relative state of charge.
+ */
+
+export interface CellBalancingSource {
+  /** publishPath carrying the cell voltages; a new timestamp there is one sample. */
+  cellPath: string;
+  extract: (stateByPath: StateByPath, clock: SampleClock) => CellSample | undefined;
+}
+
+const states = new Map<string, BalancingState>();
+const lastCellTimestamps = new Map<string, string>();
+const restored = new Set<string>();
+
+/** Test seam; production never needs to forget a device. */
+export function resetCellBalancingState(): void {
+  states.clear();
+  lastCellTimestamps.clear();
+  restored.clear();
+}
+
+function stateFor(key: string, deviceType: string, deviceId: string): BalancingState {
+  let state = states.get(key);
+  if (state != null) {
+    return state;
+  }
+
+  state = initialBalancingState();
+
+  // Restore only what survives an unobserved gap. The in-flight session and the
+  // drift window are deliberately not persisted: we have no idea what the pack
+  // did while we were not running, and a slope measured across the downtime
+  // would be meaningless.
+  if (!restored.has(key)) {
+    restored.add(key);
+    const stored = loadRecord(deviceType, deviceId);
+    if (stored != null) {
+      state.cycles = stored.cycles;
+      state.msAboveThreshold = stored.msAboveThreshold;
+      state.msAboveHighThreshold = stored.msAboveHighThreshold;
+      state.localDate = stored.localDate;
+      state.minSocPct = stored.minSocPct;
+    }
+  }
+
+  states.set(key, state);
+  return state;
+}
+
+/** Local calendar day, used only to roll the daily counters over. */
+function localDateOf(at: number): string {
+  return new Date(at).toLocaleDateString('en-CA');
+}
+
+export function registerCellBalancingMessage(
+  message: BuildMessageFn,
+  source: CellBalancingSource,
+): void {
+  message<CellBalancingData>(
+    {
+      // Never sent and never matched: this message is computed, not requested.
+      refreshDataPayload: '',
+      isMessage: () => false,
+      publishPath: 'cellBalancing',
+      // A derived message has no fields, so this is what declares the shape it
+      // publishes — which is how the discovery-state-topic invariant knows the
+      // advertised paths are backed by something.
+      defaultState: { cellBalancing: {} },
+      getAdditionalDeviceInfo: () => ({}),
+      pollInterval: 60000,
+      controlsDeviceAvailability: false,
+      polled: false,
+      enabled: process.env.CELL_BALANCING_DIAGNOSTICS === 'true',
+      derive: ({ stateByPath, deviceType, deviceId, at, monotonicAt }) => {
+        const key = `${deviceType}:${deviceId}`;
+
+        // One new cell reading is one sample. Without this the derivation would
+        // run for every inbound message and republish unchanged values.
+        const timestamp = stateByPath[source.cellPath]?.timestamp;
+        if (timestamp == null || lastCellTimestamps.get(key) === timestamp) {
+          return undefined;
+        }
+        lastCellTimestamps.set(key, timestamp);
+
+        const sample = source.extract(stateByPath, { at, monotonicAt });
+        if (sample == null) {
+          return undefined;
+        }
+        const stats = computeCellStats(sample.cellsMv);
+        if (stats == null) {
+          return undefined;
+        }
+
+        const previousState = stateFor(key, deviceType, deviceId);
+        const { state, cycle } = advanceBalancingState(previousState, sample, localDateOf(at));
+        states.set(key, state);
+
+        saveRecord(
+          deviceType,
+          deviceId,
+          {
+            schemaVersion: PERSIST_SCHEMA_VERSION,
+            cycles: state.cycles,
+            msAboveThreshold: state.msAboveThreshold,
+            msAboveHighThreshold: state.msAboveHighThreshold,
+            localDate: state.localDate,
+            minSocPct: state.minSocPct,
+            savedAt: new Date(at).toISOString(),
+          },
+          // A completed cycle is the thing worth keeping; the running counters
+          // can wait for the throttle.
+          { immediate: cycle != null },
+        );
+
+        const lastCycle = state.cycles[state.cycles.length - 1];
+        return {
+          cellBalancing: {
+            spreadMv: stats.spreadMv,
+            sigmaMv: stats.sigmaMv,
+            meanMv: stats.meanMv,
+            normalisedDeviations: stats.normalisedDeviations,
+            driftMvPerHour: computeDrift(state.driftPoints),
+            balanceConditionsMet:
+              sample.chargingIn === true && stats.maxMv >= CELL_BALANCE_THRESHOLD_MV,
+            minutesAboveThreshold: state.msAboveThreshold / 60000,
+            minutesAboveHighThreshold: state.msAboveHighThreshold / 60000,
+            sessionMinutes: state.sessionMs / 60000,
+            crossingSpreadMv: state.crossing?.spreadMv,
+            crossingSigmaMv: state.crossing?.sigmaMv,
+            restedSpreadMv: state.rested?.spreadMv,
+            restedSigmaMv: state.rested?.sigmaMv,
+            lastCycleEndedAt: lastCycle?.endedAt,
+            cycleCount: state.cycles.length,
+          },
+        };
+      },
+    },
+    ({ advertise }) => {
+      advertise(
+        ['cellBalancing', 'spreadMv'],
+        sensorComponent<number>({
+          id: 'cell_spread',
+          name: 'Cell Spread',
+          device_class: 'voltage',
+          unit_of_measurement: 'mV',
+          state_class: 'measurement',
+        }),
+      );
+      advertise(
+        ['cellBalancing', 'sigmaMv'],
+        sensorComponent<number>({
+          id: 'cell_spread_stddev',
+          name: 'Cell Voltage Standard Deviation',
+          device_class: 'voltage',
+          unit_of_measurement: 'mV',
+          state_class: 'measurement',
+        }),
+      );
+      advertise(
+        ['cellBalancing', 'meanMv'],
+        sensorComponent<number>({
+          id: 'cell_mean_voltage',
+          name: 'Mean Cell Voltage',
+          device_class: 'voltage',
+          unit_of_measurement: 'mV',
+          state_class: 'measurement',
+        }),
+      );
+      advertise(
+        ['cellBalancing', 'driftMvPerHour'],
+        sensorComponent<number>({
+          id: 'cell_mean_voltage_drift',
+          name: 'Mean Cell Voltage Drift',
+          unit_of_measurement: 'mV/h',
+          state_class: 'measurement',
+          icon: 'mdi:trending-down',
+        }),
+      );
+      advertise(
+        ['cellBalancing', 'balanceConditionsMet'],
+        binarySensorComponent({
+          id: 'balance_conditions_met',
+          name: 'Balance Conditions Met',
+          icon: 'mdi:scale-balance',
+        }),
+      );
+      advertise(
+        ['cellBalancing', 'minutesAboveThreshold'],
+        sensorComponent<number>({
+          id: 'minutes_above_balance_threshold',
+          name: `Minutes Above ${CELL_BALANCE_THRESHOLD_MV} mV Today`,
+          unit_of_measurement: 'min',
+          state_class: 'measurement',
+          icon: 'mdi:timer-outline',
+        }),
+      );
+      advertise(
+        ['cellBalancing', 'minutesAboveHighThreshold'],
+        sensorComponent<number>({
+          id: 'minutes_above_high_balance_threshold',
+          name: `Minutes Above ${CELL_BALANCE_HIGH_THRESHOLD_MV} mV Today`,
+          unit_of_measurement: 'min',
+          state_class: 'measurement',
+          icon: 'mdi:timer-outline',
+        }),
+      );
+      advertise(
+        ['cellBalancing', 'sessionMinutes'],
+        sensorComponent<number>({
+          id: 'balance_session_minutes',
+          name: 'Balance Session Duration',
+          unit_of_measurement: 'min',
+          state_class: 'measurement',
+          icon: 'mdi:timer-play-outline',
+          enabled_by_default: false,
+        }),
+      );
+
+      // Cross-cycle values only mean anything if they survive a restart, so
+      // they are advertised only when there is somewhere durable to store them.
+      // This must stay a predicate rather than a captured constant: discovery
+      // calls it on every publish, whereas anything read at import time would
+      // be pinned to whatever was true before the probe ran.
+      const withPersistence = { enabled: () => isPersistenceAvailable() };
+
+      advertise(
+        ['cellBalancing', 'crossingSpreadMv'],
+        sensorComponent<number>({
+          id: 'cell_spread_at_crossing',
+          name: `Cell Spread at ${CELL_KNEE_CROSSING_MV} mV`,
+          device_class: 'voltage',
+          unit_of_measurement: 'mV',
+          state_class: 'measurement',
+        }),
+        withPersistence,
+      );
+      advertise(
+        ['cellBalancing', 'crossingSigmaMv'],
+        sensorComponent<number>({
+          id: 'cell_stddev_at_crossing',
+          name: `Cell Standard Deviation at ${CELL_KNEE_CROSSING_MV} mV`,
+          device_class: 'voltage',
+          unit_of_measurement: 'mV',
+          state_class: 'measurement',
+          enabled_by_default: false,
+        }),
+        withPersistence,
+      );
+      advertise(
+        ['cellBalancing', 'restedSpreadMv'],
+        sensorComponent<number>({
+          id: 'rested_cell_spread',
+          name: 'Rested Cell Spread',
+          device_class: 'voltage',
+          unit_of_measurement: 'mV',
+          state_class: 'measurement',
+        }),
+        withPersistence,
+      );
+      advertise(
+        ['cellBalancing', 'restedSigmaMv'],
+        sensorComponent<number>({
+          id: 'rested_cell_stddev',
+          name: 'Rested Cell Standard Deviation',
+          device_class: 'voltage',
+          unit_of_measurement: 'mV',
+          state_class: 'measurement',
+          enabled_by_default: false,
+        }),
+        withPersistence,
+      );
+      advertise(
+        ['cellBalancing', 'lastCycleEndedAt'],
+        sensorComponent<string>({
+          id: 'last_charge_cycle',
+          name: 'Last Charge Cycle',
+          device_class: 'timestamp',
+          icon: 'mdi:calendar-clock',
+          enabled_by_default: false,
+        }),
+        withPersistence,
+      );
+    },
+  );
+}

--- a/src/device/cellBalancingMessage.ts
+++ b/src/device/cellBalancingMessage.ts
@@ -35,15 +35,19 @@ export interface CellBalancingSource {
   cellPath: string;
   extract: (stateByPath: StateByPath, clock: SampleClock) => CellSample | undefined;
   /**
-   * Called once at registration, and only when the diagnostics are actually
-   * on, so a family can point out that it is missing an input the flag alone
-   * cannot supply.
+   * Called the first time a given device produces a usable sample, so a family
+   * can point out an input the flag alone cannot supply.
+   *
+   * Deferred to here rather than to registration because every device type is
+   * registered on every start, whether or not the user owns one — warning at
+   * import time would tell a Venus owner what to configure on a B2500.
    */
-  warnIfIncomplete?: () => void;
+  warnIfIncomplete?: (deviceType: string, deviceId: string) => void;
 }
 
 const states = new Map<string, BalancingState>();
 const lastCellTimestamps = new Map<string, string>();
+const warnedDevices = new Set<string>();
 
 let warnedAboutCellData = false;
 
@@ -70,6 +74,7 @@ function cellBalancingEnabled(): boolean {
 export function resetCellBalancingState(): void {
   states.clear();
   lastCellTimestamps.clear();
+  warnedDevices.clear();
 }
 
 function stateFor(key: string, deviceType: string, deviceId: string): BalancingState {
@@ -116,10 +121,6 @@ export function registerCellBalancingMessage(
   message: BuildMessageFn,
   source: CellBalancingSource,
 ): void {
-  const enabled = cellBalancingEnabled();
-  if (enabled) {
-    source.warnIfIncomplete?.();
-  }
   message<CellBalancingData>(
     {
       // Never sent and never matched: this message is computed, not requested.
@@ -137,7 +138,7 @@ export function registerCellBalancingMessage(
       // Both flags are required. The diagnostics are computed from the cell
       // message, so with POLL_CELL_DATA off nothing is ever polled to feed them
       // and every entity would sit at unknown forever.
-      enabled,
+      enabled: cellBalancingEnabled(),
       derive: ({ stateByPath, deviceType, deviceId, at, monotonicAt }) => {
         const key = `${deviceType}:${deviceId}`;
 
@@ -160,6 +161,13 @@ export function registerCellBalancingMessage(
         // consumed any earlier would discard a sample whose other inputs are
         // still on their way, rather than reconsidering it on the next update.
         lastCellTimestamps.set(key, timestamp);
+
+        // A real device of this family has just reported, so anything the
+        // family still needs configured is worth saying — once, per device.
+        if (!warnedDevices.has(key)) {
+          warnedDevices.add(key);
+          source.warnIfIncomplete?.(deviceType, deviceId);
+        }
 
         const previousState = stateFor(key, deviceType, deviceId);
         const { state, cycle, conditionsMet } = advanceBalancingState(

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -23,6 +23,8 @@ import {
   WeekdaySet,
 } from '../types.js';
 import { registerNetworkInfoMessage } from './networkInfoBase.js';
+import { registerCellBalancingMessage } from './cellBalancingMessage.js';
+import { extractVenusSample } from '../cellBalancing.js';
 import logger from '../logger.js';
 import {
   buttonComponent,
@@ -264,6 +266,7 @@ registerDeviceDefinition(
   ({ message }) => {
     registerRuntimeInfoMessage(message);
     registerBMSInfoMessage(message);
+    registerVenusCellBalancingMessage(message);
     registerBMSPackMessage(message);
     registerBMSPackDetailMessages(message);
     registerVenusNetworkInfoMessage(message);
@@ -279,6 +282,7 @@ registerDeviceDefinition(
   ({ message }) => {
     registerRuntimeInfoMessage(message);
     registerBMSInfoMessage(message, { scaleTemperatures: true });
+    registerVenusCellBalancingMessage(message);
     registerBMSPackMessage(message, { scaleTemperatures: true });
     registerBMSPackDetailMessages(message, { scaleTemperatures: true });
     registerVenusNetworkInfoMessage(message);
@@ -2151,6 +2155,18 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
         publishCallback(processCommand(CommandType.DEPTH_OF_DISCHARGE, { dod: dodValue }));
       },
     });
+  });
+}
+
+/**
+ * Cell balancing diagnostics for Venus. The cd=14 payload carries the cell
+ * voltages, pack current, temperatures and state of charge together, so every
+ * sample is internally consistent.
+ */
+function registerVenusCellBalancingMessage(message: BuildMessageFn) {
+  registerCellBalancingMessage(message, {
+    cellPath: 'bms',
+    extract: extractVenusSample,
   });
 }
 

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -120,6 +120,15 @@ export interface MessageDefinition<T extends BaseDeviceData> {
   controlsDeviceAvailability: boolean;
   enabled?: boolean;
   /**
+   * Whether this message is requested from the device at all. Defaults to true.
+   *
+   * Derived messages compute their state locally from other messages' state, so
+   * they are never requested and never parsed. They must not contribute to the
+   * polling interval GCD (their `pollInterval` is meaningless) and must not have
+   * their `refreshDataPayload` sent.
+   */
+  polled?: boolean;
+  /**
    * Optional state-aware poll predicate. When provided, the message is only
    * polled if this returns true for the current (merged) device state. Used to
    * dynamically poll per-pack BMS details only for packs that are present.
@@ -175,6 +184,7 @@ export type BuildMessageFn = <T extends BaseDeviceData>(
     pollInterval: number;
     controlsDeviceAvailability: boolean;
     enabled?: boolean;
+    polled?: boolean;
     shouldPoll?: (state: BaseDeviceData) => boolean;
   },
   args: BuildMessageDefinitionFn<T>,
@@ -227,6 +237,7 @@ export function registerDeviceDefinition(
       commands,
       ...messageOptions,
       enabled: messageOptions.enabled !== false,
+      polled: messageOptions.polled !== false,
     } satisfies MessageDefinition<any>;
     messages.push(messageDefinition);
   };

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -107,6 +107,35 @@ export interface DeviceDefinition<T extends BaseDeviceData> {
   messages: MessageDefinition<T>[];
 }
 
+export type DeriveContext<T extends BaseDeviceData> = {
+  /**
+   * State keyed by publishPath, *not* the merged view from
+   * `DeviceManager.getDeviceState`. That merge is shallow and last-writer-wins,
+   * and every path contributes its own `timestamp`, so the merged one is
+   * ambiguous — which matters here, since deciding whether a derivation has
+   * anything new to do means comparing one specific path's timestamp.
+   */
+  stateByPath: Record<string, BaseDeviceData>;
+  previous: T;
+  /** Wall clock, for stamping. */
+  at: number;
+  /** Monotonic clock, for measuring durations across calls. */
+  monotonicAt: number;
+};
+
+/**
+ * Computes state from other messages' state instead of from a device payload.
+ *
+ * Returning undefined means "nothing changed": no state is written and nothing
+ * is published. That matters because derivations run after every inbound
+ * message — on a Venus with cell data enabled that is eight messages per poll
+ * cycle, and publishing each time would create a Home Assistant recorder row
+ * per sensor for a value that did not move.
+ */
+export type DeriveFn<T extends BaseDeviceData> = (
+  context: DeriveContext<T>,
+) => Partial<T> | undefined;
+
 export interface MessageDefinition<T extends BaseDeviceData> {
   commands: ControlHandlerDefinition<T>[];
   advertisements: HaAdvertisement<T, KeyPath<T> | []>[];
@@ -128,6 +157,12 @@ export interface MessageDefinition<T extends BaseDeviceData> {
    * their `refreshDataPayload` sent.
    */
   polled?: boolean;
+  /**
+   * Marks this as a derived message: its state is computed from other messages
+   * rather than parsed from a payload. Such a message should also set
+   * `polled: false` and an `isMessage` that never matches.
+   */
+  derive?: DeriveFn<T>;
   /**
    * Optional state-aware poll predicate. When provided, the message is only
    * polled if this returns true for the current (merged) device state. Used to
@@ -185,6 +220,7 @@ export type BuildMessageFn = <T extends BaseDeviceData>(
     controlsDeviceAvailability: boolean;
     enabled?: boolean;
     polled?: boolean;
+    derive?: DeriveFn<T>;
     shouldPoll?: (state: BaseDeviceData) => boolean;
   },
   args: BuildMessageDefinitionFn<T>,
@@ -220,7 +256,13 @@ export function registerDeviceDefinition(
     };
     const advertisements: HaAdvertisement<any, KeyPath<any> | []>[] = [];
     const advertise: AdvertiseComponentFn<any> = (keyPath, advertise, options = {}) => {
-      // If the message is disabled, override enabled to always return false
+      // Note the asymmetry: the message-level `enabled` below is collapsed to a
+      // boolean here, at registration time, whereas an advertisement's `enabled`
+      // predicate is called lazily on every discovery publish. Anything not yet
+      // known when the device modules are imported therefore has to be a
+      // predicate that reads the value when called — capturing it into a const
+      // at import time silently pins it to its starting value, and the two forms
+      // look identical in a diff.
       const enabled = messageOptions.enabled === false ? () => false : options.enabled;
 
       advertisements.push({

--- a/src/deviceDefinition.ts
+++ b/src/deviceDefinition.ts
@@ -117,6 +117,8 @@ export type DeriveContext<T extends BaseDeviceData> = {
    */
   stateByPath: Record<string, BaseDeviceData>;
   previous: T;
+  deviceType: string;
+  deviceId: string;
   /** Wall clock, for stamping. */
   at: number;
   /** Monotonic clock, for measuring durations across calls. */

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -265,7 +265,7 @@ describe('DeviceManager', () => {
     // process. None of this was covered before.
     const defineType = (
       deviceType: string,
-      messages: { pollInterval: number; enabled?: boolean }[],
+      messages: { pollInterval: number; enabled?: boolean; polled?: boolean }[],
     ) => {
       registerDeviceDefinition({ deviceTypes: [deviceType] }, ({ message }) => {
         messages.forEach((options, idx) => {
@@ -306,10 +306,18 @@ describe('DeviceManager', () => {
       expect(intervalFor('TESTGCDDISABLED')).toBe(60000);
     });
 
+    it('ignores derived messages, which are never requested', () => {
+      defineType('TESTGCDDERIVED', [
+        { pollInterval: 60000 },
+        { pollInterval: 5000, polled: false },
+      ]);
+      expect(intervalFor('TESTGCDDERIVED')).toBe(60000);
+    });
+
     it('falls back to the unfiltered set rather than leaving the tick undefined', () => {
       defineType('TESTGCDNONE', [
         { pollInterval: 30000, enabled: false },
-        { pollInterval: 45000, enabled: false },
+        { pollInterval: 45000, polled: false },
       ]);
       expect(intervalFor('TESTGCDNONE')).toBe(15000);
     });

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -259,6 +259,114 @@ describe('DeviceManager', () => {
     });
   });
 
+  describe('derived messages', () => {
+    const defineDerived = (deviceType: string, derive: any) => {
+      registerDeviceDefinition({ deviceTypes: [deviceType] }, ({ message }) => {
+        message(
+          {
+            refreshDataPayload: 'cd=1',
+            isMessage: () => true,
+            publishPath: 'data',
+            defaultState: {},
+            getAdditionalDeviceInfo: () => ({}),
+            pollInterval: 60000,
+            controlsDeviceAvailability: true,
+          },
+          () => {},
+        );
+        message(
+          {
+            refreshDataPayload: '',
+            isMessage: () => false,
+            publishPath: 'derived',
+            defaultState: {},
+            getAdditionalDeviceInfo: () => ({}),
+            pollInterval: 60000,
+            controlsDeviceAvailability: false,
+            polled: false,
+            derive,
+          },
+          () => {},
+        );
+      });
+    };
+
+    const managerFor = (deviceType: string, onUpdate: any) =>
+      new DeviceManager({ ...mockConfig, devices: [{ deviceType, deviceId: 'd1' }] }, onUpdate);
+
+    it('publishes derived state when the derivation returns a value', () => {
+      defineDerived('TESTDERIVEA', ({ stateByPath }: any) => ({
+        doubled: (stateByPath['data']?.raw ?? 0) * 2,
+      }));
+      const onUpdate = jest.fn();
+      const dm = managerFor('TESTDERIVEA', onUpdate);
+      const device = { deviceType: 'TESTDERIVEA', deviceId: 'd1' };
+
+      dm.updateDeviceState(device, 'data', () => ({ raw: 21 }) as any);
+
+      const paths = onUpdate.mock.calls.map((c: any[]) => c[1]);
+      expect(paths).toEqual(['data', 'derived']);
+      expect((onUpdate.mock.calls[1][2] as any).doubled).toBe(42);
+    });
+
+    it('publishes nothing when the derivation returns undefined', () => {
+      // This is what keeps a Venus from emitting a derived state update per
+      // inbound message — eight per poll cycle — for a value that never moved.
+      defineDerived('TESTDERIVEB', () => undefined);
+      const onUpdate = jest.fn();
+      const dm = managerFor('TESTDERIVEB', onUpdate);
+      const device = { deviceType: 'TESTDERIVEB', deviceId: 'd1' };
+
+      dm.updateDeviceState(device, 'data', () => ({ raw: 1 }) as any);
+      dm.updateDeviceState(device, 'data', () => ({ raw: 2 }) as any);
+
+      const paths = onUpdate.mock.calls.map((c: any[]) => c[1]);
+      expect(paths).toEqual(['data', 'data']);
+    });
+
+    it('does not let a derived write trigger another derivation', () => {
+      let calls = 0;
+      defineDerived('TESTDERIVEC', () => {
+        calls += 1;
+        return { tick: calls };
+      });
+      const onUpdate = jest.fn();
+      const dm = managerFor('TESTDERIVEC', onUpdate);
+      const device = { deviceType: 'TESTDERIVEC', deviceId: 'd1' };
+
+      dm.updateDeviceState(device, 'data', () => ({ raw: 1 }) as any);
+      expect(calls).toBe(1);
+    });
+
+    it('survives a derivation that throws', () => {
+      defineDerived('TESTDERIVED', () => {
+        throw new Error('boom');
+      });
+      const onUpdate = jest.fn();
+      const dm = managerFor('TESTDERIVED', onUpdate);
+      const device = { deviceType: 'TESTDERIVED', deviceId: 'd1' };
+
+      expect(() => dm.updateDeviceState(device, 'data', () => ({ raw: 1 }) as any)).not.toThrow();
+      expect(onUpdate.mock.calls.map((c: any[]) => c[1])).toEqual(['data']);
+    });
+
+    it('sees per-path state rather than the flattened merge', () => {
+      // Every path carries its own `timestamp`, so the merged view cannot say
+      // which message a timestamp belongs to. Derivations get the real thing.
+      let seen: any;
+      defineDerived('TESTDERIVEE', ({ stateByPath }: any) => {
+        seen = stateByPath;
+        return { ok: true };
+      });
+      const dm = managerFor('TESTDERIVEE', jest.fn());
+      const device = { deviceType: 'TESTDERIVEE', deviceId: 'd1' };
+
+      dm.updateDeviceState(device, 'data', () => ({ raw: 1 }) as any);
+      expect(Object.keys(seen)).toContain('data');
+      expect(seen['data'].raw).toBe(1);
+    });
+  });
+
   describe('getPollingInterval', () => {
     // The shared polling timer runs at the GCD of every message's interval, so a
     // single badly chosen interval speeds up polling for every device in the

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -365,12 +365,14 @@ export class DeviceManager {
       throw new Error('No valid devices configured');
     }
 
-    // Only messages that are actually requested from the device get a say in
-    // the tick. A disabled message — POLL_CELL_DATA=false, say — is never sent,
-    // so letting it contribute drives the shared timer faster than anything
-    // needs. Fall back to the unfiltered set if that leaves nothing, so the tick
-    // stays defined.
-    const polledIntervals = collect(message => message.enabled !== false);
+    // Only messages that are actually requested from the device get a say in the
+    // tick. A disabled message (POLL_CELL_DATA=false) is never sent, and a
+    // derived message is never sent at all, so letting either contribute would
+    // drive the shared timer faster than anything needs. Fall back to the
+    // unfiltered set if that leaves nothing, so the tick stays defined.
+    const polledIntervals = collect(
+      message => message.enabled !== false && message.polled !== false,
+    );
     const intervals = polledIntervals.length > 0 ? polledIntervals : allPollingIntervals;
 
     function gcd2(a: number, b: number): number {

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -191,7 +191,77 @@ export class DeviceManager {
       [path]: newDeviceState,
     };
     this.onUpdateState(device, path, newDeviceState);
+    this.runDerivations(device, path);
     return newDeviceState as DeviceStateData & T;
+  }
+
+  /**
+   * Recompute any derived messages after a state update.
+   *
+   * A derivation that returns undefined writes nothing and publishes nothing.
+   * Derivations run after every inbound message, so publishing unconditionally
+   * would emit a state update per derived message per message received — eight
+   * per poll cycle on a Venus with cell data enabled — each one a Home Assistant
+   * recorder row per sensor for a value that has not changed.
+   */
+  private runDerivations(device: Device, triggeringPath: string): void {
+    const deviceDefinition = getDeviceDefinition(device.deviceType);
+    if (!deviceDefinition) {
+      return;
+    }
+
+    const derived = deviceDefinition.messages.filter(
+      message => message.derive != null && message.enabled !== false,
+    );
+    if (derived.length === 0) {
+      return;
+    }
+
+    // A derived write must not trigger another round of derivation.
+    if (derived.some(message => message.publishPath === triggeringPath)) {
+      return;
+    }
+
+    const deviceKey = this.getDeviceKey(device);
+    for (const message of derived) {
+      const previous = this.getDeviceStateForPath(device, message.publishPath);
+      let update;
+      try {
+        update = message.derive?.({
+          stateByPath: (this.deviceStates[deviceKey] ?? {}) as Record<string, any>,
+          previous: previous as any,
+          at: Date.now(),
+          monotonicAt: performance.now(),
+        });
+      } catch (error) {
+        // A broken derivation must never take the bridge down with it.
+        logger.warn(
+          `Derivation for ${device.deviceType}:${device.deviceId} ${message.publishPath} failed:`,
+          error,
+        );
+        continue;
+      }
+
+      if (update == null) {
+        continue;
+      }
+
+      const newDeviceState = {
+        ...previous,
+        ...update,
+        // Regenerated every time, so these win over whatever the previous
+        // derived state carried.
+        deviceType: device.deviceType,
+        deviceId: device.deviceId,
+        timestamp: new Date().toISOString(),
+      } as DeviceStateData;
+
+      this.deviceStates[deviceKey] = {
+        ...this.deviceStates[deviceKey],
+        [message.publishPath]: newDeviceState,
+      };
+      this.onUpdateState(device, message.publishPath, newDeviceState);
+    }
   }
 
   /**

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -230,6 +230,8 @@ export class DeviceManager {
         update = message.derive?.({
           stateByPath: (this.deviceStates[deviceKey] ?? {}) as Record<string, any>,
           previous: previous as any,
+          deviceType: device.deviceType,
+          deviceId: device.deviceId,
           at: Date.now(),
           monotonicAt: performance.now(),
         });

--- a/src/discoveryStateTopics.test.ts
+++ b/src/discoveryStateTopics.test.ts
@@ -24,6 +24,10 @@ function joinPath(keyPath: ReadonlyArray<string | number>): string {
 /**
  * The paths a message can actually publish: the base keys, the message's default
  * state and every field the parser fills in.
+ *
+ * A derived message has no fields — its values come from `derive()` — so its
+ * default state is what declares the shape it publishes. The paths themselves
+ * are already type-checked against the message's state type at registration.
  */
 function publishablePaths(message: MessageDefinition<BaseDeviceData>): string[] {
   return [

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,9 +324,7 @@ async function main() {
       // outcome this handler exists to avoid. A failure to stop the proxy must
       // also not cost us the MQTT close, which is what publishes the offline
       // availability, nor the flush this whole path exists for.
-      await runShutdownStep('flushing the cell balancing history', async () =>
-        flushPersistence(),
-      );
+      await runShutdownStep('flushing the cell balancing history', async () => flushPersistence());
 
       const proxy = mqttProxy;
       if (proxy) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import logger from './logger.js';
 import { DataHandler } from './dataHandler.js';
 import { MqttProxy, MqttProxyConfig } from './mqttProxy.js';
 import { runShutdownStep } from './shutdown.js';
+import { flushPersistence } from './persistence.js';
 
 // MQTT Proxy configuration
 const MQTT_PROXY_ENABLED = process.env.MQTT_PROXY_ENABLED === 'true';
@@ -305,7 +306,8 @@ async function main() {
     // Handle process termination. SIGTERM matters as much as SIGINT: Docker and
     // the Home Assistant Supervisor both send it to stop a container, so without
     // a handler an ordinary restart or add-on update skipped this path entirely
-    // and the container was killed after the grace period instead.
+    // and the container was killed after the grace period instead — which is
+    // also exactly the case the cell balancing history has to survive.
     let shuttingDown = false;
     const shutdown = async (signal: string) => {
       if (shuttingDown) {
@@ -321,7 +323,11 @@ async function main() {
       // otherwise block the exit until the runtime killed us, which is the
       // outcome this handler exists to avoid. A failure to stop the proxy must
       // also not cost us the MQTT close, which is what publishes the offline
-      // availability.
+      // availability, nor the flush this whole path exists for.
+      await runShutdownStep('flushing the cell balancing history', async () =>
+        flushPersistence(),
+      );
+
       const proxy = mqttProxy;
       if (proxy) {
         logger.info('Stopping MQTT Proxy...');

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -287,10 +287,27 @@ describe('MqttClient shouldPoll gating', () => {
     }
   }
 
-  test('sends nothing at all when every message is disabled', () => {
+  test('never requests a derived message', () => {
+    const { payloads } = pollFor([
+      makeMessage({ refreshDataPayload: 'cd=1', publishPath: 'data' }),
+      makeMessage({
+        refreshDataPayload: 'cd=999',
+        publishPath: 'cellBalancing',
+        polled: false,
+      }),
+    ]);
+    expect(payloads).toContain('cd=1');
+    expect(payloads).not.toContain('cd=999');
+  });
+
+  test('sends nothing at all when every message is derived or disabled', () => {
     const { payloads } = pollFor([
       makeMessage({ refreshDataPayload: 'cd=13', publishPath: 'cells', enabled: false }),
-      makeMessage({ refreshDataPayload: 'cd=21', publishPath: 'calibration', enabled: false }),
+      makeMessage({
+        refreshDataPayload: 'cd=999',
+        publishPath: 'cellBalancing',
+        polled: false,
+      }),
     ]);
     expect(payloads).toEqual([]);
   });

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -355,12 +355,12 @@ export class MqttClient {
     let needsRefresh = false;
     let shouldStartTimeout = false;
     for (const [idx, message] of deviseDefinition.messages.entries()) {
-      // Mirror the skip applied when actually sending, below. Without it a
+      // Mirror the skips applied when actually sending, below. Without them a
       // message that is never sent never gets a `lastRequestTime`, so it stays
       // permanently "due" and `needsRefresh` is always true — which made the
       // early return below dead code on every device that has a disabled
       // message (i.e. all of them, whenever POLL_CELL_DATA is off).
-      if (!message.enabled) {
+      if (!message.enabled || message.polled === false) {
         continue;
       }
       if (message.shouldPoll && !message.shouldPoll(pollState)) {
@@ -400,8 +400,9 @@ export class MqttClient {
 
     // Send requests for all messages that need to be refreshed, but only if no outstanding timeout
     for (const [idx, message] of deviseDefinition.messages.entries()) {
-      // Skip polling for disabled messages
-      if (!message.enabled) {
+      // Skip polling for disabled messages, and for derived messages which are
+      // computed locally and have no refresh payload to send.
+      if (!message.enabled || message.polled === false) {
         continue;
       }
 

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -76,6 +76,44 @@ describe('MQTT Message Parser', () => {
     // The malformed part should be skipped
   });
 
+  describe('B2500 per-pack status flags (l0/l1)', () => {
+    const base =
+      'p1=0,p2=0,w1=0,w2=0,pe=14,vv=224,sv=3,cs=0,cd=0,am=0,o1=0,o2=0,do=90,lv=800,cj=1,kn=313,g1=0,g2=0,b1=0,b2=0,md=0,d1=1,e1=0:0,f1=23:59,h1=800,sg=0,sp=80,st=0,tl=12,th=13,tc=0,tf=0,fc=202310231502,id=5,a0=14,a1=0,a2=0';
+
+    const statusFor = (l0: number, l1: number) => {
+      const parsed = parseMessage(`${base},l0=${l0},l1=${l1}`, 'HMA-1', 'e88da6f35def');
+      return (parsed['data'] as B2500V2DeviceData).packStatus;
+    };
+
+    test('decodes the host pack from l0', () => {
+      // bit 1 = charging
+      expect(statusFor(0b0010, 0)?.host).toMatchObject({
+        discharging: false,
+        charging: true,
+        dodReached: false,
+        undervoltage: false,
+      });
+      // bit 0 = discharging, bit 2 = DoD reached
+      expect(statusFor(0b0101, 0)?.host).toMatchObject({
+        discharging: true,
+        charging: false,
+        dodReached: true,
+      });
+    });
+
+    test('splits l1 into extra2 (low nibble) and extra1 (high nibble)', () => {
+      // extra1 charging (bit 5), extra2 discharging (bit 0)
+      const status = statusFor(0, 0b0010_0001);
+      expect(status?.extra1).toMatchObject({ charging: true, discharging: false });
+      expect(status?.extra2).toMatchObject({ charging: false, discharging: true });
+    });
+
+    test('is absent on firmware that does not report the fields', () => {
+      const parsed = parseMessage(base, 'HMA-1', 'e88da6f35def');
+      expect((parsed['data'] as B2500V2DeviceData).packStatus).toBeUndefined();
+    });
+  });
+
   test('should parse a full device message correctly', () => {
     // Full message example from documentation
     const message =

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -1,0 +1,158 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  flushPersistence,
+  loadRecord,
+  PersistedRecord,
+  probeDataDir,
+  resetPersistenceProbe,
+  saveRecord,
+} from './persistence.js';
+import { PERSIST_SCHEMA_VERSION } from './constants.js';
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hm2mqtt-persist-'));
+}
+
+function record(overrides: Partial<PersistedRecord> = {}): PersistedRecord {
+  return {
+    schemaVersion: PERSIST_SCHEMA_VERSION,
+    cycles: [],
+    msAboveThreshold: 0,
+    msAboveHighThreshold: 0,
+    savedAt: '2026-08-06T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('probeDataDir', () => {
+  afterEach(() => resetPersistenceProbe());
+
+  it('accepts a writable directory', () => {
+    const dir = tempDir();
+    const probe = probeDataDir({ HM2MQTT_DATA_DIR: dir } as NodeJS.ProcessEnv);
+    expect(probe.available).toBe(true);
+    expect(probe.dir).toBe(path.join(dir, 'cell-balancing'));
+  });
+
+  it('reports unavailable rather than throwing on a read-only directory', () => {
+    const dir = tempDir();
+    fs.chmodSync(dir, 0o500);
+    try {
+      let probe: ReturnType<typeof probeDataDir>;
+      expect(() => {
+        probe = probeDataDir({ HM2MQTT_DATA_DIR: dir } as NodeJS.ProcessEnv);
+      }).not.toThrow();
+      // Running as root defeats permission bits, which is exactly how the
+      // container runs; only assert the shape when the bits actually bite.
+      if (!probe!.available) {
+        expect(probe!.reason).toContain('not writable');
+      }
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+  });
+
+  it('refuses a default directory it would have had to create itself', () => {
+    // The standalone image declares no VOLUME, has no /data and runs as root,
+    // so mkdir would succeed into the container's writable layer and the
+    // history would vanish on the next `docker compose pull` — the very update
+    // persistence exists to survive.
+    const missing = path.join(tempDir(), 'definitely-not-mounted');
+    const probe = probeDataDir({} as NodeJS.ProcessEnv, missing);
+    expect(probe.available).toBe(false);
+    expect(probe.reason).toContain('does not exist');
+    // And it must not have quietly created it on the way to saying no.
+    expect(fs.existsSync(missing)).toBe(false);
+  });
+
+  it('accepts a default directory that is already mounted', () => {
+    const mounted = tempDir();
+    const probe = probeDataDir({} as NodeJS.ProcessEnv, mounted);
+    expect(probe.available).toBe(true);
+    expect(probe.dir).toBe(path.join(mounted, 'cell-balancing'));
+  });
+
+  it('creates an explicitly configured directory, because asking for it is intent', () => {
+    const dir = path.join(tempDir(), 'nested', 'deeper');
+    const probe = probeDataDir({ HM2MQTT_DATA_DIR: dir } as NodeJS.ProcessEnv);
+    expect(probe.available).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'cell-balancing'))).toBe(true);
+  });
+});
+
+describe('record storage', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tempDir();
+    resetPersistenceProbe({ available: true, dir });
+  });
+
+  afterEach(() => resetPersistenceProbe());
+
+  it('round-trips a record', () => {
+    saveRecord('VNSD-0', 'venus1', record({ msAboveThreshold: 1234 }), { immediate: true });
+    expect(loadRecord('VNSD-0', 'venus1')?.msAboveThreshold).toBe(1234);
+  });
+
+  it('keeps devices apart', () => {
+    saveRecord('VNSD-0', 'a', record({ msAboveThreshold: 1 }), { immediate: true });
+    saveRecord('VNSD-0', 'b', record({ msAboveThreshold: 2 }), { immediate: true });
+    expect(loadRecord('VNSD-0', 'a')?.msAboveThreshold).toBe(1);
+    expect(loadRecord('VNSD-0', 'b')?.msAboveThreshold).toBe(2);
+  });
+
+  it('cannot be made to write outside its directory', () => {
+    // deviceId comes from a DEVICE_n environment variable, so it is arbitrary.
+    saveRecord('VNSD-0', '../../escape', record({ msAboveThreshold: 7 }), { immediate: true });
+    const written = fs.readdirSync(dir);
+    expect(written).toEqual(['VNSD-0_______escape.json']);
+    expect(loadRecord('VNSD-0', '../../escape')?.msAboveThreshold).toBe(7);
+  });
+
+  it('ignores a record written by a different schema version', () => {
+    saveRecord('VNSD-0', 'venus1', record(), { immediate: true });
+    const file = path.join(dir, 'VNSD-0_venus1.json');
+    fs.writeFileSync(file, JSON.stringify({ schemaVersion: 999, cycles: [{}] }));
+    expect(loadRecord('VNSD-0', 'venus1')).toBeUndefined();
+  });
+
+  it('survives a corrupt file', () => {
+    const file = path.join(dir, 'VNSD-0_venus1.json');
+    fs.writeFileSync(file, '{not json');
+    expect(() => loadRecord('VNSD-0', 'venus1')).not.toThrow();
+    expect(loadRecord('VNSD-0', 'venus1')).toBeUndefined();
+  });
+
+  it('returns nothing when no record was ever written', () => {
+    expect(loadRecord('VNSD-0', 'never')).toBeUndefined();
+  });
+
+  it('leaves the previous record intact if the process dies before the rename', () => {
+    saveRecord('VNSD-0', 'venus1', record({ msAboveThreshold: 100 }), { immediate: true });
+    // Simulate a half-finished write: the temp file exists, the real one is
+    // untouched. This is the state a power cut mid-write leaves behind.
+    const file = path.join(dir, 'VNSD-0_venus1.json');
+    fs.writeFileSync(`${file}.tmp`, JSON.stringify(record({ msAboveThreshold: 999 })));
+    expect(loadRecord('VNSD-0', 'venus1')?.msAboveThreshold).toBe(100);
+  });
+
+  it('throttles the running counters but flushes on demand', () => {
+    saveRecord('VNSD-0', 'venus1', record({ msAboveThreshold: 1 }), { immediate: true });
+    // Immediately afterwards, so the throttle window is still open.
+    saveRecord('VNSD-0', 'venus1', record({ msAboveThreshold: 2 }));
+    expect(loadRecord('VNSD-0', 'venus1')?.msAboveThreshold).toBe(1);
+
+    // What the SIGTERM handler does on an add-on update.
+    flushPersistence();
+    expect(loadRecord('VNSD-0', 'venus1')?.msAboveThreshold).toBe(2);
+  });
+
+  it('does nothing at all when persistence is unavailable', () => {
+    resetPersistenceProbe({ available: false, reason: 'test' });
+    expect(() => saveRecord('VNSD-0', 'venus1', record(), { immediate: true })).not.toThrow();
+    expect(loadRecord('VNSD-0', 'venus1')).toBeUndefined();
+  });
+});

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -116,12 +117,23 @@ describe('record storage', () => {
 
   it('cannot be made to write outside its directory', () => {
     // deviceId comes from a DEVICE_n environment variable, so it is arbitrary.
-    saveRecord('VNSD-0', '../../escape', record({ msAboveThreshold: 7 }), { immediate: true });
-    const written = fs.readdirSync(dir);
+    // Enough `..` segments to climb past the device type it is glued to and
+    // then out of the storage directory itself — a shorter run is swallowed by
+    // the prefix and would pass whether or not anything sanitises the name.
+    const parent = tempDir();
+    const inner = path.join(parent, 'cell-balancing');
+    fs.mkdirSync(inner);
+    resetPersistenceProbe({ available: true, dir: inner });
+
+    const deviceId = '../../../escape';
+    saveRecord('VNSD-0', deviceId, record({ msAboveThreshold: 7 }), { immediate: true });
+
+    expect(fs.readdirSync(parent)).toEqual(['cell-balancing']);
+    const written = fs.readdirSync(inner);
     expect(written).toHaveLength(1);
     expect(written[0]).not.toContain('/');
     expect(written[0]).not.toContain('..');
-    expect(loadRecord('VNSD-0', '../../escape')?.msAboveThreshold).toBe(7);
+    expect(loadRecord('VNSD-0', deviceId)?.msAboveThreshold).toBe(7);
   });
 
   it('keeps devices apart even when sanitising collapses their ids', () => {
@@ -158,12 +170,23 @@ describe('record storage', () => {
     expect(loadRecord('VNSD-0', 'never')).toBeUndefined();
   });
 
-  it('leaves the previous record intact if the process dies before the rename', () => {
+  it('leaves the previous record intact when a write cannot complete', () => {
     saveRecord('VNSD-0', 'venus1', record({ msAboveThreshold: 100 }), { immediate: true });
-    // Simulate a half-finished write: the temp file exists, the real one is
-    // untouched. This is the state a power cut mid-write leaves behind.
-    const file = path.join(dir, fs.readdirSync(dir)[0]);
-    fs.writeFileSync(`${file}.tmp`, JSON.stringify(record({ msAboveThreshold: 999 })));
+
+    // The whole point of writing to the side and renaming: if the new contents
+    // never make it into place, the old record is still there. Writing the file
+    // directly would instead truncate it and lose everything.
+    const rename = jest.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw Object.assign(new Error('no space left on device'), { code: 'ENOSPC' });
+    });
+    try {
+      expect(() =>
+        saveRecord('VNSD-0', 'venus1', record({ msAboveThreshold: 999 }), { immediate: true }),
+      ).not.toThrow();
+    } finally {
+      rename.mockRestore();
+    }
+
     expect(loadRecord('VNSD-0', 'venus1')?.msAboveThreshold).toBe(100);
   });
 

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -11,9 +11,19 @@ import {
 } from './persistence.js';
 import { PERSIST_SCHEMA_VERSION } from './constants.js';
 
+const createdDirs: string[] = [];
+
 function tempDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'hm2mqtt-persist-'));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hm2mqtt-persist-'));
+  createdDirs.push(dir);
+  return dir;
 }
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function record(overrides: Partial<PersistedRecord> = {}): PersistedRecord {
   return {

--- a/src/persistence.test.ts
+++ b/src/persistence.test.ts
@@ -108,19 +108,37 @@ describe('record storage', () => {
     // deviceId comes from a DEVICE_n environment variable, so it is arbitrary.
     saveRecord('VNSD-0', '../../escape', record({ msAboveThreshold: 7 }), { immediate: true });
     const written = fs.readdirSync(dir);
-    expect(written).toEqual(['VNSD-0_______escape.json']);
+    expect(written).toHaveLength(1);
+    expect(written[0]).not.toContain('/');
+    expect(written[0]).not.toContain('..');
     expect(loadRecord('VNSD-0', '../../escape')?.msAboveThreshold).toBe(7);
   });
 
+  it('keeps devices apart even when sanitising collapses their ids', () => {
+    // Sanitising is many-to-one, so without a digest these two would share one
+    // history file and silently merge.
+    saveRecord('VNSD-0', 'ab:cd', record({ msAboveThreshold: 1 }), { immediate: true });
+    saveRecord('VNSD-0', 'ab_cd', record({ msAboveThreshold: 2 }), { immediate: true });
+    expect(fs.readdirSync(dir)).toHaveLength(2);
+    expect(loadRecord('VNSD-0', 'ab:cd')?.msAboveThreshold).toBe(1);
+    expect(loadRecord('VNSD-0', 'ab_cd')?.msAboveThreshold).toBe(2);
+  });
+
+  // The filename carries a digest, so tests that need the path ask the
+  // directory for it rather than hardcoding one.
+  const fileFor = (deviceType: string, deviceId: string) => {
+    saveRecord(deviceType, deviceId, record(), { immediate: true });
+    return path.join(dir, fs.readdirSync(dir)[0]);
+  };
+
   it('ignores a record written by a different schema version', () => {
-    saveRecord('VNSD-0', 'venus1', record(), { immediate: true });
-    const file = path.join(dir, 'VNSD-0_venus1.json');
+    const file = fileFor('VNSD-0', 'venus1');
     fs.writeFileSync(file, JSON.stringify({ schemaVersion: 999, cycles: [{}] }));
     expect(loadRecord('VNSD-0', 'venus1')).toBeUndefined();
   });
 
   it('survives a corrupt file', () => {
-    const file = path.join(dir, 'VNSD-0_venus1.json');
+    const file = fileFor('VNSD-0', 'venus1');
     fs.writeFileSync(file, '{not json');
     expect(() => loadRecord('VNSD-0', 'venus1')).not.toThrow();
     expect(loadRecord('VNSD-0', 'venus1')).toBeUndefined();
@@ -134,7 +152,7 @@ describe('record storage', () => {
     saveRecord('VNSD-0', 'venus1', record({ msAboveThreshold: 100 }), { immediate: true });
     // Simulate a half-finished write: the temp file exists, the real one is
     // untouched. This is the state a power cut mid-write leaves behind.
-    const file = path.join(dir, 'VNSD-0_venus1.json');
+    const file = path.join(dir, fs.readdirSync(dir)[0]);
     fs.writeFileSync(`${file}.tmp`, JSON.stringify(record({ msAboveThreshold: 999 })));
     expect(loadRecord('VNSD-0', 'venus1')?.msAboveThreshold).toBe(100);
   });

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import { createHash } from 'crypto';
 import logger from './logger.js';
-import { CycleRecord } from './cellBalancing.js';
+import { CycleRecord, LatchCandidate } from './cellBalancing.js';
 import { PERSIST_THROTTLE_MS, PERSIST_SCHEMA_VERSION } from './constants.js';
 
 /**
@@ -29,6 +30,13 @@ export interface PersistedRecord {
   msAboveHighThreshold: number;
   localDate?: string;
   minSocPct?: number;
+  /**
+   * The latched values themselves, not just the cycle history. Without these
+   * the sensors gated on persistence go unknown after every restart until the
+   * next full charge — which would make gating them on storage pointless.
+   */
+  crossing?: LatchCandidate;
+  rested?: LatchCandidate;
   savedAt: string;
 }
 
@@ -101,6 +109,9 @@ export function isPersistenceAvailable(): boolean {
 /** Test seam. */
 export function resetPersistenceProbe(override?: PersistenceProbe): void {
   probed = override;
+  pending.clear();
+  lastWriteAt.clear();
+  lastWritten.clear();
 }
 
 function fileFor(deviceType: string, deviceId: string): string | undefined {
@@ -109,10 +120,13 @@ function fileFor(deviceType: string, deviceId: string): string | undefined {
     return undefined;
   }
   // deviceId comes straight from a DEVICE_n environment variable, so it is
-  // arbitrary user input. Sanitised the same way topics are, which also stops a
-  // path separator escaping the directory the probe blessed.
+  // arbitrary user input. Sanitising stops a path separator escaping the
+  // directory the probe blessed, but it is many-to-one — 'ab:cd' and 'ab_cd'
+  // both become 'ab_cd' — so a short digest of the originals keeps two devices
+  // from silently sharing one history file.
   const safe = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, '_');
-  return path.join(dir, `${safe(deviceType)}_${safe(deviceId)}.json`);
+  const digest = createHash('sha1').update(`${deviceType}\u0000${deviceId}`).digest('hex');
+  return path.join(dir, `${safe(deviceType)}_${safe(deviceId)}-${digest.slice(0, 8)}.json`);
 }
 
 export function loadRecord(deviceType: string, deviceId: string): PersistedRecord | undefined {
@@ -140,6 +154,7 @@ export function loadRecord(deviceType: string, deviceId: string): PersistedRecor
 
 const pending = new Map<string, PersistedRecord>();
 const lastWriteAt = new Map<string, number>();
+const lastWritten = new Map<string, PersistedRecord>();
 
 function writeNow(file: string, record: PersistedRecord): void {
   const tmp = `${file}.tmp`;
@@ -167,10 +182,30 @@ function writeNow(file: string, record: PersistedRecord): void {
     }
 
     lastWriteAt.set(file, Date.now());
+    lastWritten.set(file, record);
     pending.delete(file);
   } catch (error) {
+    // Stamp the attempt even though it failed, so a permanently unwritable
+    // filesystem — the read-only mount or full SD card this throttle exists for
+    // — retries on the throttle interval rather than on every single poll, with
+    // a warning each time.
+    lastWriteAt.set(file, Date.now());
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // Nothing useful to do; the next write overwrites it anyway.
+    }
     logger.warn(`Could not write cell balancing history to ${file}:`, error);
   }
+}
+
+/** Compare two records ignoring the timestamp, which changes on every sample. */
+function sameContent(a: PersistedRecord | undefined, b: PersistedRecord): boolean {
+  if (a == null) {
+    return false;
+  }
+  const strip = ({ savedAt: _savedAt, ...rest }: PersistedRecord) => rest;
+  return JSON.stringify(strip(a)) === JSON.stringify(strip(b));
 }
 
 /**
@@ -186,6 +221,12 @@ export function saveRecord(
 ): void {
   const file = fileFor(deviceType, deviceId);
   if (file == null) {
+    return;
+  }
+
+  // A pack sitting idle produces an identical record every poll. Writing it
+  // would put an fsync on the SD card every throttle interval for nothing.
+  if (!immediate && sameContent(lastWritten.get(file), record)) {
     return;
   }
 

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -125,7 +125,7 @@ function fileFor(deviceType: string, deviceId: string): string | undefined {
   // both become 'ab_cd' — so a short digest of the originals keeps two devices
   // from silently sharing one history file.
   const safe = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, '_');
-  const digest = createHash('sha1').update(`${deviceType}\u0000${deviceId}`).digest('hex');
+  const digest = createHash('sha256').update(`${deviceType}\u0000${deviceId}`).digest('hex');
   return path.join(dir, `${safe(deviceType)}_${safe(deviceId)}-${digest.slice(0, 8)}.json`);
 }
 
@@ -145,7 +145,14 @@ export function loadRecord(deviceType: string, deviceId: string): PersistedRecor
       );
       return undefined;
     }
-    return { ...parsed, cycles: Array.isArray(parsed.cycles) ? parsed.cycles : [] };
+    const counter = (value: unknown) =>
+      typeof value === 'number' && Number.isFinite(value) ? value : 0;
+    return {
+      ...parsed,
+      cycles: Array.isArray(parsed.cycles) ? parsed.cycles : [],
+      msAboveThreshold: counter(parsed.msAboveThreshold),
+      msAboveHighThreshold: counter(parsed.msAboveHighThreshold),
+    };
   } catch (error) {
     logger.warn(`Could not read cell balancing history from ${file}:`, error);
     return undefined;

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,0 +1,206 @@
+import fs from 'fs';
+import path from 'path';
+import logger from './logger.js';
+import { CycleRecord } from './cellBalancing.js';
+import { PERSIST_THROTTLE_MS, PERSIST_SCHEMA_VERSION } from './constants.js';
+
+/**
+ * The only runtime filesystem access in the project.
+ *
+ * Charge-cycle history has to outlive the process: comparing the spread at the
+ * top of charge from one day to the next is the whole point, and an add-on
+ * update must not reset it. Everything else the diagnostics publish is
+ * recomputed from the next poll and needs no storage.
+ */
+
+const DEFAULT_DATA_DIR = '/data';
+const SUBDIRECTORY = 'cell-balancing';
+
+export interface PersistenceProbe {
+  available: boolean;
+  dir?: string;
+  reason?: string;
+}
+
+export interface PersistedRecord {
+  schemaVersion: number;
+  cycles: CycleRecord[];
+  msAboveThreshold: number;
+  msAboveHighThreshold: number;
+  localDate?: string;
+  minSocPct?: number;
+  savedAt: string;
+}
+
+/**
+ * Decide whether there is somewhere durable to write.
+ *
+ * The subtle case is the standalone Docker image: it declares no VOLUME, has no
+ * /data, and runs as root, so simply creating the directory would succeed — into
+ * the container's writable layer, which `docker compose pull` throws away. That
+ * is precisely the update this file exists to survive, so a default directory we
+ * had to create ourselves counts as *not* available. An explicitly configured
+ * directory is taken at face value: asking for it is the user saying they meant
+ * it.
+ */
+export function probeDataDir(
+  env: NodeJS.ProcessEnv = process.env,
+  defaultDir: string = DEFAULT_DATA_DIR,
+): PersistenceProbe {
+  const configured = env.HM2MQTT_DATA_DIR;
+  const base = configured ?? defaultDir;
+
+  if (configured == null && !fs.existsSync(base)) {
+    return {
+      available: false,
+      reason:
+        `${base} does not exist. Cell balancing history needs somewhere durable to live: ` +
+        `mount a volume at ${base}, or set HM2MQTT_DATA_DIR to a directory that persists.`,
+    };
+  }
+
+  const dir = path.join(base, SUBDIRECTORY);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const probeFile = path.join(dir, '.write-test');
+    fs.writeFileSync(probeFile, '');
+    fs.unlinkSync(probeFile);
+    return { available: true, dir };
+  } catch (error) {
+    return {
+      available: false,
+      reason: `${dir} is not writable (${error instanceof Error ? error.message : String(error)})`,
+    };
+  }
+}
+
+let probed: PersistenceProbe | undefined;
+
+/**
+ * Memoized so the probe runs once, on first use. Deliberately lazy rather than
+ * a module-level side effect: discovery consults this through a predicate that
+ * is called on every publish, so there is no need to touch the filesystem while
+ * modules are still being imported.
+ */
+export function getPersistence(): PersistenceProbe {
+  if (probed == null) {
+    probed = probeDataDir();
+    if (probed.available) {
+      logger.info(`Cell balancing history will be stored in ${probed.dir}`);
+    } else {
+      logger.info(`Cell balancing history is disabled: ${probed.reason}`);
+    }
+  }
+  return probed;
+}
+
+export function isPersistenceAvailable(): boolean {
+  return getPersistence().available;
+}
+
+/** Test seam. */
+export function resetPersistenceProbe(override?: PersistenceProbe): void {
+  probed = override;
+}
+
+function fileFor(deviceType: string, deviceId: string): string | undefined {
+  const { available, dir } = getPersistence();
+  if (!available || dir == null) {
+    return undefined;
+  }
+  // deviceId comes straight from a DEVICE_n environment variable, so it is
+  // arbitrary user input. Sanitised the same way topics are, which also stops a
+  // path separator escaping the directory the probe blessed.
+  const safe = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return path.join(dir, `${safe(deviceType)}_${safe(deviceId)}.json`);
+}
+
+export function loadRecord(deviceType: string, deviceId: string): PersistedRecord | undefined {
+  const file = fileFor(deviceType, deviceId);
+  if (file == null || !fs.existsSync(file)) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (parsed?.schemaVersion !== PERSIST_SCHEMA_VERSION) {
+      // Either older than we understand or written by a newer version we have
+      // been rolled back from. Starting fresh beats crashing on it.
+      logger.warn(
+        `Ignoring cell balancing history in ${file}: schema version ${parsed?.schemaVersion} is not ${PERSIST_SCHEMA_VERSION}`,
+      );
+      return undefined;
+    }
+    return { ...parsed, cycles: Array.isArray(parsed.cycles) ? parsed.cycles : [] };
+  } catch (error) {
+    logger.warn(`Could not read cell balancing history from ${file}:`, error);
+    return undefined;
+  }
+}
+
+const pending = new Map<string, PersistedRecord>();
+const lastWriteAt = new Map<string, number>();
+
+function writeNow(file: string, record: PersistedRecord): void {
+  const tmp = `${file}.tmp`;
+  try {
+    const fd = fs.openSync(tmp, 'w');
+    try {
+      fs.writeFileSync(fd, JSON.stringify(record));
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, file);
+
+    // Without this the rename itself can be lost after a power cut even though
+    // the file contents were flushed.
+    try {
+      const dirFd = fs.openSync(path.dirname(file), 'r');
+      try {
+        fs.fsyncSync(dirFd);
+      } finally {
+        fs.closeSync(dirFd);
+      }
+    } catch {
+      // Directory fsync is not supported everywhere; the rename is still atomic.
+    }
+
+    lastWriteAt.set(file, Date.now());
+    pending.delete(file);
+  } catch (error) {
+    logger.warn(`Could not write cell balancing history to ${file}:`, error);
+  }
+}
+
+/**
+ * Store a record. Written immediately when a charge cycle completes, otherwise
+ * at most once per throttle interval — most add-on installs run from an SD card,
+ * and the running counters change on every poll.
+ */
+export function saveRecord(
+  deviceType: string,
+  deviceId: string,
+  record: PersistedRecord,
+  { immediate = false }: { immediate?: boolean } = {},
+): void {
+  const file = fileFor(deviceType, deviceId);
+  if (file == null) {
+    return;
+  }
+
+  pending.set(file, record);
+  const last = lastWriteAt.get(file);
+  if (immediate || last == null || Date.now() - last >= PERSIST_THROTTLE_MS) {
+    writeNow(file, record);
+  }
+}
+
+/** Write anything the throttle is still holding. */
+export function flushPersistence(): void {
+  // writeNow deletes the entry it just wrote; removing the current key during
+  // Map iteration is well defined, so this needs no snapshot.
+  for (const [file, record] of pending) {
+    writeNow(file, record);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,12 +52,34 @@ export function isValidB2500RechargeMode(mode: string): mode is B2500RechargeMod
 export type B2500V1ChargingMode = 'chargeThenDischarge' | 'pv2PassThrough';
 export type B2500V2ChargingMode = 'chargeDischargeSimultaneously' | 'chargeThenDischarge';
 
+/**
+ * Per-pack status flags decoded from the `l0`/`l1` bitmasks (firmware 212.17
+ * and later). Reported per battery pack, unlike the combined `pe` state of
+ * charge.
+ */
+export interface B2500PackStatus {
+  discharging?: boolean;
+  charging?: boolean;
+  dodReached?: boolean;
+  undervoltage?: boolean;
+}
+
 export interface B2500BaseDeviceData extends BaseDeviceData {
   // Battery information
   batteryPercentage?: number;
   batteryCapacity?: number;
   batteryOutputThreshold?: number;
   dischargeDepth?: number;
+
+  /**
+   * Per-pack charge/discharge status. Absent on firmware older than 212.17,
+   * which does not report `l0`/`l1` at all.
+   */
+  packStatus?: {
+    host?: B2500PackStatus;
+    extra1?: B2500PackStatus;
+    extra2?: B2500PackStatus;
+  };
 
   // Solar input information
   solarInputStatus?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,6 +192,14 @@ export interface CellBalancingData extends BaseDeviceData {
     meanMv?: number;
     /** Each cell's share of the spread; the direct test for the slide artifact. */
     normalisedDeviations?: number[];
+    /**
+     * How much of the spread the highest cell owns, as a percentage. Constant
+     * while the whole stack drifts down together, falling when that cell is
+     * actually brought back into line.
+     */
+    highestCellSharePct?: number;
+    /** Which cell that is, numbered from 1. */
+    highestCell?: number;
     driftMvPerHour?: number;
     balanceConditionsMet?: boolean;
     minutesAboveThreshold?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,37 @@ export interface B2500CellData extends BaseDeviceData {
   };
 }
 
+/**
+ * Derived cell balancing diagnostics. Shared by every family that reports
+ * individual cell voltages; the values themselves are computed in
+ * cellBalancing.ts and never come from a device payload.
+ *
+ * Everything lives under a single key so that the derived fields do not join
+ * the flat namespace that DeviceManager.getDeviceState() merges every path into.
+ */
+export interface CellBalancingData extends BaseDeviceData {
+  cellBalancing?: {
+    spreadMv?: number;
+    sigmaMv?: number;
+    meanMv?: number;
+    /** Each cell's share of the spread; the direct test for the slide artifact. */
+    normalisedDeviations?: number[];
+    driftMvPerHour?: number;
+    balanceConditionsMet?: boolean;
+    minutesAboveThreshold?: number;
+    minutesAboveHighThreshold?: number;
+    sessionMinutes?: number;
+    /** Comparable end-of-charge spread, interpolated at a fixed mean voltage. */
+    crossingSpreadMv?: number;
+    crossingSigmaMv?: number;
+    /** Spread an hour after charging stopped, free of IR contamination. */
+    restedSpreadMv?: number;
+    restedSigmaMv?: number;
+    lastCycleEndedAt?: string;
+    cycleCount?: number;
+  };
+}
+
 export interface B2500CalibrationData extends BaseDeviceData {
   charge?: number;
   discharge?: number;


### PR DESCRIPTION
## Summary

*Cell Voltage Difference* is easy to misread. After a full charge it collapses overnight from tens of millivolts to one or two, which looks like the pack balancing itself. Usually it isn't: at 100% with nothing to export the unit disconnects its solar input and runs off the battery, so every cell drains equally and slides off the steep top of the LFP curve onto its flat middle, where the same imbalance shows up as a much smaller gap. Nothing was corrected — the ruler changed.

This adds diagnostics that tell the two apart, behind `CELL_BALANCING_DIAGNOSTICS` (default off, requires `POLL_CELL_DATA`). B2500, Greensolar storage and Venus.

## The metrics

**Normalised deviations are the discriminator.** The artifact is *defined* by relative cell state of charge being unchanged, so a stack drifting down together keeps every cell's share of the spread constant while the spread collapses. A share that falls cannot be explained that way. Exposed as *Highest Cell Share of Spread*, with the full per-cell vector in the payload.

**Two latches, both defined analytically** rather than by "when charging stopped", which jitters by a poll interval and lands at whatever the taper current happened to be:

- *Cell Spread at 3450 mV* — interpolated between the two samples bracketing a fixed mean voltage, so it is an iso-SoC point on the steep part of the curve. Sampling rate affects interpolation error only, never which point is measured. Confirmed by the following sample so a single spike cannot latch.
- *Rested Cell Spread* — median of the samples an hour after charging stops, with the pack measurably idle (|I| ≤ 0.5 A). The clock starts on the charging→idle transition, not on idleness, or it would fire every evening at whatever state of charge the discharge left. A load appearing mid-window abandons the measurement rather than restarting it somewhere arbitrary. Families that report no pack current never latch this at all, since "idle" and "discharging into the house" are indistinguishable without one.

**Drift** — least-squares slope of the mean cell voltage over 30 minutes. Quantisation is not the limiting noise (averaging 16 cells gives σ ≈ 0.07 mV); a load step is, worth ~12 mV/h of spurious slope against a ~4 mV/h signal. So: gated on the pack having stayed under 1 A across the window, with residual-outlier rejection and a linearity check that suppresses the post-charge relaxation transient.

**Counters** — time above 3400 mV and above 3500 mV separately. At 3.40 V an hour of bleed moves a cell about half a millivolt; at 3.50 V it moves several times further, so one combined total would imply they are equivalent.

## Structure

- `src/cellBalancing.ts` — pure functions: statistics, drift, the state machine, per-family adapters.
- `src/device/cellBalancingMessage.ts` — registers the derived message shared by both families.
- `src/persistence.ts` — the project's only runtime file I/O.
- New `derive` on `MessageDefinition`: computed from other messages' state, never polled, never parsed. It receives per-path state rather than `getDeviceState()`'s shallow merge, whose `timestamp` is ambiguous. Returning `undefined` publishes nothing, which is what stops eight state updates per poll cycle on a Venus for a value that did not move.

Sample hygiene throughout: readings outside 2.0–4.0 V never enter a statistic, latches take a whole sample rather than medianing fields independently, durations come from a monotonic clock, time accrues only between samples actually observed, and a changing cell count discards the drift window.

## Persistence

`${HM2MQTT_DATA_DIR}/cell-balancing/<device>.json`, default `/data`, which Supervisor already mounts — so the add-on needs no configuration. Docker users mount a volume; without one the cross-cycle entities are not advertised and the log says why.

The probe deliberately refuses a default `/data` it had to create itself: the standalone image declares no `VOLUME` and runs as root, so `mkdir` would succeed into the container's writable layer and the history would vanish on the next `docker compose pull` — the exact update it exists to survive.

Restored: cycle history, daily counters, and the latched values themselves. Discarded: any in-flight session and the drift window, because we cannot know what the pack did while we were not running.

Writes are atomic (temp file, fsync, rename, directory fsync) and throttled, with completed cycles written straight through.

## Also in here

- **Derived messages are kept out of the shared polling tick.** It runs at the GCD of every message's interval, and a derived message — computed locally, never requested — would otherwise contribute one. Adds `MessageDefinition.polled`, on top of the `enabled` filtering from #414.
- B2500 `l0`/`l1` per-pack status flags, documented in `docs/b2500.md` but never parsed.
- The history is flushed on shutdown, through the bounded, independently-guarded step mechanism #414 added — so a hung MQTT proxy cannot cost you the flush, and a failed flush cannot cost you the clean disconnect.

## Notes on the day boundary

`todayLocalDate` uses container-local time. Node bundles full ICU, so `TZ` is honoured in the standalone image without installing `tzdata`; the add-on gets `TZ` from Supervisor.

## Validation

```
npm run lint && npm run format:check && npm test -- --runInBand && npm run build
```

563 tests. Beyond unit tests, a synthetic charge → hold → rest sequence was replayed through the built code with faked clocks: injecting 4 mV/h of sag recovered −4.35 mV/h, the crossing latch interpolated to 40.00 mV, the rested latch fired and recorded a cycle, and a second process against the same directory restored the history while correctly discarding the in-flight session and drift window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cell Balancing Diagnostics for B2500, Greensolar, and Venus devices, including cell spread, voltage drift, balancing status, charge-cycle, and rest metrics.
  * Added optional per-pack status indicators for supported B2500 devices.
  * Added persistent diagnostic history across restarts when storage is available.
  * Expanded cell-data, calibration, and battery-data support and documentation.

* **Bug Fixes**
  * Improved environment loading, graceful shutdown, MQTT termination, and polling behavior.
  * Corrected Venus BMS Current units and expanded supported-device descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->