### PR TITLE
Venus: report BMS current in amps, not milliamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Fixed
 
+- Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values
+
 - B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)
 - Venus & Jupiter: Fix the tens digit of the minutes being dropped when setting a *Time Period X Time From/To* before 10:00. Setting `02:43` made the device store `02:03` and report that back to Home Assistant, and any later change to the same period (power, weekday, enabled) re-applied the mangled time (fixes #184, PR #401)
 - B2500 V2/V3, Venus & Jupiter: Stop Home Assistant flooding the log with `Template variable warning: 'dict object' has no attribute 'meterType'` (and the same for `meterMac`) on every poll once the *Meter Type* or *Meter MAC* entity was enabled. The device never reports either setting back, so both entities now simply show the last value that was set. *Meter MAC* also no longer fails with `Value "" … doesn't match pattern ^[0-9A-Fa-f]{12}$` (fixes #346)

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -2295,12 +2295,16 @@ function registerBMSInfoMessage(
             stateClass: 'measurement',
           },
         ],
+        // Pack current is reported in deci-amps (e.g. -94 -> -9.4 A), signed
+        // negative while discharging. Jupiter's cd=14 response uses the same key
+        // at the same scale.
         [
           'b_cur',
           {
             id: 'current',
             deviceClass: 'current',
-            unitOfMeasurement: 'mA',
+            unitOfMeasurement: 'A',
+            transform: divide(10),
             stateClass: 'measurement',
           },
         ],

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1439,6 +1439,10 @@ describe('MQTT Message Parser', () => {
     const result = parsed['bms'] as VenusBMSInfo;
     expect(result.bms?.voltage).toBeCloseTo(52.23);
     expect(result.bms?.chargeVoltage).toBeCloseTo(57.1);
+    // Deci-amps, negative while discharging: -9.4 A across 52.23 V is about
+    // 490 W. Read as the milliamps this used to claim it would have been 4.9 W,
+    // which is not a pack under load at all.
+    expect(result.bms?.current).toBeCloseTo(-9.4);
     // Other Venus variants already report temperatures in whole degrees.
     expect(result.bms?.mosfetTemp).toBe(23);
     expect(result.cells?.temperatures?.[0]).toBe(18);


### PR DESCRIPTION
## What changed

Venus `b_cur` (cd=14) was published verbatim and labelled milliamps. It is deci-amps, so *BMS Current* read 100× too low. It now uses `divide(10)` with unit `A`.

## Why

The milliamp label was never sourced from anything — `docs/venus.md` has no cd=14 section at all. Three independent things say deci-amps:

- **Field reading.** A VNSD reporting `-72` while discharging at night is −7.2 A, roughly 370 W on a ~51 V pack. As milliamps it would imply 3.7 W, which is not a pack under load.
- **Firmware sample.** The `b_cur=-94` sample in `venus.ts` works out the same way: −9.4 A across the 52.23 V the same payload reports.
- **Internal inconsistency.** Jupiter's cd=14 response carries the identical `b_cur` key and already uses `divide(10)` — `parser.test.ts` asserts `6.3` A for `b_cur=63`. The two families were being read at scales 100× apart from the same command.

Sign convention is negative for discharge, positive for charge.

## Impact

User-visible: the entity's unit and value both change. History recorded before this update keeps the old values, so graphs will show a step. Nothing else reads the field.

## How it was validated

```
npm run lint && npm run format:check && npm test -- --runInBand && npm run build
```

482 tests pass. Added an assertion on the Venus sample covering the new scale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Venus BMS current is now reported in amps with correct scaling and sign.
  * Existing recorded history remains unchanged and retains its previous values.

* **Documentation**
  * Updated the changelog to clarify the current-unit change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->