### PR TITLE
Force re-read of commanded messages after control writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Fixed
 
-- Settings you change from Home Assistant now show the value the device accepted within about a second. Changing something like *Discharge Depth*, *Charging Mode* or *Adaptive Mode* was supposed to trigger an immediate read-back, but that read-back was skipped whenever the device had been read recently — so whether the entity updated straight away or sat on its old value until the next poll (up to a minute with the default polling interval) depended on when you happened to change it
+- Settings you change from Home Assistant, such as *Discharge Depth* or *Charging Mode*, sometimes kept showing their old value for up to a minute. They now update within about a second
 - Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values
 
 - B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Fixed
 
+- Settings you change from Home Assistant now show the value the device accepted within about a second. Changing something like *Discharge Depth*, *Charging Mode* or *Adaptive Mode* was supposed to trigger an immediate read-back, but that read-back was skipped whenever the device had been read recently — so whether the entity updated straight away or sat on its old value until the next poll (up to a minute with the default polling interval) depended on when you happened to change it
 - Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values
 
 - B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Fixed
 
-- Settings you change from Home Assistant, such as *Discharge Depth* or *Charging Mode*, sometimes kept showing their old value for up to a minute. They now update within about a second
+- Settings you change from Home Assistant, such as *Discharge Depth* or *Charging Mode*, sometimes kept showing their old value for up to a minute. They now update within about a second (PR #413)
 - Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values
 
 - B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)

--- a/src/controlHandler.test.ts
+++ b/src/controlHandler.test.ts
@@ -3,8 +3,19 @@ import './device/registry.js';
 import logger from './logger.js';
 import { ControlHandler } from './controlHandler.js';
 import { DeviceManager, DeviceStateData } from './deviceManager.js';
+import { getDeviceDefinition } from './deviceDefinition.js';
 import { MqttConfig, Device, B2500V2DeviceData, B2500BaseDeviceData } from './types.js';
 import { DEFAULT_TOPIC_PREFIX } from './constants.js';
+
+/**
+ * Build a ControlHandler whose publish callback records only `(device, payload)`.
+ * The handler also passes the index of the message definition owning the command,
+ * which is covered separately below; dropping it here keeps the payload
+ * assertions in this file exact.
+ */
+function controlHandlerFor(deviceManager: DeviceManager, publishCallback: jest.Mock) {
+  return new ControlHandler(deviceManager, (device, payload) => publishCallback(device, payload));
+}
 
 describe('ControlHandler', () => {
   let controlHandler: ControlHandler;
@@ -46,7 +57,7 @@ describe('ControlHandler', () => {
     deviceManager.updateDeviceState(testDeviceV1, 'data', () => ({ useFlashCommands: true }));
     deviceManager.updateDeviceState(testDeviceV2, 'data', () => ({ useFlashCommands: true }));
     publishCallback = jest.fn();
-    controlHandler = new ControlHandler(deviceManager, publishCallback);
+    controlHandler = controlHandlerFor(deviceManager, publishCallback);
   });
 
   afterEach(() => {
@@ -429,7 +440,7 @@ describe('ControlHandler', () => {
       };
       deviceManager = new DeviceManager(config, () => {});
       publishCallback = jest.fn();
-      controlHandler = new ControlHandler(deviceManager, publishCallback);
+      controlHandler = controlHandlerFor(deviceManager, publishCallback);
     });
 
     test('should fold the switched phase into the reported bitmask', () => {
@@ -467,7 +478,7 @@ describe('ControlHandler', () => {
         };
         deviceManager = new DeviceManager(config, () => {});
         publishCallback = jest.fn();
-        controlHandler = new ControlHandler(deviceManager, publishCallback);
+        controlHandler = controlHandlerFor(deviceManager, publishCallback);
 
         handleControlTopic(device, 'phase1-measurement-reversed', 'true');
         expect(publishCallback).toHaveBeenCalledWith(device, expected);
@@ -496,7 +507,7 @@ describe('ControlHandler', () => {
       };
       deviceManager = new DeviceManager(config, () => {});
       publishCallback = jest.fn();
-      controlHandler = new ControlHandler(deviceManager, publishCallback);
+      controlHandler = controlHandlerFor(deviceManager, publishCallback);
 
       handleControlTopic(smr, 'phase1-measurement-reversed', 'true');
 
@@ -518,7 +529,7 @@ describe('ControlHandler', () => {
       };
       deviceManager = new DeviceManager(config, () => {});
       publishCallback = jest.fn();
-      controlHandler = new ControlHandler(deviceManager, publishCallback);
+      controlHandler = controlHandlerFor(deviceManager, publishCallback);
     };
 
     test.each(['HME-4', 'TPM-CN', 'TPM2-0', 'SMR-0'])(
@@ -544,6 +555,33 @@ describe('ControlHandler', () => {
 
       handleControlTopic(device, 'factory-reset', 'off');
       expect(publishCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('commanded message index', () => {
+    test('reports the message definition that declares the command', () => {
+      const indices: number[] = [];
+      const handler = new ControlHandler(deviceManager, (_device, _payload, messageIndex) => {
+        indices.push(messageIndex);
+      });
+      const deviceTopics = deviceManager.getDeviceTopics(testDeviceV2);
+      if (!deviceTopics) {
+        throw new Error('Device topics not found');
+      }
+      handler.handleControlTopic(
+        testDeviceV2,
+        `${deviceTopics.controlSubscriptionTopic}/discharge-depth`,
+        '75',
+      );
+
+      expect(indices).toHaveLength(1);
+      const messages = getDeviceDefinition(testDeviceV2.deviceType)?.messages ?? [];
+      const commanded = messages[indices[0]];
+      // It has to point at the runtime message that declares `discharge-depth`,
+      // not at the separately polled cell-voltage or calibration messages: the
+      // index is what decides which message gets re-read after the write.
+      expect(commanded.commands.map(c => c.command)).toContain('discharge-depth');
+      expect(commanded.refreshDataPayload).toBe('cd=1');
     });
   });
 });

--- a/src/controlHandler.ts
+++ b/src/controlHandler.ts
@@ -45,11 +45,13 @@ export class ControlHandler {
    * Create a new ControlHandler
    *
    * @param deviceManager - Device manager instance
-   * @param publishCallback - Callback to publish messages
+   * @param publishCallback - Callback to publish messages. `messageIndex` is the
+   *   index of the message definition the command belongs to, so the caller can
+   *   re-read exactly that message after the write instead of every message.
    */
   constructor(
     private deviceManager: DeviceManager,
-    private publishCallback: (device: Device, payload: string) => void,
+    private publishCallback: (device: Device, payload: string, messageIndex: number) => void,
   ) {}
 
   /**
@@ -71,11 +73,13 @@ export class ControlHandler {
       const controlTopicBase = topics.controlSubscriptionTopic;
       const controlPath = topic.substring(controlTopicBase.length + 1); // +1 for the slash
       const deviceDefinition = getDeviceDefinition(device.deviceType);
-      for (const messageDefinition of deviceDefinition?.messages ?? []) {
+      for (const [messageIndex, messageDefinition] of (
+        deviceDefinition?.messages ?? []
+      ).entries()) {
         const handlerParams: ControlHandlerParams<any> = {
           device,
           message,
-          publishCallback: payload => this.publishCallback(device, payload),
+          publishCallback: payload => this.publishCallback(device, payload, messageIndex),
           deviceState: this.deviceManager.getDeviceState(device) as any,
           updateDeviceState: update =>
             this.deviceManager.updateDeviceState(

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1812,7 +1812,11 @@ describe('Device Commands', () => {
     deviceManager.updateDeviceState(device, 'data', () => baseState);
 
     publishCallback = jest.fn();
-    controlHandler = new ControlHandler(deviceManager, publishCallback);
+    // Record only `(device, payload)`; the message index the handler also passes
+    // is covered in controlHandler.test.ts and is not what these cases assert.
+    controlHandler = new ControlHandler(deviceManager, (device, payload) =>
+      publishCallback(device, payload),
+    );
 
     return device;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ async function main() {
     mqttClient = new MqttClient(config, deviceManager, messageHandler);
 
     // Create control handler
-    const controlHandler = new ControlHandler(deviceManager, (device, payload) => {
+    const controlHandler = new ControlHandler(deviceManager, (device, payload, messageIndex) => {
       const topics = deviceManager.getDeviceTopics(device);
 
       if (!topics) {
@@ -263,7 +263,10 @@ async function main() {
           // Wait a short delay to allow the device to process the command
           setTimeout(() => {
             logger.debug(`Requesting updated device data for ${device.deviceId} after command`);
-            mqttClient.requestDeviceData(device);
+            // Force the message the command belongs to: without this the read-back
+            // is dropped whenever that message was polled less than one polling
+            // interval ago, which is most of the time.
+            mqttClient.requestDeviceData(device, { forceMessageIndices: [messageIndex] });
           }, 500);
         })
         .catch(err => {

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -254,3 +254,129 @@ describe('MqttClient shouldPoll gating', () => {
     expect(payloads).not.toContain('cd=42,bms_idx=2');
   });
 });
+
+describe('MqttClient forced refresh', () => {
+  const topics = {
+    deviceTopicOld: 'hame_energy/HMA-1/device/b2500/ctrl',
+    deviceTopicNew: 'marstek_energy/HMA-1/device/b2500/ctrl',
+    publishTopic: 'homeassistant/HMA-1/device/b2500/data',
+    deviceControlTopicOld: 'hame_energy/HMA-1/App/b2500/ctrl',
+    deviceControlTopicNew: 'marstek_energy/HMA-1/App/b2500/ctrl',
+    controlSubscriptionTopic: 'homeassistant/HMA-1/control/b2500/control',
+    availabilityTopic: 'homeassistant/HMA-1/availability/b2500',
+  };
+
+  const device: Device = { deviceType: 'HMA-1', deviceId: 'b2500' };
+
+  function makeMessage(overrides: any) {
+    return {
+      isMessage: () => true,
+      getAdditionalDeviceInfo: () => ({}),
+      // Long enough that nothing is ever due again during a test
+      pollInterval: 60000,
+      controlsDeviceAvailability: false,
+      enabled: true,
+      ...overrides,
+    };
+  }
+
+  /**
+   * Poll once so every message has a recent `lastRequestTime`, then return a
+   * client that is well inside its polling interval.
+   */
+  function setUpPolledClient(messages: any[], state: any = {}) {
+    mockGetDeviceDefinition.mockReturnValue({ messages } as any);
+    const deviceManager: any = {
+      getDeviceTopics: () => topics,
+      getDeviceState: () => state,
+      getDevices: () => [],
+      getResponseTimeout: () => 5000,
+      setResponseTimeout: jest.fn(),
+      clearResponseTimeout: jest.fn(),
+    };
+    const config: any = {
+      brokerUrl: 'mqtt://localhost:1883',
+      clientId: 'test-client',
+      topicPrefix: 'homeassistant',
+      autodiscoveryTopicPrefix: 'homeassistant',
+    };
+    const mqttClient = new MqttClient(config, deviceManager, jest.fn());
+    mqttClient.requestDeviceData(device);
+    jest.advanceTimersByTime(1000);
+    mockPublish.mockClear();
+    return mqttClient;
+  }
+
+  function payloadsAfter(fn: () => void): string[] {
+    fn();
+    jest.advanceTimersByTime(1000);
+    return mockPublish.mock.calls.map((c: any[]) => c[1]);
+  }
+
+  const runtime = () =>
+    makeMessage({
+      refreshDataPayload: 'cd=1',
+      publishPath: 'data',
+      controlsDeviceAvailability: true,
+    });
+  const cells = (overrides: any = {}) =>
+    makeMessage({ refreshDataPayload: 'cd=13', publishPath: 'cells', ...overrides });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('re-reads only the forced message while the poll interval is still running', () => {
+    const mqttClient = setUpPolledClient([runtime(), cells()]);
+
+    // Without forcing, nothing is due yet
+    expect(payloadsAfter(() => mqttClient.requestDeviceData(device))).toEqual([]);
+
+    const payloads = payloadsAfter(() =>
+      mqttClient.requestDeviceData(device, { forceMessageIndices: [0] }),
+    );
+    expect(payloads).toContain('cd=1');
+    expect(payloads).not.toContain('cd=13');
+  });
+
+  test('re-anchors the poll schedule so a forced read is not followed by a due one', () => {
+    const mqttClient = setUpPolledClient([runtime()]);
+
+    expect(payloadsAfter(() => mqttClient.requestDeviceData(device))).toEqual([]);
+    mockPublish.mockClear();
+
+    payloadsAfter(() => mqttClient.requestDeviceData(device, { forceMessageIndices: [0] }));
+    mockPublish.mockClear();
+
+    // The forced read counts as this interval's poll
+    expect(payloadsAfter(() => mqttClient.requestDeviceData(device))).toEqual([]);
+  });
+
+  test('does not force a disabled message', () => {
+    const mqttClient = setUpPolledClient([runtime(), cells({ enabled: false })]);
+
+    expect(
+      payloadsAfter(() => mqttClient.requestDeviceData(device, { forceMessageIndices: [1] })),
+    ).toEqual([]);
+  });
+
+  test('does not force a message its poll predicate rules out', () => {
+    const mqttClient = setUpPolledClient([runtime(), cells({ shouldPoll: () => false })]);
+
+    expect(
+      payloadsAfter(() => mqttClient.requestDeviceData(device, { forceMessageIndices: [1] })),
+    ).toEqual([]);
+  });
+
+  test('ignores an out-of-range index', () => {
+    const mqttClient = setUpPolledClient([runtime()]);
+
+    expect(
+      payloadsAfter(() => mqttClient.requestDeviceData(device, { forceMessageIndices: [7] })),
+    ).toEqual([]);
+  });
+});

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -280,18 +280,15 @@ describe('MqttClient forced refresh', () => {
     };
   }
 
-  /**
-   * Poll once so every message has a recent `lastRequestTime`, then return a
-   * client that is well inside its polling interval.
-   */
-  function setUpPolledClient(messages: any[], state: any = {}) {
+  function makeClient(messages: any[], state: any = {}) {
     mockGetDeviceDefinition.mockReturnValue({ messages } as any);
+    const setResponseTimeout = jest.fn();
     const deviceManager: any = {
       getDeviceTopics: () => topics,
       getDeviceState: () => state,
       getDevices: () => [],
       getResponseTimeout: () => 5000,
-      setResponseTimeout: jest.fn(),
+      setResponseTimeout,
       clearResponseTimeout: jest.fn(),
     };
     const config: any = {
@@ -300,7 +297,15 @@ describe('MqttClient forced refresh', () => {
       topicPrefix: 'homeassistant',
       autodiscoveryTopicPrefix: 'homeassistant',
     };
-    const mqttClient = new MqttClient(config, deviceManager, jest.fn());
+    return { mqttClient: new MqttClient(config, deviceManager, jest.fn()), setResponseTimeout };
+  }
+
+  /**
+   * Poll once so every message has a recent `lastRequestTime`, then return a
+   * client that is well inside its polling interval.
+   */
+  function setUpPolledClient(messages: any[], state: any = {}) {
+    const { mqttClient } = makeClient(messages, state);
     mqttClient.requestDeviceData(device);
     jest.advanceTimersByTime(1000);
     mockPublish.mockClear();
@@ -313,11 +318,12 @@ describe('MqttClient forced refresh', () => {
     return mockPublish.mock.calls.map((c: any[]) => c[1]);
   }
 
-  const runtime = () =>
+  const runtime = (overrides: any = {}) =>
     makeMessage({
       refreshDataPayload: 'cd=1',
       publishPath: 'data',
       controlsDeviceAvailability: true,
+      ...overrides,
     });
   const cells = (overrides: any = {}) =>
     makeMessage({ refreshDataPayload: 'cd=13', publishPath: 'cells', ...overrides });
@@ -344,16 +350,28 @@ describe('MqttClient forced refresh', () => {
   });
 
   test('re-anchors the poll schedule so a forced read is not followed by a due one', () => {
-    const mqttClient = setUpPolledClient([runtime()]);
+    // Not the availability message: advancing past its response timeout below
+    // would publish `offline` and pollute the payload assertion.
+    const mqttClient = setUpPolledClient([cells()]);
 
-    expect(payloadsAfter(() => mqttClient.requestDeviceData(device))).toEqual([]);
-    mockPublish.mockClear();
-
+    // The regular poll ran at t=0, so the next one is due at t=60000. Forcing a
+    // read at t=1000 has to move that deadline to t=61000.
     payloadsAfter(() => mqttClient.requestDeviceData(device, { forceMessageIndices: [0] }));
     mockPublish.mockClear();
 
-    // The forced read counts as this interval's poll
+    // Land at t=60500, between the two deadlines. Without re-anchoring the
+    // message reads as due here and this request would publish.
+    jest.advanceTimersByTime(58500);
     expect(payloadsAfter(() => mqttClient.requestDeviceData(device))).toEqual([]);
+  });
+
+  test('does not arm the availability timeout for a disabled message', () => {
+    // A disabled message is never requested, so nothing would ever arrive to
+    // clear a timeout armed on its behalf and the device would go offline.
+    const { mqttClient, setResponseTimeout } = makeClient([runtime({ enabled: false }), cells()]);
+
+    expect(payloadsAfter(() => mqttClient.requestDeviceData(device))).toEqual(['cd=13', 'cd=13']);
+    expect(setResponseTimeout).not.toHaveBeenCalled();
   });
 
   test('does not force a disabled message', () => {

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -354,25 +354,24 @@ export class MqttClient {
     // (e.g. only polling per-pack BMS details for packs that are present).
     const pollState = (this.deviceManager.getDeviceState(device) ?? {}) as BaseDeviceData;
 
-    // A forced message is re-read regardless of when it was last requested, but
-    // it still has to be enabled and pass its poll predicate — forcing must not
-    // poll something the configuration or the device state rules out.
-    const forced = new Set(
-      (options?.forceMessageIndices ?? []).filter(idx => {
-        const message = deviseDefinition.messages[idx];
-        return (
-          message != null &&
-          message.enabled &&
-          (!message.shouldPoll || message.shouldPoll(pollState))
-        );
-      }),
-    );
+    // A forced message is re-read regardless of when it was last requested. Both
+    // loops below still skip disabled messages and messages their poll predicate
+    // rules out before consulting this set, so forcing can only bypass the
+    // timing gate, never the configuration or the device state.
+    const forced = new Set(options?.forceMessageIndices ?? []);
 
     // Find the first message that needs to be refreshed
     let now = Date.now();
     let needsRefresh = false;
     let shouldStartTimeout = false;
     for (const [idx, message] of deviseDefinition.messages.entries()) {
+      // A disabled message is never requested below, so it must not make the
+      // device look due for a refresh. It would otherwise arm the availability
+      // timeout on every poll without ever sending a request to clear it, and
+      // a responsive device would be marked offline.
+      if (!message.enabled) {
+        continue;
+      }
       if (message.shouldPoll && !message.shouldPoll(pollState)) {
         continue;
       }

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -327,8 +327,12 @@ export class MqttClient {
    * Request device data
    *
    * @param device - The device configuration
+   * @param options.forceMessageIndices - Indices of message definitions to re-read
+   *   even though their poll interval has not elapsed yet. Used after a control
+   *   command so the entity reflects what the device actually accepted instead of
+   *   waiting up to a full polling interval.
    */
-  requestDeviceData(device: Device): void {
+  requestDeviceData(device: Device, options?: { forceMessageIndices?: readonly number[] }): void {
     const topics = this.deviceManager.getDeviceTopics(device);
     const deviseDefinition = getDeviceDefinition(device.deviceType);
 
@@ -350,6 +354,20 @@ export class MqttClient {
     // (e.g. only polling per-pack BMS details for packs that are present).
     const pollState = (this.deviceManager.getDeviceState(device) ?? {}) as BaseDeviceData;
 
+    // A forced message is re-read regardless of when it was last requested, but
+    // it still has to be enabled and pass its poll predicate — forcing must not
+    // poll something the configuration or the device state rules out.
+    const forced = new Set(
+      (options?.forceMessageIndices ?? []).filter(idx => {
+        const message = deviseDefinition.messages[idx];
+        return (
+          message != null &&
+          message.enabled &&
+          (!message.shouldPoll || message.shouldPoll(pollState))
+        );
+      }),
+    );
+
     // Find the first message that needs to be refreshed
     let now = Date.now();
     let needsRefresh = false;
@@ -360,7 +378,11 @@ export class MqttClient {
       }
       let lastRequestTimeKey = `${device.deviceId}:${idx}`;
       const lastRequestTime = this.lastRequestTime.get(lastRequestTimeKey);
-      if (lastRequestTime == null || now > lastRequestTime + message.pollInterval) {
+      if (
+        forced.has(idx) ||
+        lastRequestTime == null ||
+        now > lastRequestTime + message.pollInterval
+      ) {
         needsRefresh = true;
         shouldStartTimeout = shouldStartTimeout || message.controlsDeviceAvailability;
       }
@@ -404,7 +426,13 @@ export class MqttClient {
 
       let lastRequestTimeKey = `${device.deviceId}:${idx}`;
       const lastRequestTime = this.lastRequestTime.get(lastRequestTimeKey);
-      if (lastRequestTime == null || now > lastRequestTime + message.pollInterval) {
+      if (
+        forced.has(idx) ||
+        lastRequestTime == null ||
+        now > lastRequestTime + message.pollInterval
+      ) {
+        // Re-anchor the schedule so a forced read does not leave a regular poll
+        // due a moment later.
         this.lastRequestTime.set(lastRequestTimeKey, now);
         const payload = message.refreshDataPayload;
         setTimeout(


### PR DESCRIPTION
## Summary

Settings changed from Home Assistant (e.g., *Discharge Depth*, *Charging Mode*) sometimes kept showing their old value for up to a minute. This fix ensures that the message containing a command is re-read immediately after the write, so the entity reflects what the device actually accepted instead of waiting up to a full polling interval.

## Changes

- **MqttClient**: Added `forceMessageIndices` option to `requestDeviceData()` to allow re-reading specific messages even when their poll interval has not elapsed. Forced messages still respect the `enabled` flag and `shouldPoll` predicate, and re-anchor the poll schedule to prevent a forced read from being immediately followed by a regular poll.

- **ControlHandler**: Modified the `publishCallback` signature to include a `messageIndex` parameter, identifying which message definition declares the command. This allows the caller to force re-read only that specific message after the write.

- **index.ts**: Updated the control handler callback to pass the message index and call `requestDeviceData()` with `forceMessageIndices` containing that index, ensuring the read-back happens within ~500ms instead of waiting up to a full polling interval.

- **Tests**: Added comprehensive test suite for forced refresh behavior, including edge cases (disabled messages, poll predicates, out-of-range indices). Updated existing test helpers to accommodate the new callback signature.

## Validation

- All existing tests pass
- New test suite covers forced refresh logic, schedule re-anchoring, and predicate/enabled checks
- No configuration changes required

https://claude.ai/code/session_01Sncjq1yPU8KPxFpfWNzG5D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Home Assistant settings now refresh within about a second instead of potentially remaining stale for up to a minute.
  * Device data refreshes immediately after control commands, ensuring updated values are read back reliably.
  * Forced refreshes respect enabled-state and polling eligibility rules without triggering unnecessary scheduled polls.
  * Disabled or ineligible data points are excluded from refresh requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->