### PR TITLE
Fix .env loading, SIGTERM shutdown, polling tick and option descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### Fixed
 
+- Settings in a `.env` file were ignored; only real environment variables took effect. Affects manual installations only
+- hm2mqtt now shuts down cleanly when stopped by Home Assistant or Docker, which send a signal it did not handle. The MQTT connection is now closed properly instead of the process being killed after a grace period
+- Devices were polled more often than configured. Options that are switched off still pulled the shared polling timer faster than any device needed, which showed up at *Polling Interval* values that are not a multiple of 60 seconds
+- The descriptions of *Enable Cell Data*, *Enable Calibration Data* and *Enable Extra Battery Data* said B2500 only. All three also work on Greensolar storage, and *Enable Cell Data* additionally covers Venus and Jupiter
 - Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values
 
 - B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 
 ### Fixed
 
-- Settings in a `.env` file were ignored; only real environment variables took effect. Affects manual installations only
-- hm2mqtt now shuts down cleanly when stopped by Home Assistant or Docker, which send a signal it did not handle. The MQTT connection is now closed properly instead of the process being killed after a grace period. With the MQTT proxy enabled, a device that was still connected could hold the shutdown open indefinitely; each step now gives up after a few seconds so the restart always completes
-- Devices were polled more often than configured. Options that are switched off still pulled the shared polling timer faster than any device needed, which showed up at *Polling Interval* values that are not a multiple of 60 seconds
-- The descriptions of *Enable Cell Data*, *Enable Calibration Data* and *Enable Extra Battery Data* said B2500 only. All three also work on Greensolar storage, and *Enable Cell Data* additionally covers Venus and Jupiter
+- Settings in a `.env` file were ignored; only real environment variables took effect. Manual installations only (PR #414)
+- hm2mqtt now shuts down cleanly when Home Assistant or Docker stops it, instead of being killed after the grace period (PR #414)
+- Devices were polled more often than the configured *Polling Interval* (PR #414)
+- *Enable Cell Data*, *Enable Calibration Data* and *Enable Extra Battery Data* said B2500 only. All three also cover Greensolar storage, and *Enable Cell Data* also Venus and Jupiter (PR #414)
 - Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values
 
 - B2500 V2/V3: Fix *Sync Time* setting the device clock wrong, which made every discharge timer start and stop early by your timezone's offset from UTC — two hours in CEST, one in CET. A device that was synced by an affected version keeps the wrong clock until it is synced again, so press *Sync Time* once after updating (PR #405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 
 - Settings in a `.env` file were ignored; only real environment variables took effect. Affects manual installations only
-- hm2mqtt now shuts down cleanly when stopped by Home Assistant or Docker, which send a signal it did not handle. The MQTT connection is now closed properly instead of the process being killed after a grace period
+- hm2mqtt now shuts down cleanly when stopped by Home Assistant or Docker, which send a signal it did not handle. The MQTT connection is now closed properly instead of the process being killed after a grace period. With the MQTT proxy enabled, a device that was still connected could hold the shutdown open indefinitely; each step now gives up after a few seconds so the restart always completes
 - Devices were polled more often than configured. Options that are switched off still pulled the shared polling timer faster than any device needed, which showed up at *Polling Interval* values that are not a multiple of 60 seconds
 - The descriptions of *Enable Cell Data*, *Enable Calibration Data* and *Enable Extra Battery Data* said B2500 only. All three also work on Greensolar storage, and *Enable Cell Data* additionally covers Venus and Jupiter
 - Venus: *BMS Current* was reported in milliamps and read 100x too low — a pack drawing 9.4 A showed 94 mA. It now reports amps, matching the same field on Jupiter. History recorded before this update keeps the old values

--- a/README.md
+++ b/README.md
@@ -283,9 +283,9 @@ services:
 | `MQTT_PASSWORD` | MQTT password | -                       |
 | `MQTT_POLLING_INTERVAL` | Interval between device polls in seconds | `60`                 |
 | `MQTT_RESPONSE_TIMEOUT` | Timeout for device responses in seconds | `15`                 |
-| `POLL_CELL_DATA` | Enable cell-level battery data (individual cell voltages, temperatures and, on Venus, detailed per-pack BMS data) | false |
-| `POLL_EXTRA_BATTERY_DATA` | Enable extra battery data reporting (only available on B2500 devices) | false |
-| `POLL_CALIBRATION_DATA` | Enable calibration data reporting (only available on B2500 devices) | false |
+| `POLL_CELL_DATA` | Enable cell-level battery data: individual cell voltages and temperatures, plus detailed per-pack BMS data on Venus. B2500, Greensolar, Venus and Jupiter | false |
+| `POLL_EXTRA_BATTERY_DATA` | Enable extra battery data reporting (B2500 and Greensolar storage only) | false |
+| `POLL_CALIBRATION_DATA` | Enable calibration data reporting (B2500 and Greensolar storage only) | false |
 | `DEVICE_n` | Device configuration in format `{type}:{mac}` | -                       |
 | `MQTT_ALLOWED_CONSECUTIVE_TIMEOUTS` | Number of consecutive timeouts before a device is marked offline | `3` |
 | `MQTT_PROXY_ENABLED` | Enable MQTT proxy server for B2500 client ID conflict resolution | `false` |

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -7,13 +7,13 @@ configuration:
     description: "Timeout in Sekunden für Geräteantworten bevor das Gerät als offline deklariert wird (Standard: 30)"
   enableCellData:
     name: "Zellspannung"
-    description: "Aktiviere Abruf der Zellenspannung (nur verfügbar für B2500)"
+    description: "Aktiviere Abruf der Zellenspannung (B2500, Greensolar, Venus und Jupiter). Bei Venus zusätzlich detaillierte BMS-Daten je Batteriepack"
   enableCalibrationData:
     name: "Kalibrierungsdaten"
-    description: "Aktiviere Abruf der Kalibrierungsdaten (nur verfügbar für B2500)"
+    description: "Aktiviere Abruf der Kalibrierungsdaten (nur B2500 und Greensolar)"
   enableExtraBatteryData:
     name: "Zusätzliche Batteriedaten"
-    description: "Aktiviere Abruf zusätzlicher Batteriedaten (nur verfügbar für B2500)"
+    description: "Aktiviere Abruf zusätzlicher Batteriedaten (nur B2500 und Greensolar)"
   allowedConsecutiveTimeouts:
     name: Maximale aufeinanderfolgende Timeouts
     description: "Anzahl aufeinanderfolgender Timeouts, bevor ein Gerät als offline markiert wird (Standard: 3)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -7,13 +7,13 @@ configuration:
     description: "Timeout in seconds for device responses before considering the device to be offline (default: 30)"
   enableCellData:
     name: Enable Cell Data
-    description: "Enable cell voltage (only available on B2500 devices)"
+    description: "Enable cell voltage data (B2500, Greensolar, Venus and Jupiter). On Venus it also adds detailed per-pack BMS data"
   enableCalibrationData:
     name: Enable Calibration Data
-    description: "Enable calibration data reporting (only available on B2500 devices)"
+    description: "Enable calibration data reporting (B2500 and Greensolar storage only)"
   enableExtraBatteryData:
     name: Enable Extra Battery Data
-    description: "Enable extra battery data reporting (only available on B2500 devices)"
+    description: "Enable extra battery data reporting (B2500 and Greensolar storage only)"
   allowedConsecutiveTimeouts:
     name: Allowed Consecutive Timeouts
     description: "Number of consecutive timeouts before a device is marked offline (default: 3)"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,3 +18,10 @@ export const DEFAULT_AUTODISCOVERY_TOPIC_PREFIX = 'homeassistant';
  * not lower this floor; a longer one wins.
  */
 export const MIN_PHASE_ENERGY_POLL_INTERVAL_MS = 300000;
+
+/**
+ * How long a single shutdown step may take before it is abandoned. Docker's
+ * default grace period before SIGKILL is 10s, so both steps together have to
+ * finish well inside it for the clean shutdown to be worth anything.
+ */
+export const SHUTDOWN_STEP_TIMEOUT_MS = 3000;

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import './device/registry.js';
 import { DeviceManager } from './deviceManager.js';
+import { registerDeviceDefinition } from './deviceDefinition.js';
 import { MqttConfig } from './types.js';
 import { DEFAULT_TOPIC_PREFIX } from './constants.js';
 import { calculateNewVersionTopicId } from './utils/crypt.js';
@@ -255,6 +256,62 @@ describe('DeviceManager', () => {
       const stats = (b2500.getDeviceState(hma) as any).dailyStats;
       expect(stats.batteryChargingPower).toBe(100); // corrupt drop rejected
       expect(stats.batteryDischargePower).toBe(60); // sibling increase preserved
+    });
+  });
+
+  describe('getPollingInterval', () => {
+    // The shared polling timer runs at the GCD of every message's interval, so a
+    // single badly chosen interval speeds up polling for every device in the
+    // process. None of this was covered before.
+    const defineType = (
+      deviceType: string,
+      messages: { pollInterval: number; enabled?: boolean }[],
+    ) => {
+      registerDeviceDefinition({ deviceTypes: [deviceType] }, ({ message }) => {
+        messages.forEach((options, idx) => {
+          message(
+            {
+              refreshDataPayload: `cd=${idx}`,
+              isMessage: () => false,
+              publishPath: `path${idx}`,
+              defaultState: {},
+              getAdditionalDeviceInfo: () => ({}),
+              controlsDeviceAvailability: false,
+              ...options,
+            },
+            () => {},
+          );
+        });
+      });
+    };
+
+    const intervalFor = (deviceType: string) =>
+      new DeviceManager(
+        { ...mockConfig, devices: [{ deviceType, deviceId: 'gcd' }] },
+        jest.fn(),
+      ).getPollingInterval();
+
+    it('returns the greatest common divisor of the polled intervals', () => {
+      defineType('TESTGCDPLAIN', [{ pollInterval: 60000 }, { pollInterval: 300000 }]);
+      expect(intervalFor('TESTGCDPLAIN')).toBe(60000);
+    });
+
+    it('ignores disabled messages', () => {
+      // 7000 is deliberately not a divisor of 60000: were it counted, the tick
+      // would collapse to 1000 ms for every device in the process.
+      defineType('TESTGCDDISABLED', [
+        { pollInterval: 60000 },
+        { pollInterval: 7000, enabled: false },
+      ]);
+      expect(intervalFor('TESTGCDDISABLED')).toBe(60000);
+    });
+
+    it('falls back to the unfiltered set rather than leaving the tick undefined', () => {
+      defineType('TESTGCDNONE', [
+        { pollInterval: 30000, enabled: false },
+        { pollInterval: 45000, enabled: false },
+      ]);
+      expect(intervalFor('TESTGCDNONE')).toBe(15000);
     });
   });
 });

--- a/src/deviceManager.ts
+++ b/src/deviceManager.ts
@@ -5,6 +5,7 @@ import {
   getSuggestedDeviceType,
   FieldDefinition,
   KeyPath,
+  MessageDefinition,
 } from './deviceDefinition.js';
 import { calculateNewVersionTopicId } from './utils/crypt.js';
 import logger from './logger.js';
@@ -348,20 +349,29 @@ export class DeviceManager {
    * @returns The polling interval in milliseconds
    */
   getPollingInterval(): number {
-    const allPollingIntervals = this.getDevices().flatMap(device => {
-      return (
-        getDeviceDefinition(device.deviceType)
-          ?.messages.map(message => {
-            return message.pollInterval;
-          })
-          ?.filter(n => n != null) ?? []
+    const collect = (filter: (message: MessageDefinition<any>) => boolean): number[] =>
+      this.getDevices().flatMap(
+        device =>
+          getDeviceDefinition(device.deviceType)
+            ?.messages.filter(filter)
+            .map(message => message.pollInterval)
+            .filter(n => n != null) ?? [],
       );
-    });
+
+    const allPollingIntervals = collect(() => true);
 
     // Check if there are any valid polling intervals
     if (allPollingIntervals.length === 0) {
       throw new Error('No valid devices configured');
     }
+
+    // Only messages that are actually requested from the device get a say in
+    // the tick. A disabled message — POLL_CELL_DATA=false, say — is never sent,
+    // so letting it contribute drives the shared timer faster than anything
+    // needs. Fall back to the unfiltered set if that leaves nothing, so the tick
+    // stays defined.
+    const polledIntervals = collect(message => message.enabled !== false);
+    const intervals = polledIntervals.length > 0 ? polledIntervals : allPollingIntervals;
 
     function gcd2(a: number, b: number): number {
       if (b === 0) {
@@ -370,7 +380,7 @@ export class DeviceManager {
       return gcd2(b, a % b);
     }
 
-    return allPollingIntervals.reduce(gcd2, allPollingIntervals[0]);
+    return intervals.reduce(gcd2, intervals[0]);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
-import * as dotenv from 'dotenv';
-// Load environment variables
-dotenv.config();
-
+// Must stay the first import: it loads `.env`, and the device definitions read
+// environment variables while they are being imported.
+import './loadEnv.js';
 import './device/registry.js';
 import { Device, MqttConfig } from './types.js';
 import { DEFAULT_AUTODISCOVERY_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX } from './constants.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,18 +301,35 @@ async function main() {
       logger.info('MQTT Proxy is disabled (set MQTT_PROXY_ENABLED=true to enable)');
     }
 
-    // Handle process termination
-    process.on('SIGINT', async () => {
-      logger.info('Shutting down...');
-
-      if (mqttProxy) {
-        logger.info('Stopping MQTT Proxy...');
-        await mqttProxy.stop();
+    // Handle process termination. SIGTERM matters as much as SIGINT: Docker and
+    // the Home Assistant Supervisor both send it to stop a container, so without
+    // a handler an ordinary restart or add-on update skipped this path entirely
+    // and the container was killed after the grace period instead.
+    let shuttingDown = false;
+    const shutdown = async (signal: string) => {
+      if (shuttingDown) {
+        return;
       }
+      shuttingDown = true;
+      logger.info(`Received ${signal}, shutting down...`);
 
-      await mqttClient.close();
-      process.exit();
-    });
+      // Best-effort: a rejection here must not stop the process exiting, or the
+      // container hangs until it is killed anyway.
+      try {
+        if (mqttProxy) {
+          logger.info('Stopping MQTT Proxy...');
+          await mqttProxy.stop();
+        }
+
+        await mqttClient.close();
+      } catch (error) {
+        logger.error('Error during shutdown:', error);
+      } finally {
+        process.exit();
+      }
+    };
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
 
     logger.debug('Application initialized successfully');
   } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { ControlHandler } from './controlHandler.js';
 import logger from './logger.js';
 import { DataHandler } from './dataHandler.js';
 import { MqttProxy, MqttProxyConfig } from './mqttProxy.js';
+import { runShutdownStep } from './shutdown.js';
 
 // MQTT Proxy configuration
 const MQTT_PROXY_ENABLED = process.env.MQTT_PROXY_ENABLED === 'true';
@@ -313,20 +314,22 @@ async function main() {
       shuttingDown = true;
       logger.info(`Received ${signal}, shutting down...`);
 
-      // Best-effort: a rejection here must not stop the process exiting, or the
-      // container hangs until it is killed anyway.
-      try {
-        if (mqttProxy) {
-          logger.info('Stopping MQTT Proxy...');
-          await mqttProxy.stop();
-        }
-
-        await mqttClient.close();
-      } catch (error) {
-        logger.error('Error during shutdown:', error);
-      } finally {
-        process.exit();
+      // Each step is independent and time-bounded, because neither failing nor
+      // hanging may keep the process alive. MqttProxy.stop() waits for its TCP
+      // server to close, and a TCP server does not close while a client still
+      // holds a connection open — so a device that is still connected would
+      // otherwise block the exit until the runtime killed us, which is the
+      // outcome this handler exists to avoid. A failure to stop the proxy must
+      // also not cost us the MQTT close, which is what publishes the offline
+      // availability.
+      const proxy = mqttProxy;
+      if (proxy) {
+        logger.info('Stopping MQTT Proxy...');
+        await runShutdownStep('stopping the MQTT proxy', () => proxy.stop());
       }
+      await runShutdownStep('closing the MQTT connection', () => mqttClient.close());
+
+      process.exit();
     };
     process.on('SIGINT', () => shutdown('SIGINT'));
     process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/src/loadEnv.test.ts
+++ b/src/loadEnv.test.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const srcDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * This asserts on the *source order* of two imports rather than on behaviour,
+ * which is unusual but is the only thing that actually guards the invariant.
+ *
+ * `.env` is loaded by importing `./loadEnv.js`, and the device definitions read
+ * `process.env` while they are being imported (the `POLL_*` flags, and
+ * `globalPollInterval` in deviceDefinition.ts). ESM evaluates imports in source
+ * order, so if `./device/registry.js` is ever moved above `./loadEnv.js` — or if
+ * someone "tidies up" by moving the dotenv call back into the body of index.ts —
+ * every value in `.env` is silently ignored again. No runtime assertion catches
+ * that, because the flags simply fall back to their defaults.
+ */
+describe('environment loading order', () => {
+  const indexSource = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf8');
+
+  test('loadEnv is imported before the device registry', () => {
+    const loadEnvIndex = indexSource.indexOf("import './loadEnv.js'");
+    const registryIndex = indexSource.indexOf("import './device/registry.js'");
+
+    expect(loadEnvIndex).toBeGreaterThanOrEqual(0);
+    expect(registryIndex).toBeGreaterThanOrEqual(0);
+    expect(loadEnvIndex).toBeLessThan(registryIndex);
+  });
+
+  test('dotenv is not invoked from the body of index.ts', () => {
+    expect(indexSource).not.toContain('dotenv.config()');
+  });
+});

--- a/src/loadEnv.ts
+++ b/src/loadEnv.ts
@@ -1,0 +1,12 @@
+import * as dotenv from 'dotenv';
+
+// `.env` has to be loaded before any module that reads `process.env` while it is
+// being imported. Several do: `globalPollInterval` in deviceDefinition.ts and the
+// `POLL_*` flags in the device definitions are all evaluated at import time.
+//
+// ESM evaluates every import of a module before that module's own body, so a
+// `dotenv.config()` call in the body of index.ts runs *after* the device
+// definitions have already been registered — the values in `.env` were silently
+// ignored. Keeping the call in its own module and importing it first is what
+// guarantees the ordering.
+dotenv.config();

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -254,19 +254,20 @@ describe('MqttClient shouldPoll gating', () => {
     expect(payloads).not.toContain('cd=42,bms_idx=2');
   });
 
-  function pollPayloadsFor(messages: any[]): string[] {
+  function pollFor(messages: any[]): { payloads: string[]; setResponseTimeout: jest.Mock } {
     jest.useFakeTimers();
     try {
       mockGetDeviceDefinition.mockReturnValue({ messages } as any);
       mockPublish.mockClear();
 
       const device: Device = { deviceType: 'VNSD-0', deviceId: 'venus1' };
+      const setResponseTimeout = jest.fn();
       const deviceManager: any = {
         getDeviceTopics: () => topics,
         getDeviceState: () => ({}),
         getDevices: () => [],
         getResponseTimeout: () => 5000,
-        setResponseTimeout: jest.fn(),
+        setResponseTimeout,
         clearResponseTimeout: jest.fn(),
       };
       const config: any = {
@@ -280,17 +281,36 @@ describe('MqttClient shouldPoll gating', () => {
       mqttClient.requestDeviceData(device);
       jest.advanceTimersByTime(1000);
 
-      return mockPublish.mock.calls.map((c: any[]) => c[1]);
+      return { payloads: mockPublish.mock.calls.map((c: any[]) => c[1]), setResponseTimeout };
     } finally {
       jest.useRealTimers();
     }
   }
 
   test('sends nothing at all when every message is disabled', () => {
-    const payloads = pollPayloadsFor([
+    const { payloads } = pollFor([
       makeMessage({ refreshDataPayload: 'cd=13', publishPath: 'cells', enabled: false }),
       makeMessage({ refreshDataPayload: 'cd=21', publishPath: 'calibration', enabled: false }),
     ]);
     expect(payloads).toEqual([]);
+  });
+
+  test('a disabled message does not arm a response timeout it can never answer', () => {
+    // The send loop always skipped disabled messages, so the assertion above
+    // held before this change too. This is the behaviour that actually moved:
+    // the due-check loop used to see the disabled message, mark the device as
+    // needing a refresh and — because the message controls availability — arm a
+    // response timeout for a request that is never sent. Nothing could answer
+    // it, so it would fire and count towards marking the device offline.
+    const { payloads, setResponseTimeout } = pollFor([
+      makeMessage({
+        refreshDataPayload: 'cd=1',
+        publishPath: 'data',
+        controlsDeviceAvailability: true,
+        enabled: false,
+      }),
+    ]);
+    expect(payloads).toEqual([]);
+    expect(setResponseTimeout).not.toHaveBeenCalled();
   });
 });

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -253,4 +253,44 @@ describe('MqttClient shouldPoll gating', () => {
     expect(payloads).not.toContain('cd=42,bms_idx=1');
     expect(payloads).not.toContain('cd=42,bms_idx=2');
   });
+
+  function pollPayloadsFor(messages: any[]): string[] {
+    jest.useFakeTimers();
+    try {
+      mockGetDeviceDefinition.mockReturnValue({ messages } as any);
+      mockPublish.mockClear();
+
+      const device: Device = { deviceType: 'VNSD-0', deviceId: 'venus1' };
+      const deviceManager: any = {
+        getDeviceTopics: () => topics,
+        getDeviceState: () => ({}),
+        getDevices: () => [],
+        getResponseTimeout: () => 5000,
+        setResponseTimeout: jest.fn(),
+        clearResponseTimeout: jest.fn(),
+      };
+      const config: any = {
+        brokerUrl: 'mqtt://localhost:1883',
+        clientId: 'test-client',
+        topicPrefix: 'homeassistant',
+        autodiscoveryTopicPrefix: 'homeassistant',
+      };
+
+      const mqttClient = new MqttClient(config, deviceManager, jest.fn());
+      mqttClient.requestDeviceData(device);
+      jest.advanceTimersByTime(1000);
+
+      return mockPublish.mock.calls.map((c: any[]) => c[1]);
+    } finally {
+      jest.useRealTimers();
+    }
+  }
+
+  test('sends nothing at all when every message is disabled', () => {
+    const payloads = pollPayloadsFor([
+      makeMessage({ refreshDataPayload: 'cd=13', publishPath: 'cells', enabled: false }),
+      makeMessage({ refreshDataPayload: 'cd=21', publishPath: 'calibration', enabled: false }),
+    ]);
+    expect(payloads).toEqual([]);
+  });
 });

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -355,6 +355,14 @@ export class MqttClient {
     let needsRefresh = false;
     let shouldStartTimeout = false;
     for (const [idx, message] of deviseDefinition.messages.entries()) {
+      // Mirror the skip applied when actually sending, below. Without it a
+      // message that is never sent never gets a `lastRequestTime`, so it stays
+      // permanently "due" and `needsRefresh` is always true — which made the
+      // early return below dead code on every device that has a disabled
+      // message (i.e. all of them, whenever POLL_CELL_DATA is off).
+      if (!message.enabled) {
+        continue;
+      }
       if (message.shouldPoll && !message.shouldPoll(pollState)) {
         continue;
       }

--- a/src/shutdown.test.ts
+++ b/src/shutdown.test.ts
@@ -1,0 +1,46 @@
+import { runShutdownStep } from './shutdown.js';
+
+describe('runShutdownStep', () => {
+  test('awaits a step that resolves', async () => {
+    let finished = false;
+    await runShutdownStep('doing the thing', async () => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      finished = true;
+    });
+    expect(finished).toBe(true);
+  });
+
+  test('survives a step that rejects', async () => {
+    await expect(
+      runShutdownStep('doing the thing', async () => {
+        throw new Error('nope');
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test('survives a step that throws synchronously', async () => {
+    await expect(
+      runShutdownStep('doing the thing', () => {
+        throw new Error('nope');
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test('gives up on a step that never settles (regression: proxy stop blocked the exit)', async () => {
+    // MqttProxy.stop() resolves only once its TCP server closes, which never
+    // happens while a device still holds a connection open. Without the
+    // timeout the shutdown handler awaits forever and process.exit() is never
+    // reached, so the container is killed after the grace period instead.
+    const start = Date.now();
+    await expect(runShutdownStep('hanging', () => new Promise<void>(() => {}), 20)).resolves.toBe(
+      undefined,
+    );
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  test('does not wait out the timeout when the step finishes early', async () => {
+    const start = Date.now();
+    await runShutdownStep('quick', async () => {}, 60000);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -1,0 +1,34 @@
+import { SHUTDOWN_STEP_TIMEOUT_MS } from './constants.js';
+import logger from './logger.js';
+
+/**
+ * Run one shutdown step, swallowing both a rejection and a step that never
+ * settles. Always resolves, so the caller can continue to the next step and to
+ * `process.exit()` regardless of what happened here.
+ *
+ * The timeout is the point: `MqttProxy.stop()` waits for its TCP server to
+ * close, and a TCP server does not close while a client still holds a
+ * connection open. A device that is still connected would otherwise block the
+ * exit until the runtime killed the container.
+ */
+export async function runShutdownStep(
+  what: string,
+  step: () => Promise<void>,
+  timeoutMs: number = SHUTDOWN_STEP_TIMEOUT_MS,
+): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      step(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+        // Never hold the event loop open on our own account.
+        timer.unref();
+      }),
+    ]);
+  } catch (error) {
+    logger.error(`Error during shutdown while ${what}:`, error);
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary

Four independent fixes, split out of #411 so that PR is only the cell balancing feature. Each is a standalone bug on `develop` today.

## What changed

**`.env` was silently ignored.** `dotenv.config()` ran in the body of `index.ts`, but `import './device/registry.js'` sits above it and ESM evaluates every import before any body statement — so the device definitions read `process.env.POLL_CELL_DATA` and friends before `.env` was loaded. `README.md` tells users to configure exactly those flags that way. It has been harmless only because the documented values happen to match the defaults. Moved into `src/loadEnv.ts`, imported first, with a test asserting the import order so it cannot regress.

Verified: `MQTT_POLLING_INTERVAL=17` in `.env` produced a 60000 ms tick before, 17000 ms after.

**No `SIGTERM` handler existed.** Only `SIGINT` was handled, so Docker and the Home Assistant Supervisor — both of which stop a container with `SIGTERM` — skipped the shutdown path entirely and the process was killed after the grace period, without closing the MQTT connection. Added, sharing one guarded handler with `SIGINT`.

Adding it made an existing hazard reachable, which is fixed here too: `MqttProxy.stop()` resolves only once its TCP server closes, and a TCP server does not close while a client still holds a connection open. With the proxy enabled and a device still connected the `await` never returned, so `process.exit()` was never reached and the container was killed anyway — the exact outcome the handler exists to prevent. Sharing one `try` was nearly as bad: a failure stopping the proxy skipped the `mqttClient.close()` that publishes offline availability. Each step now runs independently through `runShutdownStep`, which logs and swallows a rejection and gives up after 3s, well inside Docker's 10s default grace period.

**Disabled messages pulled the shared polling tick faster than anything needed.** The timer runs at the GCD of every message's poll interval, and messages behind a `POLL_*` flag contributed theirs even while switched off and never sent. Visible at `MQTT_POLLING_INTERVAL` values that are not a multiple of 60 s. The same omission in the first loop of `requestDeviceData` meant a disabled message never got a `lastRequestTime`, stayed permanently due, and kept `needsRefresh` true — making the early return dead code on every device with a disabled message. Worse, a disabled message that controls device availability would arm a response timeout for a request that was never sent; nothing could answer it, so it fired and counted towards marking the device offline. The GCD had no test coverage at all; it does now.

**Option descriptions named the wrong devices.** All three `POLL_*` options also apply to the HMK Greensolar storage v3, which shares the B2500 v2 definition, so "B2500 only" told those owners the toggles did not apply to them. *Enable Cell Data* was further out: it drives the Venus and Jupiter BMS messages too. Corrected in `README.md` and both add-on translations.

## Validation

```
npm run lint && npm run format:check && npm test -- --runInBand && npm run build
```

494 tests pass. Both behavioural fixes were checked against a deliberately reverted source to confirm the new tests actually fail without them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Environment settings are now recognized reliably at startup.
  - Polling avoids running more frequently than necessary and ignores disabled data requests.
  - Shutdown responds to common stop signals, closes MQTT cleanly, and continues even if cleanup fails or times out.

- **Documentation**
  - Clarified supported storage devices and data options, including Greensolar, Venus, and Jupiter.
  - Added details about per-pack BMS data available for Venus devices.

- **Tests**
  - Expanded coverage for polling, disabled requests, environment loading, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->