### PR TITLE
Mark cell balancing diagnostics as experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- B2500, Greensolar & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that measure the cell spread at the same point of every charge, so it can be compared between days. Requires *Enable Cell Data*. Experimental: which sensors exist, and the thresholds behind them, may still change between releases. See the README for what each sensor means (PR #411)
+- B2500, Greensolar & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that measure the cell spread at the same point of every charge, so it can be compared between days. Requires *Enable Cell Data*. Experimental: which sensors exist, and the thresholds behind them, may still change between releases. See the README for what each sensor means (PR #411, PR #416)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- B2500, Greensolar & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that measure the cell spread at the same point of every charge, so it can be compared between days. Requires *Enable Cell Data*. See the README for what each sensor means (PR #411)
+- B2500, Greensolar & Venus: New *Enable Cell Balancing Diagnostics* option, adding sensors that measure the cell spread at the same point of every charge, so it can be compared between days. Requires *Enable Cell Data*. Experimental: which sensors exist, and the thresholds behind them, may still change between releases. See the README for what each sensor means (PR #411)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,11 @@ services:
 
 > **📖 Background**: This issue was first reported in [GitHub Issue #41](https://github.com/tomquist/hm2mqtt/issues/41) where users experienced problems with multiple B2500 devices after firmware update 226.5.
 
-### Cell Balancing Diagnostics
+### Cell Balancing Diagnostics (experimental)
+
+**Experimental.** Which sensors exist, and the thresholds behind them, may still change
+between releases, so an entity you build a dashboard or automation on could be renamed or
+dropped. Feedback on whether the numbers match what your pack actually does is welcome.
 
 B2500, Greensolar storage and Venus. Set `CELL_BALANCING_DIAGNOSTICS=true` and
 `POLL_CELL_DATA=true` (add-on: *Enable Cell Balancing Diagnostics* and *Enable Cell Data*).

--- a/README.md
+++ b/README.md
@@ -450,9 +450,25 @@ successive days. The per-cell vector is published as `normalisedDeviations`, wit
 Cell* naming the outlier.
 
 No Marstek device reports whether its balancer is running, so all of this is inferred from
-voltage and current. The two day-to-day sensors also need storage that survives a restart:
-the add-on has it, under Docker mount a volume at `/data` or point `HM2MQTT_DATA_DIR`
-somewhere else.
+voltage and current.
+
+*Cell Spread at 3450 mV* and *Rested Cell Spread* compare one day against the next, so they
+need storage that outlives a container rebuild. The add-on already has it. Under Docker,
+mount something at `/data` — without it those two entities are not created at all, and the
+log says why at startup:
+
+```yaml
+services:
+  hm2mqtt:
+    volumes:
+      - hm2mqtt-data:/data
+
+volumes:
+  hm2mqtt-data:
+```
+
+With `docker run` that is `-v hm2mqtt-data:/data`. A bind mount to a host directory works
+just as well, and `HM2MQTT_DATA_DIR` moves the location if `/data` does not suit.
 
 ## Frequently Asked Questions (FAQ)
 

--- a/ha_addon/translations/de.yaml
+++ b/ha_addon/translations/de.yaml
@@ -15,8 +15,8 @@ configuration:
     name: "Zusätzliche Batteriedaten"
     description: "Aktiviere Abruf zusätzlicher Batteriedaten (nur B2500 und Greensolar)"
   enableCellBalancingDiagnostics:
-    name: "Balancing-Diagnose"
-    description: "Aktiviere die Balancing-Analyse, die die Zellspannungsspreizung an einem festen Punkt jeder Ladung misst und so über Tage vergleichbar macht. Benötigt Zellspannungen (B2500, Greensolar und Venus)"
+    name: "Balancing-Diagnose (experimentell)"
+    description: "Experimentell: Welche Sensoren es gibt und welche Schwellwerte dahinterstehen, kann sich zwischen Releases noch ändern. Aktiviert die Balancing-Analyse, die die Zellspannungsspreizung an einem festen Punkt jeder Ladung misst und so über Tage vergleichbar macht. Benötigt Zellspannungen (B2500, Greensolar und Venus)"
   allowedConsecutiveTimeouts:
     name: Maximale aufeinanderfolgende Timeouts
     description: "Anzahl aufeinanderfolgender Timeouts, bevor ein Gerät als offline markiert wird (Standard: 3)"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -15,8 +15,8 @@ configuration:
     name: Enable Extra Battery Data
     description: "Enable extra battery data reporting (B2500 and Greensolar storage only)"
   enableCellBalancingDiagnostics:
-    name: Enable Cell Balancing Diagnostics
-    description: "Enable cell balancing analysis, measuring the cell spread at the same point of every charge so it can be compared between days. Requires cell data (B2500, Greensolar and Venus)"
+    name: Enable Cell Balancing Diagnostics (experimental)
+    description: "Experimental: which sensors exist, and the thresholds behind them, may still change between releases. Enables cell balancing analysis, measuring the cell spread at the same point of every charge so it can be compared between days. Requires cell data (B2500, Greensolar and Venus)"
   allowedConsecutiveTimeouts:
     name: Allowed Consecutive Timeouts
     description: "Number of consecutive timeouts before a device is marked offline (default: 3)"

--- a/src/device/cellBalancingMessage.test.ts
+++ b/src/device/cellBalancingMessage.test.ts
@@ -25,13 +25,18 @@ async function loadWithDiagnostics(env: NodeJS.ProcessEnv = {}) {
   // be visible to a test that cares whether it was warned at all.
   const logger = (await import('../logger.js')).default;
   const warnings: string[] = [];
+  const notices: string[] = [];
   jest.spyOn(logger, 'warn').mockImplementation((...args: unknown[]) => {
     warnings.push(String(args[0]));
+  });
+  jest.spyOn(logger, 'info').mockImplementation((...args: unknown[]) => {
+    notices.push(String(args[0]));
   });
 
   await import('./registry.js');
   return {
     warnings,
+    notices,
     generateDiscoveryConfigs: (await import('../generateDiscoveryConfigs.js'))
       .generateDiscoveryConfigs,
     DeviceManager: (await import('../deviceManager.js')).DeviceManager,
@@ -112,6 +117,29 @@ describe('cell balancing discovery', () => {
 
     expect(published.some(t => t.includes('cell_spread_at_crossing'))).toBe(true);
     expect(published.some(t => t.includes('rested_cell_spread'))).toBe(true);
+  });
+
+  it('says once that the feature is experimental, not once per family', async () => {
+    // B2500 V1, B2500 V2 and Venus each register the derived message, so the
+    // notice has to be guarded — and it is about the feature, not about any
+    // battery, so unlike the pack-current warning it belongs at registration.
+    const { notices } = await loadWithDiagnostics();
+    expect(notices.filter(m => m.includes('experimental'))).toHaveLength(1);
+  });
+
+  it('stays quiet about the feature nobody turned on', async () => {
+    jest.resetModules();
+    delete process.env.CELL_BALANCING_DIAGNOSTICS;
+    process.env.POLL_CELL_DATA = 'true';
+    const logger = (await import('../logger.js')).default;
+    const notices: string[] = [];
+    jest.spyOn(logger, 'info').mockImplementation((...args: unknown[]) => {
+      notices.push(String(args[0]));
+    });
+
+    await import('./registry.js');
+
+    expect(notices.filter(m => m.includes('experimental'))).toHaveLength(0);
   });
 
   it('removes every diagnostic entity when the feature is off', async () => {

--- a/src/device/cellBalancingMessage.ts
+++ b/src/device/cellBalancingMessage.ts
@@ -50,6 +50,7 @@ const lastCellTimestamps = new Map<string, string>();
 const warnedDevices = new Set<string>();
 
 let warnedAboutCellData = false;
+let announcedExperimental = false;
 
 /**
  * The diagnostics need their own flag *and* the cell data they are computed
@@ -65,6 +66,17 @@ function cellBalancingEnabled(): boolean {
       'Cell balancing diagnostics are enabled but cell data polling is not. ' +
         'Set POLL_CELL_DATA=true (add-on: "Enable Cell Data") — without it there ' +
         'are no cell readings to analyse, so no diagnostic entities are created.',
+    );
+  }
+  // Said at registration rather than per device, because it is true of the
+  // feature and not of any one battery — and only to someone who turned it on.
+  // Configuring by environment variable never shows the add-on's label, so
+  // without this a Docker user has only the README to go on.
+  if (requested && !announcedExperimental) {
+    announcedExperimental = true;
+    logger.info(
+      'Cell balancing diagnostics are experimental: which sensors exist, and ' +
+        'the thresholds behind them, may still change between releases.',
     );
   }
   return requested && haveCellData;


### PR DESCRIPTION
Follow-up to #411.

## What changed

The cell balancing diagnostics are now labelled experimental in the three places a user meets the feature, plus once at startup:

- **Add-on option** — the name becomes *Enable Cell Balancing Diagnostics (experimental)*, and the description leads with what that means. Both `en` and `de`.
- **README** — the section heading and a short lead paragraph.
- **Changelog** — the existing `[Next]` entry, which is still unreleased.
- **Startup log** — one `info` line when the feature is enabled.

The option key, the entity IDs and the behaviour are untouched, so this is not a breaking change for anyone already running it.

## Why

The sensor set and the thresholds behind it are still likely to move, and nothing told a user that before they built a dashboard or an automation on one of the entities. The label is the warning; the startup line exists because configuring by environment variable never shows the add-on's label, so a Docker user would otherwise have only the README to go on.

## One design note

The notice is emitted at registration, not per device — unlike the pack-current warning added late in #411, which had to move to per-device precisely because registration happens for every family whether or not the user owns one. That reasoning does not apply here: the statement is about the feature rather than about any one battery, and it is only reachable by someone who turned the feature on. Two tests pin both properties:

- it appears exactly once, though B2500 V1, B2500 V2 and Venus each register the derived message
- it does not appear at all when the flag is off

## Validation

```
npm run lint          # clean
npm run format:check  # clean
npm test -- --runInBand   # 575 passed
npm run build         # clean
```

Both translation files were also parsed to confirm the YAML still loads.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDsQ2evsw4e5DcpZ9Sg1GE)_