### PR TITLE
Venus E Mini: correct energy field semantics and add missing states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Monitoring only. Beta: some values may be wrong and the sensors may still change (discussion #425, PR #429, PR #430)
+- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Monitoring only. Beta: some values may be wrong and the sensors may still change (discussion #425, PR #429, PR #430, PR #433)
 
 ## [1.10.0] - 2026-08-15
 

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -5,7 +5,7 @@ import {
 } from '../deviceDefinition.js';
 import { VenusMiniDeviceData, VenusMiniTimePeriod } from '../types.js';
 import { binarySensorComponent, sensorComponent } from '../homeAssistantDiscovery.js';
-import { divide, equalsBoolean, identity, map, number } from '../transforms.js';
+import { divide, equalsBoolean, identity, map, negate, number } from '../transforms.js';
 
 /**
  * Marstek Venus E Mini, device type `VNSEMINI-X` (e.g. `VNSEMINI-0`).
@@ -71,25 +71,33 @@ function parseVenusMiniDeviceTime(value: string): string {
   return date.toISOString();
 }
 
+// Fields the vendor app does parse, named after what it parses them into.
+// That says what each one is about, but none of the individual codes is
+// known - only ls=1, gs=5 and ser=0/rechg_type=0 have been seen at all - so
+// they are reported as plain numbers rather than mapped to labels, and stay
+// disabled by default until someone works out what the codes mean.
+const venusMiniNamedRawFields = [
+  { key: 'ls', path: 'loadState', id: 'load_state', name: 'Load State' },
+  { key: 'gs', path: 'gridMode', id: 'grid_mode', name: 'Grid Mode' },
+  { key: 'ser', path: 'serverState', id: 'server_state', name: 'Server State' },
+  { key: 'rechg_type', path: 'rechargeType', id: 'recharge_type', name: 'Recharge Type' },
+] as const;
+
 // Fields observed in the Venus E Mini's cd=1 payload with no confirmed
 // meaning (see VENUS_MINI_NOTES.md and VENUS_MINI_IMPLEMENTATION_PROMPT.md).
 // Exposed verbatim as disabled-by-default sensors, keyed by their raw MQTT
 // field name, so the values are available for correlation without asserting
-// semantics. dgb/dgp and tgb/tgp: the daily-vs-lifetime pattern itself is
-// confirmed (see gridSoldEnergyToday/Total), but which of "bought"/"pass"
-// each suffix means is still just a hypothesis.
+// semantics. tgb/tgp look like the lifetime totals of the named dgb/dgp
+// counters, but no t* key is read by the vendor app at all, so that reading
+// is still a hypothesis and they stay here.
 const venusMiniRawFields = [
-  'ls',
   'eg',
-  'gs',
   'cv',
   'ct',
   'gn',
   'ar',
   'aw',
   'apt',
-  'rechg_type',
-  'ser',
   'e1',
   'e2',
   'e3',
@@ -97,8 +105,6 @@ const venusMiniRawFields = [
   'e5',
   'e6',
   'e7',
-  'dgb',
-  'dgp',
   'tgb',
   'tgp',
 ];
@@ -295,14 +301,19 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    // Confirmed as a live/fluctuating reading rather than a static value; the
-    // exact 0-100ish scale it's reported on is unconfirmed.
-    field({ key: 'wifi_a', path: ['wifiSignal'], transform: number() });
+    // Confirmed as a live/fluctuating reading rather than a static value. The
+    // device reports the magnitude of the RSSI, not the RSSI itself: the
+    // vendor app flips the sign of any positive value before showing it as a
+    // WiFi signal strength, so a reported 41 is -41 dBm. Negated here to match
+    // the wifiRssi sensor on the other models.
+    field({ key: 'wifi_a', path: ['wifiSignal'], transform: negate() });
     advertise(
       ['wifiSignal'],
       sensorComponent<number>({
         id: 'wifi_signal',
         name: 'WiFi Signal',
+        device_class: 'signal_strength',
+        unit_of_measurement: 'dBm',
         icon: 'mdi:wifi',
         state_class: 'measurement',
       }),
@@ -334,7 +345,8 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
 
     // Only 0 (self-consumption) and 2 (manual) have been observed; a 3rd "AI
     // optimization" mode exists in the app UI but is greyed out as "coming
-    // soon". In manual mode, actual charge/discharge behavior is driven by
+    // soon" - 3 is the code it will report, from the app's own work-mode
+    // enum. In manual mode, actual charge/discharge behavior is driven by
     // which schedule rule is enabled, not by this field itself.
     field({
       key: 'cm',
@@ -343,6 +355,7 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         {
           '0': 'selfConsumption',
           '2': 'manual',
+          '3': 'ai',
         },
         'unknown',
       ),
@@ -356,11 +369,17 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         valueMappings: {
           selfConsumption: 'Self Consumption',
           manual: 'Manual',
+          ai: 'AI Optimization',
           unknown: 'Unknown',
         },
       }),
     );
 
+    // 0/1/2 are confirmed against a real device; 3, 4 and 5 come from the
+    // state table the vendor app builds for this model, which labels 3 as
+    // bypass, 5 as a fault and both 2 and 4 as discharging. What separates
+    // the two discharge states is not known, so 4 gets the same label as 2
+    // rather than a name that invents a distinction.
     field({
       key: 'dev_sta',
       path: ['deviceState'],
@@ -369,6 +388,9 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
           '0': 'standby',
           '1': 'charging',
           '2': 'discharging',
+          '3': 'bypass',
+          '4': 'discharging',
+          '5': 'fault',
         },
         'unknown',
       ),
@@ -383,6 +405,8 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
           standby: 'Standby',
           charging: 'Charging',
           discharging: 'Discharging',
+          bypass: 'Bypass',
+          fault: 'Fault',
           unknown: 'Unknown',
         },
       }),
@@ -495,6 +519,13 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
+    // Unresolved: the vendor app reads dgs into the slot it labels as energy
+    // taken FROM the grid, which is the opposite of what these two are named
+    // here. It fits the capture (dgs=0/tgs=0 on a unit that had exported
+    // energy that day), but no isolated before/after test has been run
+    // against a real device either way, and the lifetime keys are not read by
+    // the app at all - so the existing names stay until someone confirms the
+    // direction on hardware.
     field({ key: 'dgs', path: ['gridSoldEnergyToday'], transform: number() });
     advertise(
       ['gridSoldEnergyToday'],
@@ -513,6 +544,34 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       sensorComponent<number>({
         id: 'grid_sold_energy_total',
         name: 'Grid Sold Energy Total',
+        device_class: 'energy',
+        unit_of_measurement: 'Wh',
+        state_class: 'total_increasing',
+      }),
+    );
+
+    // dgb and dgp are the app's daily load-consumption and daily
+    // exported-to-grid counters. Their tgb/tgp siblings look like the
+    // lifetime totals of the same two, but the app never reads a t* key, so
+    // those stay unnamed under `raw`.
+    field({ key: 'dgb', path: ['loadConsumedEnergyToday'], transform: number() });
+    advertise(
+      ['loadConsumedEnergyToday'],
+      sensorComponent<number>({
+        id: 'load_consumed_energy_today',
+        name: 'Load Consumed Energy Today',
+        device_class: 'energy',
+        unit_of_measurement: 'Wh',
+        state_class: 'total_increasing',
+      }),
+    );
+
+    field({ key: 'dgp', path: ['gridExportedEnergyToday'], transform: number() });
+    advertise(
+      ['gridExportedEnergyToday'],
+      sensorComponent<number>({
+        id: 'grid_exported_energy_today',
+        name: 'Grid Exported Energy Today',
         device_class: 'energy',
         unit_of_measurement: 'Wh',
         state_class: 'total_increasing',
@@ -634,6 +693,19 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         sensorComponent<number>({
           id: `schedule_${i}_repeat_raw`,
           name: `Schedule Slot ${i} Repeat (Raw)`,
+          icon: 'mdi:help-circle-outline',
+          enabled_by_default: false,
+        }),
+      );
+    }
+
+    for (const raw of venusMiniNamedRawFields) {
+      field({ key: raw.key, path: [raw.path], transform: number() });
+      advertise(
+        [raw.path],
+        sensorComponent<number>({
+          id: raw.id,
+          name: raw.name,
           icon: 'mdi:help-circle-outline',
           enabled_by_default: false,
         }),

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -5,7 +5,7 @@ import {
 } from '../deviceDefinition.js';
 import { VenusMiniDeviceData, VenusMiniTimePeriod } from '../types.js';
 import { binarySensorComponent, sensorComponent } from '../homeAssistantDiscovery.js';
-import { divide, equalsBoolean, identity, map, negate, number } from '../transforms.js';
+import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '../transforms.js';
 
 /**
  * Marstek Venus E Mini, device type `VNSEMINI-X` (e.g. `VNSEMINI-0`).
@@ -304,10 +304,12 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     // Confirmed as a live/fluctuating reading rather than a static value. The
     // device reports the magnitude of the RSSI, not the RSSI itself: the
     // vendor app flips the sign of any positive value before showing it as a
-    // WiFi signal strength (a value that is already negative it leaves
-    // alone), so a reported 41 is -41 dBm. Negated here to match the wifiRssi
-    // sensor on the other models. Only positive values have been observed.
-    field({ key: 'wifi_a', path: ['wifiSignal'], transform: negate() });
+    // WiFi signal strength, so a reported 41 is -41 dBm. Only positive values
+    // have been seen on the wire, but the app leaves an already-negative
+    // value alone, and so does this: negating unconditionally would turn a
+    // correctly signed -41 from some other firmware into +41. Reported in dBm
+    // to match the wifiRssi sensor on the other models.
+    field({ key: 'wifi_a', path: ['wifiSignal'], transform: negateIfPositive() });
     advertise(
       ['wifiSignal'],
       sensorComponent<number>({

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -520,51 +520,51 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    // Unresolved, and probably wrong: dgs lands in the vendor app's
-    // grid-import counter, which is the opposite of what these two are named
-    // here. That counter is one of six daily energy slots the app keeps -
-    // load consumption, grid import, grid export, generator input, battery
-    // charged, battery discharged - and the app's own naming of the slots was
-    // checked against the two ends we already know: the slots dbc and dbd
-    // land in are exactly the ones behind the app's Charged and Discharged
-    // readings, which match this file's device-confirmed names for those two
-    // keys. The app divides the same counters by 1000 to show kWh, which also
-    // confirms the Wh unit used here.
+    // dgs is energy taken FROM the grid, not sold to it - it was named the
+    // other way round when this file was written. It is one of six daily
+    // energy counters the vendor app keeps in one place: load consumption,
+    // grid import, grid export, generator input, battery charged, battery
+    // discharged, in that order. The order is not guesswork: the two
+    // counters dbc and dbd feed are exactly the ones behind the app's own
+    // Charged and Discharged readings, and those two keys already carry
+    // device-confirmed names here (see above), which pins the sequence at
+    // both ends. The app divides the same counters by 1000 to display kWh,
+    // confirming the Wh unit used here.
     //
-    // Against that: dgs=0/tgs=0 in the capture is at least consistent with
-    // import (the unit had been exporting), but no isolated before/after test
-    // has been run on a real device either way, and the lifetime keys are not
-    // read by the app at all. So the names stay until the direction is
-    // confirmed on hardware.
-    field({ key: 'dgs', path: ['gridSoldEnergyToday'], transform: number() });
+    // Still unconfirmed on hardware: no isolated import/export test has been
+    // run on a real unit, though dgs=0 next to dgp=99 in the capture fits an
+    // import counter on a unit that had been exporting all day. The lifetime
+    // tgs is inference too - the app reads no t* key at all - so it is named
+    // by symmetry with the other confirmed daily/lifetime pairs.
+    field({ key: 'dgs', path: ['gridImportedEnergyToday'], transform: number() });
     advertise(
-      ['gridSoldEnergyToday'],
+      ['gridImportedEnergyToday'],
       sensorComponent<number>({
-        id: 'grid_sold_energy_today',
-        name: 'Grid Sold Energy Today',
+        id: 'grid_imported_energy_today',
+        name: 'Grid Imported Energy Today',
         device_class: 'energy',
         unit_of_measurement: 'Wh',
         state_class: 'total_increasing',
       }),
     );
 
-    field({ key: 'tgs', path: ['gridSoldEnergyTotal'], transform: number() });
+    field({ key: 'tgs', path: ['gridImportedEnergyTotal'], transform: number() });
     advertise(
-      ['gridSoldEnergyTotal'],
+      ['gridImportedEnergyTotal'],
       sensorComponent<number>({
-        id: 'grid_sold_energy_total',
-        name: 'Grid Sold Energy Total',
+        id: 'grid_imported_energy_total',
+        name: 'Grid Imported Energy Total',
         device_class: 'energy',
         unit_of_measurement: 'Wh',
         state_class: 'total_increasing',
       }),
     );
 
-    // dgb and dgp are the app's daily load-consumption and daily
-    // exported-to-grid counters - two more of the six daily energy slots
-    // described above, from the same verified slot ordering. Their tgb/tgp
-    // siblings look like the lifetime totals of the same two, but the app
-    // never reads a t* key, so those stay unnamed under `raw`.
+    // dgb and dgp are the daily load-consumption and daily exported-to-grid
+    // counters from the same group, on the same evidence. Their tgb/tgp
+    // siblings look like the lifetime totals of the two, but with no t* key
+    // read by the app and no second confirmed pair to lean on, they stay
+    // unnamed under `raw`.
     field({ key: 'dgb', path: ['loadConsumedEnergyToday'], transform: number() });
     advertise(
       ['loadConsumedEnergyToday'],

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -304,8 +304,9 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     // Confirmed as a live/fluctuating reading rather than a static value. The
     // device reports the magnitude of the RSSI, not the RSSI itself: the
     // vendor app flips the sign of any positive value before showing it as a
-    // WiFi signal strength, so a reported 41 is -41 dBm. Negated here to match
-    // the wifiRssi sensor on the other models.
+    // WiFi signal strength (a value that is already negative it leaves
+    // alone), so a reported 41 is -41 dBm. Negated here to match the wifiRssi
+    // sensor on the other models. Only positive values have been observed.
     field({ key: 'wifi_a', path: ['wifiSignal'], transform: negate() });
     advertise(
       ['wifiSignal'],
@@ -377,9 +378,9 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
 
     // 0/1/2 are confirmed against a real device; 3, 4 and 5 come from the
     // state table the vendor app builds for this model, which labels 3 as
-    // bypass, 5 as a fault and both 2 and 4 as discharging. What separates
-    // the two discharge states is not known, so 4 gets the same label as 2
-    // rather than a name that invents a distinction.
+    // bypass, 5 as a fault and both 2 and 4 as discharging - 4 maps to the
+    // very same state value as 2 there, so it gets the same label here rather
+    // than a name that invents a distinction.
     field({
       key: 'dev_sta',
       path: ['deviceState'],
@@ -519,13 +520,22 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    // Unresolved: the vendor app reads dgs into the slot it labels as energy
-    // taken FROM the grid, which is the opposite of what these two are named
-    // here. It fits the capture (dgs=0/tgs=0 on a unit that had exported
-    // energy that day), but no isolated before/after test has been run
-    // against a real device either way, and the lifetime keys are not read by
-    // the app at all - so the existing names stay until someone confirms the
-    // direction on hardware.
+    // Unresolved, and probably wrong: dgs lands in the vendor app's
+    // grid-import counter, which is the opposite of what these two are named
+    // here. That counter is one of six daily energy slots the app keeps -
+    // load consumption, grid import, grid export, generator input, battery
+    // charged, battery discharged - and the app's own naming of the slots was
+    // checked against the two ends we already know: the slots dbc and dbd
+    // land in are exactly the ones behind the app's Charged and Discharged
+    // readings, which match this file's device-confirmed names for those two
+    // keys. The app divides the same counters by 1000 to show kWh, which also
+    // confirms the Wh unit used here.
+    //
+    // Against that: dgs=0/tgs=0 in the capture is at least consistent with
+    // import (the unit had been exporting), but no isolated before/after test
+    // has been run on a real device either way, and the lifetime keys are not
+    // read by the app at all. So the names stay until the direction is
+    // confirmed on hardware.
     field({ key: 'dgs', path: ['gridSoldEnergyToday'], transform: number() });
     advertise(
       ['gridSoldEnergyToday'],
@@ -551,9 +561,10 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     );
 
     // dgb and dgp are the app's daily load-consumption and daily
-    // exported-to-grid counters. Their tgb/tgp siblings look like the
-    // lifetime totals of the same two, but the app never reads a t* key, so
-    // those stay unnamed under `raw`.
+    // exported-to-grid counters - two more of the six daily energy slots
+    // described above, from the same verified slot ordering. Their tgb/tgp
+    // siblings look like the lifetime totals of the same two, but the app
+    // never reads a t* key, so those stay unnamed under `raw`.
     field({ key: 'dgb', path: ['loadConsumedEnergyToday'], transform: number() });
     advertise(
       ['loadConsumedEnergyToday'],

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1456,7 +1456,7 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('dcdcFirmwareVersion', 268);
     expect(result).toHaveProperty('wifiStatus', true);
     expect(result).toHaveProperty('mqttStatus', true);
-    expect(result).toHaveProperty('wifiSignal', 41);
+    expect(result).toHaveProperty('wifiSignal', -41); // wifi_a=41 is an RSSI magnitude
     expect(result).toHaveProperty('ctType', 0);
     expect(result).toHaveProperty('ctPhase', 0);
     expect(result).toHaveProperty('operatingMode', 'manual'); // cm=2
@@ -1470,6 +1470,12 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('batteryChargedEnergyTotal', 8); // tbc
     expect(result).toHaveProperty('gridSoldEnergyToday', 0); // dgs
     expect(result).toHaveProperty('gridSoldEnergyTotal', 0); // tgs
+    expect(result).toHaveProperty('loadConsumedEnergyToday', 32); // dgb
+    expect(result).toHaveProperty('gridExportedEnergyToday', 99); // dgp
+    expect(result).toHaveProperty('loadState', 1); // ls
+    expect(result).toHaveProperty('gridMode', 5); // gs
+    expect(result).toHaveProperty('serverState', 0); // ser
+    expect(result).toHaveProperty('rechargeType', 0); // rechg_type
 
     // The device does not zero-pad "time" ("2026-8-23 7:47:40"); it's parsed
     // into a proper ISO-8601 timestamp assuming the host's local timezone.
@@ -1510,9 +1516,6 @@ describe('MQTT Message Parser', () => {
 
     // Fields with no confirmed meaning are preserved verbatim under `raw`.
     expect(result.raw).toMatchObject({
-      gs: 5,
-      dgb: 32,
-      dgp: 99,
       tgb: 38,
       tgp: 125,
       e1: 0,
@@ -1538,6 +1541,12 @@ describe('MQTT Message Parser', () => {
     expect(result.raw).not.toHaveProperty('tbd');
     expect(result.raw).not.toHaveProperty('dbc');
     expect(result.raw).not.toHaveProperty('tbc');
+    expect(result.raw).not.toHaveProperty('dgb');
+    expect(result.raw).not.toHaveProperty('dgp');
+    expect(result.raw).not.toHaveProperty('ls');
+    expect(result.raw).not.toHaveProperty('gs');
+    expect(result.raw).not.toHaveProperty('ser');
+    expect(result.raw).not.toHaveProperty('rechg_type');
   });
 
   test('leaves an out-of-range Venus E Mini device time alone', () => {
@@ -1596,6 +1605,34 @@ describe('MQTT Message Parser', () => {
     expect(result.timePeriods?.[0]).toMatchObject({ direction: 'selfConsumption', modeRaw: 3 });
     // Already zero-padded input should pass through unchanged.
     expect(result.deviceTime).toBe(new Date(2026, 7, 23, 8, 5, 9).toISOString());
+  });
+
+  test('maps the Venus E Mini states only the vendor app documents', () => {
+    // dev_sta 3/4/5 and cm=3 have not been seen from a real device: they come
+    // from the state and work-mode tables the vendor app keeps for this
+    // model. 4 is a second discharging state, deliberately sharing the label
+    // of 2 because what separates them is unknown.
+    const base =
+      'cd=1,gp=0,lp=0,ig=0,ct=0,m1=0,mp1=0,ms1=0,st1=00:00,et1=00:00,re1=0,soc=966,be=1940,dpt=0,do=90,pmu=295,wif_s=1,mq_s=1,wifi_a=41,ct_type=0,bbs=0,leds=0,gps=0,inv_p=0,ct_ph=0,time=2026-08-23 08:05:09';
+
+    const states: [string, string][] = [
+      ['3', 'bypass'],
+      ['4', 'discharging'],
+      ['5', 'fault'],
+      ['6', 'unknown'],
+    ];
+    for (const [code, expected] of states) {
+      const parsed = parseMessage(`${base},cm=0,dev_sta=${code}`, 'VNSEMINI-0', 'venusMini123');
+      expect((parsed['data'] as VenusMiniDeviceData).deviceState).toBe(expected);
+    }
+
+    // The app's AI mode is still greyed out as "coming soon", but 3 is the
+    // code it reports.
+    const ai = parseMessage(`${base},cm=3,dev_sta=0`, 'VNSEMINI-0', 'venusMini123');
+    expect((ai['data'] as VenusMiniDeviceData).operatingMode).toBe('ai');
+
+    // wifi_a is the magnitude of the RSSI, so the sensor reports it negated.
+    expect((ai['data'] as VenusMiniDeviceData).wifiSignal).toBe(-41);
   });
 
   test('scales Venus A (VNSA) BMS voltages and temperatures (issue #218)', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1633,6 +1633,15 @@ describe('MQTT Message Parser', () => {
 
     // wifi_a is the magnitude of the RSSI, so the sensor reports it negated.
     expect((ai['data'] as VenusMiniDeviceData).wifiSignal).toBe(-41);
+
+    // A reading that already carries its sign must be left alone rather than
+    // flipped back to a positive dBm value.
+    const signed = parseMessage(
+      `${base.replace('wifi_a=41', 'wifi_a=-41')},cm=0,dev_sta=0`,
+      'VNSEMINI-0',
+      'venusMini123',
+    );
+    expect((signed['data'] as VenusMiniDeviceData).wifiSignal).toBe(-41);
   });
 
   test('scales Venus A (VNSA) BMS voltages and temperatures (issue #218)', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1468,8 +1468,8 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('batteryDischargedEnergyTotal', 79); // tbd
     expect(result).toHaveProperty('batteryChargedEnergyToday', 1); // dbc
     expect(result).toHaveProperty('batteryChargedEnergyTotal', 8); // tbc
-    expect(result).toHaveProperty('gridSoldEnergyToday', 0); // dgs
-    expect(result).toHaveProperty('gridSoldEnergyTotal', 0); // tgs
+    expect(result).toHaveProperty('gridImportedEnergyToday', 0); // dgs
+    expect(result).toHaveProperty('gridImportedEnergyTotal', 0); // tgs
     expect(result).toHaveProperty('loadConsumedEnergyToday', 32); // dgb
     expect(result).toHaveProperty('gridExportedEnergyToday', 99); // dgp
     expect(result).toHaveProperty('loadState', 1); // ls

--- a/src/transforms.test.ts
+++ b/src/transforms.test.ts
@@ -10,6 +10,7 @@ import {
   temperature,
   timeString,
   negate,
+  negateIfPositive,
   parseIntTransform,
   identity,
   map,
@@ -196,6 +197,22 @@ describe('transforms', () => {
 
     it('should generate correct Jinja2 template', () => {
       expect(transformToJinja2(negate(), 'value')).toBe('{{ -(value | int(0)) }}');
+    });
+  });
+
+  describe('negateIfPositive transform', () => {
+    it('should negate only positive values', () => {
+      expect(executeTransform(negateIfPositive(), '41')).toBe(-41);
+      // An already-signed reading must survive untouched, not flip back.
+      expect(executeTransform(negateIfPositive(), '-41')).toBe(-41);
+      expect(executeTransform(negateIfPositive(), '0')).toBe(0);
+      expect(executeTransform(negateIfPositive(), 'not a number')).toBe(0);
+    });
+
+    it('should generate a Jinja2 template that only negates positives', () => {
+      expect(transformToJinja2(negateIfPositive(), 'value')).toBe(
+        '{% set n = value | int(0) %}{% if n > 0 %}{{ -n }}{% else %}{{ n }}{% endif %}',
+      );
     });
   });
 

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -31,6 +31,7 @@ export type Transform =
   | TemperatureTransform
   | TimeStringTransform
   | NegateTransform
+  | NegateIfPositiveTransform
   | ParseIntTransform
   | IdentityTransform
   | MapTransform
@@ -118,6 +119,16 @@ export interface TimeStringTransform {
 /** Negate the numeric value */
 export interface NegateTransform {
   type: 'negate';
+}
+
+/**
+ * Negate the numeric value only if it is positive, leaving zero and negative
+ * values as they are. For devices that report the magnitude of a value that is
+ * conceptually negative, such as an RSSI sent without its minus sign, while
+ * other firmware of the same family may send it already signed.
+ */
+export interface NegateIfPositiveTransform {
+  type: 'negateIfPositive';
 }
 
 /** Parse as integer */
@@ -293,6 +304,9 @@ export const timeString = (): TimeStringTransform => ({ type: 'timeString' });
 /** Create a negate transform */
 export const negate = (): NegateTransform => ({ type: 'negate' });
 
+/** Create a transform that negates only positive values */
+export const negateIfPositive = (): NegateIfPositiveTransform => ({ type: 'negateIfPositive' });
+
 /** Create a parseInt transform */
 export const parseIntTransform = (): ParseIntTransform => ({ type: 'parseInt' });
 
@@ -465,6 +479,14 @@ export function executeTransform(
     case 'negate': {
       const num = parseInt(value, 10);
       return isNaN(num) ? 0 : -num;
+    }
+
+    case 'negateIfPositive': {
+      const num = parseInt(value, 10);
+      if (isNaN(num)) {
+        return 0;
+      }
+      return num > 0 ? -num : num;
     }
 
     case 'parseInt': {
@@ -727,6 +749,9 @@ export function transformToJinja2(
 
     case 'negate':
       return `{{ -(${valueExpr} | int(0)) }}`;
+
+    case 'negateIfPositive':
+      return `{% set n = ${valueExpr} | int(0) %}{% if n > 0 %}{{ -n }}{% else %}{{ n }}{% endif %}`;
 
     case 'parseInt':
       return `{{ ${valueExpr} | int(0) }}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -710,8 +710,8 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   batteryDischargedEnergyTotal?: number; // tbd (Wh)
   batteryChargedEnergyToday?: number; // dbc (Wh) - supporting evidence but not an isolated before/after test
   batteryChargedEnergyTotal?: number; // tbc (Wh) - same
-  gridSoldEnergyToday?: number; // dgs (Wh) - direction unconfirmed, see venusEMini.ts
-  gridSoldEnergyTotal?: number; // tgs (Wh) - same
+  gridImportedEnergyToday?: number; // dgs (Wh) - energy taken from the grid, see venusEMini.ts
+  gridImportedEnergyTotal?: number; // tgs (Wh) - lifetime counterpart, named by symmetry
   loadConsumedEnergyToday?: number; // dgb (Wh)
   gridExportedEnergyToday?: number; // dgp (Wh)
   loadState?: number; // ls (raw; the app treats it as a load state, individual codes unknown)

--- a/src/types.ts
+++ b/src/types.ts
@@ -651,13 +651,21 @@ export interface VenusMiniTimePeriod {
   repeatRaw?: number; // re{n} (raw; meaning unconfirmed, possibly a weekday bitmask)
 }
 
-// Operating mode reported by a Venus E Mini in cm. Only 0 and 2 have been
-// observed; a 3rd "AI optimization" mode exists in the app UI but is greyed
-// out as "coming soon" and not yet observed on the wire.
-export type VenusMiniOperatingMode = 'selfConsumption' | 'manual' | 'unknown';
+// Operating mode reported by a Venus E Mini in cm. Only 0 (self-consumption)
+// and 2 (manual) have been observed; the "AI optimization" mode is greyed out
+// as "coming soon" in the app UI, and 3 is the code it will report.
+export type VenusMiniOperatingMode = 'selfConsumption' | 'manual' | 'ai' | 'unknown';
 
-// Device state reported by a Venus E Mini in dev_sta.
-export type VenusMiniDeviceState = 'standby' | 'charging' | 'discharging' | 'unknown';
+// Device state reported by a Venus E Mini in dev_sta. 0/1/2 are confirmed
+// against a real device; bypass and fault are the app's own labels for 3 and
+// 5, and 4 is a second discharging state whose difference from 2 is unknown.
+export type VenusMiniDeviceState =
+  | 'standby'
+  | 'charging'
+  | 'discharging'
+  | 'bypass'
+  | 'fault'
+  | 'unknown';
 
 // Feed-in power limit preset reported by a Venus E Mini in gps. Not a literal
 // wattage value - it selects between Germany's simplified-registration cap
@@ -689,7 +697,7 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   dcdcFirmwareVersion?: number; // dcdc
   wifiStatus?: boolean; // wif_s (1 = ok)
   mqttStatus?: boolean; // mq_s (1 = ok)
-  wifiSignal?: number; // wifi_a, unitless (0-100ish scale, exact scale unconfirmed)
+  wifiSignal?: number; // wifi_a (dBm), reported as the magnitude and negated on the way in
   ctType?: number; // ct_type (only 0 = "no external meter" observed so far, full enum unconfirmed)
   ctPhase?: number; // ct_ph (only 0 observed so far, meaning unconfirmed)
   deviceTime?: string; // time, device-local timestamp, parsed to ISO-8601 assuming the device clock is in the host's local timezone (the same assumption the sync-time command makes)
@@ -702,8 +710,14 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   batteryDischargedEnergyTotal?: number; // tbd (Wh)
   batteryChargedEnergyToday?: number; // dbc (Wh) - supporting evidence but not an isolated before/after test
   batteryChargedEnergyTotal?: number; // tbc (Wh) - same
-  gridSoldEnergyToday?: number; // dgs (Wh)
-  gridSoldEnergyTotal?: number; // tgs (Wh)
+  gridSoldEnergyToday?: number; // dgs (Wh) - direction unconfirmed, see venusEMini.ts
+  gridSoldEnergyTotal?: number; // tgs (Wh) - same
+  loadConsumedEnergyToday?: number; // dgb (Wh)
+  gridExportedEnergyToday?: number; // dgp (Wh)
+  loadState?: number; // ls (raw; the app treats it as a load state, individual codes unknown)
+  gridMode?: number; // gs (raw; grid mode, individual codes unknown)
+  serverState?: number; // ser (raw; server state, individual codes unknown)
+  rechargeType?: number; // rechg_type (raw; recharge type, individual codes unknown)
   timePeriods?: VenusMiniTimePeriod[];
   // cd=19 per-phase CT readings, in W. Only reported by a unit with an external
   // meter configured, so these stay unset on a device with ct_type=0.
@@ -712,10 +726,9 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   phaseCPower?: number; // power_c
   totalPhasePower?: number; // power_s
   // Fields observed in the payload with no confirmed meaning, keyed by their
-  // raw MQTT field name (ls, eg, gs, cv, ct (bare, distinct from ct_type),
-  // gn, ar, aw, apt, rechg_type, ser, e1-e7, dgb/dgp, tgb/tgp). Exposed as
-  // disabled-by-default sensors so the data is available for correlation
-  // without asserting semantics.
+  // raw MQTT field name (eg, cv, ct (bare, distinct from ct_type), gn, ar,
+  // aw, apt, e1-e7, tgb/tgp). Exposed as disabled-by-default sensors so the
+  // data is available for correlation without asserting semantics.
   raw?: Record<string, number>;
 }
 


### PR DESCRIPTION
## What changed

Read-only additions to the Venus E Mini definition (`src/device/venusEMini.ts`). No write/set commands.

- **`dev_sta`** — 3 (bypass), 4 (a second discharging state) and 5 (fault) previously fell through to *Unknown*. 4 deliberately gets the same label as 2: it maps to the very same state value in the vendor app, so nothing supports inventing a distinction.
- **`cm`** — 3 is the AI mode the app UI still greys out as "coming soon"; it now reads as *AI Optimization* instead of *Unknown*.
- **`wifi_a`** — was exposed as an unknown 0-100ish scale. It is the magnitude of an RSSI: the app flips the sign of any positive value before showing it as signal strength, so the captured `41` is `-41 dBm`. Now `device_class: signal_strength` + `dBm`, matching `wifiRssi` on Venus/Jupiter/CT002/SMR.
- **`dgs`/`tgs` renamed** — these are energy taken **from** the grid, not sold to it. They become *Grid Imported Energy Today/Total*.
- **`dgb`/`dgp` promoted out of the raw bucket** — daily load consumption and daily energy exported to the grid.
- **`ls`/`gs`/`ser`/`rechg_type`** — still raw numbers, but named after what they are about: *Load State*, *Grid Mode*, *Server State*, *Recharge Type*. Disabled by default, since no individual code is known. Their entity ids change from `raw_ls` etc. to `load_state` etc.
- `tgb`/`tgp` stay unnamed under `raw`; see below.

One shared change outside the device file: a **`negateIfPositive`** transform in `src/transforms.ts`, used for `wifi_a`. Negating unconditionally would turn an already-signed `-41` from some other firmware into `+41`; this matches what the app does — negate a positive, leave a negative alone. It is a declarative transform rather than a one-off function so the generated Home Assistant template behaves the same as the runtime parser (function transforms can't be introspected into Jinja).

## Why

The device-side captures established the confirmed fields already in this file. The rest of the payload was mapped against the Marstek Android app 1.6.72, decompiled locally with [blutter](https://github.com/worawit/blutter) to read the parser for this device family. That's an interoperability read of Marstek's binary — no artifact from it is in this diff, only the protocol conclusions.

How much weight the app evidence carries per field:

- **`dev_sta`, `cm`** — the app's tables for this model, read directly. Values `0/1/2` were already confirmed on hardware and are unchanged.
- **The energy counters** — the app keeps six daily counters in one place, in a fixed order: load consumption, grid import, grid export, generator input, battery charged, battery discharged. `dgb`, `dgs`, `dgp`, `dbc`, `dbd` fill five of them. The ordering is pinned at both ends by keys already confirmed here: `dbc` and `dbd` feed exactly the counters behind the app's own *Charged* and *Discharged* readings. The app divides the same counters by 1000 to display kWh, which also confirms the Wh unit this file uses.
- **`ls`/`gs`/`ser`/`rechg_type`** — the app parses them, which says what each is about, but no code value is known. Hence raw numbers, disabled by default.

## Still unconfirmed

- **The `dgs` direction has not been tested on hardware.** Nobody has watched it climb on a real unit while importing. It fits the capture (`dgs=0` next to `dgp=99` on a unit that had been exporting all day), but a check on a real device would settle it.
- **`tgs` is inference by symmetry** with the confirmed daily/lifetime pairs — the app reads no `t*` key at all. Same reason `tgb`/`tgp` stay unnamed under `raw` rather than being named as lifetime totals of `dgb`/`dgp`.
- The captured energy figures don't balance under any reading (`tbc=8` charged against `tbd=79` discharged lifetime), so don't take the capture alone as arithmetic proof of anything.

## Worth testing separately

The app polls this family with **`cd=01`**, zero-padded, from the shared get-device-info command the Mini inherits. This definition sends `cd=1`. The captured response echoes `cd=1`, so this is not proof of a problem — but it is cheap to try against a real unit, and it is a candidate explanation for the README's caveat that the device only pushes telemetry while the app has a session open.

Also spotted while fixing the sign handling, and deliberately **not** changed here to keep the PR focused: `jupiter.ts` (`wif_s`) and `venus.ts` use plain `negate()` for their own WiFi signal fields and would flip an already-signed reading the same way. Worth a look separately if those devices can report a signed value.

## Validation

```
npm run lint          # clean
npm run format:check  # clean
npm test -- --runInBand   # 584 passed, 19 suites
npm run build         # clean
```

New test `maps the Venus E Mini states only the vendor app documents` covers `dev_sta` 3/4/5 plus an unmapped 6, `cm=3`, and both WiFi sign cases; `negateIfPositive` has its own runtime and Jinja tests; the existing real-capture test was updated for the renames.

No add-on option or environment variable changed, so `ha_addon/` and the translations are untouched. `VNSEMINI` is still unreleased under `[Next]`, so no entity anyone has is renamed and the changelog keeps the single existing entry, now referencing this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AI operating mode and bypass/fault device states on Venus E Mini devices.
  * Added clearer status information for load, grid, server, and recharge conditions.
  * Added daily energy readings for load consumption, grid imports, and grid exports.
  * Wi-Fi signal readings now display as negative dBm values for improved accuracy.
* **Bug Fixes**
  * Corrected energy labels to distinguish imported energy from exported energy.
  * Improved Venus E Mini data parsing and field reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->