### PR TITLE
Prevent broker password leakage in logs (fixes #424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Next]
 
+### Fixed
+
+- The MQTT broker password no longer shows up in the log. On startup, the broker URL was written to the log with its credentials in plaintext, which meant sharing a log for troubleshooting could hand out the broker password. In the Home Assistant add-on this affected the password of Home Assistant's own MQTT broker. Broker URLs now appear as `mqtt://user:***@host:1883` (fixes #424)
+
 
 ## [1.10.0] - 2026-08-15
 

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -9,11 +9,46 @@ start_application() {
     cd /app && node dist/index.js || bashio::log.error "Application crashed with exit code $?"
 }
 
+# Mask the password of a URL that carries its credentials inline
+# (e.g. mqtt://user:pass@host:1883), so broker URLs can be logged without
+# leaking the broker password. The username is kept, it is not a secret.
+redact_url_credentials() {
+    local text="$1"
+    local scheme rest userinfo host
+
+    if [[ "$text" != *"://"* ]]; then
+        echo "$text"
+        return
+    fi
+
+    scheme="${text%%://*}"
+    rest="${text#*://}"
+    userinfo="${rest%@*}"
+    host="${rest##*@}"
+
+    # No credentials, or the "@" belongs to the path rather than to userinfo
+    if [[ "$rest" != *"@"* || "$userinfo" == */* || "$userinfo" != *":"* ]]; then
+        echo "$text"
+        return
+    fi
+
+    echo "${scheme}://${userinfo%%:*}:***@${host}"
+}
+
+# Apply redact_url_credentials to every line read from stdin
+redact_credentials() {
+    local line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        redact_url_credentials "$line"
+    done
+}
+
 # Function to output environment variables for testing
 output_env_for_testing() {
     bashio::log.info "Running in test mode, outputting environment variables"
     # Output all environment variables that start with MQTT_ or DEVICE_
-    env | grep -E "^(MQTT_|AUTODISCOVERY_|DEVICE_|POLL_|CELL_|DEBUG=|LOG_LEVEL=)" | sort
+    env | grep -E "^(MQTT_|AUTODISCOVERY_|DEVICE_|POLL_|CELL_|DEBUG=|LOG_LEVEL=)" | sort |
+        redact_credentials
 }
 
 # Function to manually parse options.json
@@ -91,7 +126,11 @@ if bashio::config.true 'debug' 2>/dev/null; then
     
     # Try to print configuration but don't fail if it errors
     bashio::log.debug "Attempting to print full addon configuration:"
-    (bashio::config 2>/dev/null | jq '.' 2>/dev/null) || bashio::log.warning "Failed to print configuration"
+    if ADDON_CONFIG=$(bashio::config 2>/dev/null | jq '.' 2>/dev/null); then
+        echo "$ADDON_CONFIG" | redact_credentials
+    else
+        bashio::log.warning "Failed to print configuration"
+    fi
 fi
 
 # Create config directory
@@ -99,7 +138,7 @@ mkdir -p /app/config
 
 # Get MQTT URI
 BROKER_URL=$(get_mqtt_uri)
-bashio::log.info "MQTT Broker URL: ${BROKER_URL}"
+bashio::log.info "MQTT Broker URL: $(redact_url_credentials "${BROKER_URL}")"
 
 # Set environment variables for the application
 export MQTT_BROKER_URL="${BROKER_URL}"
@@ -195,7 +234,7 @@ env | grep "^DEVICE_" | sort
 # In debug mode, show all environment variables (excluding passwords)
 if bashio::config.true 'debug'; then
     bashio::log.debug "All environment variables (excluding passwords):"
-    env | grep -v -i "password" | sort
+    env | grep -v -i "password" | sort | redact_credentials
 fi
 
 if [ "$DEVICE_COUNT" -eq 0 ]; then

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -32,6 +32,13 @@ redact_url_credentials() {
         return
     fi
 
+    # An empty password is left alone, matching the application side: masking it
+    # would suggest a password is set when none is
+    if [[ -z "${userinfo#*:}" ]]; then
+        echo "$text"
+        return
+    fi
+
     echo "${scheme}://${userinfo%%:*}:***@${host}"
 }
 
@@ -46,9 +53,10 @@ redact_credentials() {
 # Function to output environment variables for testing
 output_env_for_testing() {
     bashio::log.info "Running in test mode, outputting environment variables"
-    # Output all environment variables that start with MQTT_ or DEVICE_
-    env | grep -E "^(MQTT_|AUTODISCOVERY_|DEVICE_|POLL_|CELL_|DEBUG=|LOG_LEVEL=)" | sort |
-        redact_credentials
+    # Output all environment variables that start with MQTT_ or DEVICE_,
+    # skipping passwords the same way the debug output below does
+    env | grep -E "^(MQTT_|AUTODISCOVERY_|DEVICE_|POLL_|CELL_|DEBUG=|LOG_LEVEL=)" |
+        grep -v -i "password" | sort | redact_credentials
 }
 
 # Function to manually parse options.json

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { DataHandler } from './dataHandler.js';
 import { MqttProxy, MqttProxyConfig } from './mqttProxy.js';
 import { runShutdownStep } from './shutdown.js';
 import { flushPersistence } from './persistence.js';
+import { redactSecrets, redactUrlCredentials } from './utils/redact.js';
 
 // MQTT Proxy configuration
 const MQTT_PROXY_ENABLED = process.env.MQTT_PROXY_ENABLED === 'true';
@@ -73,7 +74,7 @@ function parseDeviceConfigurations(): Device[] {
       .filter(key => !key.toLowerCase().includes('password'))
       .sort()
       .forEach(key => {
-        logger.info(`${key}=${process.env[key]}`);
+        logger.info(`${key}=${redactUrlCredentials(process.env[key] ?? '')}`);
       });
 
     logger.info('\nPlease check your addon configuration and ensure you have added devices.');
@@ -140,23 +141,13 @@ async function main() {
         .filter(key => !key.toLowerCase().includes('password'))
         .sort()
         .forEach(key => {
-          logger.trace(`${key}=${process.env[key]}`);
+          logger.trace(`${key}=${redactUrlCredentials(process.env[key] ?? '')}`);
         });
 
       // Print full configuration
       logger.debug('Full configuration:');
       const config = createMqttConfig(parseDeviceConfigurations());
-      logger.debug(
-        JSON.stringify(
-          config,
-          (key, value) => {
-            // Mask password fields
-            if (key.toLowerCase().includes('password')) return '***';
-            return value;
-          },
-          2,
-        ),
-      );
+      logger.debug(JSON.stringify(config, redactSecrets, 2));
     }
 
     // Parse device configurations
@@ -170,12 +161,9 @@ async function main() {
     // Create MQTT configuration
     logger.debug('Creating MQTT configuration...');
     const config = createMqttConfig(devices);
-    logger.debug(`MQTT Broker: ${config.brokerUrl}`);
+    logger.debug(`MQTT Broker: ${redactUrlCredentials(config.brokerUrl)}`);
     logger.debug(`MQTT Client ID: ${config.clientId}`);
-    logger.debug(
-      'Full MQTT config:',
-      JSON.stringify(config, (key, value) => (key === 'password' ? '***' : value), 2),
-    );
+    logger.debug('Full MQTT config:', JSON.stringify(config, redactSecrets, 2));
 
     const deviceStateUpdateHandler = (
       device: Device,

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -153,6 +153,28 @@ describe('logMethodHook', () => {
     );
   });
 
+  it('masks credentials in a leading object, which pino writes as log fields', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+    const bindings = { brokerUrl: 'mqtt://user:secret@broker:1883' };
+
+    logger.info(bindings, 'Connecting to MQTT broker');
+
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.brokerUrl).toBe('mqtt://user:***@broker:1883');
+    expect(bindings.brokerUrl).toBe('mqtt://user:secret@broker:1883');
+  });
+
+  it('masks credentials in an object interpolated through %o', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.info('MQTT config: %o', { brokerUrl: 'mqtt://user:secret@broker:1883' });
+
+    expect(lastMessage(lines)).toContain('mqtt://user:***@broker:1883');
+    expect(lastMessage(lines)).not.toContain('secret');
+  });
+
   it('still folds surplus arguments into the message', () => {
     const lines: string[] = [];
     const logger = createTestLogger(lines);

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -175,6 +175,19 @@ describe('logMethodHook', () => {
     expect(lastMessage(lines)).not.toContain('secret');
   });
 
+  it('masks credentials in an error logged the way this codebase logs errors', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.error(
+      'MQTT client error:',
+      new Error('connect failed for mqtt://user:secret@broker:1883'),
+    );
+
+    expect(lastMessage(lines)).toContain('mqtt://user:***@broker:1883');
+    expect(lastMessage(lines)).not.toContain('secret');
+  });
+
   it('still folds surplus arguments into the message', () => {
     const lines: string[] = [];
     const logger = createTestLogger(lines);

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,5 +1,5 @@
 import pino from 'pino';
-import { consoleStyleLogMethod } from './logger.js';
+import { consoleStyleLogMethod, logMethodHook } from './logger.js';
 
 // pino v10's printf-placeholder-aware typings reject console.log-style calls
 // (a trailing object/string with no matching `%s`/`%d`). consoleStyleLogMethod
@@ -109,5 +109,56 @@ describe('consoleStyleLogMethod', () => {
     const entry = JSON.parse(lines[lines.length - 1]);
     expect(entry.msg).toBe('Device registered');
     expect(entry.deviceId).toBe('abc');
+  });
+});
+
+describe('logMethodHook', () => {
+  function createTestLogger(lines: string[]): ConsoleStyleLogger {
+    return pino(
+      {
+        level: 'debug',
+        hooks: { logMethod: logMethodHook },
+      },
+      {
+        write(chunk: string) {
+          lines.push(chunk);
+        },
+      },
+    ) as unknown as ConsoleStyleLogger;
+  }
+
+  function lastMessage(lines: string[]): string {
+    return JSON.parse(lines[lines.length - 1]).msg;
+  }
+
+  it('masks credentials embedded in a logged broker URL (regression #424)', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.info('Connecting to MQTT broker at mqtt://user:secret@broker:1883 with client ID x');
+
+    expect(lastMessage(lines)).toBe(
+      'Connecting to MQTT broker at mqtt://user:***@broker:1883 with client ID x',
+    );
+  });
+
+  it('masks credentials inside appended objects', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.debug('Full MQTT config:', { brokerUrl: 'mqtt://user:secret@broker:1883' });
+
+    expect(lastMessage(lines)).toBe(
+      "Full MQTT config: { brokerUrl: 'mqtt://user:***@broker:1883' }",
+    );
+  });
+
+  it('still folds surplus arguments into the message', () => {
+    const lines: string[] = [];
+    const logger = createTestLogger(lines);
+
+    logger.warn('Invalid output value (should be 0-800):', 'abc');
+
+    expect(lastMessage(lines)).toBe('Invalid output value (should be 0-800): abc');
   });
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
 import pino, { type Logger } from 'pino';
 import { inspect } from 'util';
-import { redactUrlCredentials } from './utils/redact.js';
+import { redactDeep } from './utils/redact.js';
 
 /**
  * Loosely-typed log function.
@@ -62,13 +62,15 @@ export function consoleStyleLogMethod(
 
 /**
  * Masks credentials embedded in URLs (`mqtt://user:pass@host`) in every logged
- * string, so a broker URL cannot leak the broker password no matter which call
+ * value, so a broker URL cannot leak the broker password no matter which call
  * site logs it (see issue #424).
+ *
+ * Objects are covered as well as strings: pino writes the properties of a
+ * leading object straight into the log line, and interpolates `%o`/`%j`
+ * arguments into the message after this hook has run.
  */
 export function redactLogArgs(args: Parameters<pino.LogFn>): Parameters<pino.LogFn> {
-  return args.map(arg =>
-    typeof arg === 'string' ? redactUrlCredentials(arg) : arg,
-  ) as Parameters<pino.LogFn>;
+  return args.map(arg => redactDeep(arg)) as Parameters<pino.LogFn>;
 }
 
 /**

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,6 @@
 import pino, { type Logger } from 'pino';
 import { inspect } from 'util';
+import { redactUrlCredentials } from './utils/redact.js';
 
 /**
  * Loosely-typed log function.
@@ -59,10 +60,37 @@ export function consoleStyleLogMethod(
   method.apply(this, inputArgs);
 }
 
+/**
+ * Masks credentials embedded in URLs (`mqtt://user:pass@host`) in every logged
+ * string, so a broker URL cannot leak the broker password no matter which call
+ * site logs it (see issue #424).
+ */
+export function redactLogArgs(args: Parameters<pino.LogFn>): Parameters<pino.LogFn> {
+  return args.map(arg =>
+    typeof arg === 'string' ? redactUrlCredentials(arg) : arg,
+  ) as Parameters<pino.LogFn>;
+}
+
+/**
+ * The hook the application logger runs on every log call: surplus arguments are
+ * folded into the message first, then the finished message is redacted - that
+ * way credentials inside logged objects are masked as well.
+ */
+export function logMethodHook(
+  this: pino.Logger,
+  inputArgs: Parameters<pino.LogFn>,
+  method: pino.LogFn,
+): void {
+  const redactingMethod = ((...args: unknown[]) => {
+    method.apply(this, redactLogArgs(args as Parameters<pino.LogFn>));
+  }) as pino.LogFn;
+  consoleStyleLogMethod.call(this, inputArgs, redactingMethod);
+}
+
 const logger: LooseLogger = pino({
   level: resolvedLevel,
   hooks: {
-    logMethod: consoleStyleLogMethod,
+    logMethod: logMethodHook,
   },
   transport: {
     targets: [

--- a/src/mqttClient.test.ts
+++ b/src/mqttClient.test.ts
@@ -38,6 +38,7 @@ jest.unstable_mockModule('./deviceDefinition.js', () => ({
 
 const { MqttClient } = await import('./mqttClient.js');
 import type { Device } from './types.js';
+import logger from './logger.js';
 
 describe('MqttClient discovery re-publish', () => {
   test('re-publishes discovery when additional device info changes after first data on same path (regression #235)', () => {
@@ -458,5 +459,29 @@ describe('MqttClient forced refresh', () => {
     expect(
       payloadsAfter(() => mqttClient.requestDeviceData(device, { forceMessageIndices: [7] })),
     ).toEqual([]);
+  });
+});
+
+describe('MqttClient connection logging', () => {
+  test('does not log the broker password (regression #424)', () => {
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+
+    try {
+      const config: any = {
+        brokerUrl: 'mqtt://user:secret@broker:1883',
+        clientId: 'test-client',
+        topicPrefix: 'homeassistant',
+        autodiscoveryTopicPrefix: 'homeassistant',
+      };
+      const deviceManager: any = { getDevices: jest.fn(() => []) };
+
+      new MqttClient(config, deviceManager, jest.fn());
+
+      const logged = infoSpy.mock.calls.flat().join(' ');
+      expect(logged).not.toContain('secret');
+      expect(logged).toContain('mqtt://user:***@broker:1883');
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 });

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -4,6 +4,7 @@ import { DeviceManager } from './deviceManager.js';
 import { publishDiscoveryConfigs } from './generateDiscoveryConfigs.js';
 import { AdditionalDeviceInfo, BaseDeviceData, getDeviceDefinition } from './deviceDefinition.js';
 import logger from './logger.js';
+import { redactUrlCredentials } from './utils/redact.js';
 
 export class MqttClient {
   private client: mqtt.MqttClient;
@@ -47,7 +48,7 @@ export class MqttClient {
     };
 
     logger.info(
-      `Connecting to MQTT broker at ${this.config.brokerUrl} with client ID ${this.config.clientId}`,
+      `Connecting to MQTT broker at ${redactUrlCredentials(this.config.brokerUrl)} with client ID ${this.config.clientId}`,
     );
     logger.debug(`MQTT username: ${this.config.username ? this.config.username : 'not provided'}`);
     logger.debug(`MQTT password: ${this.config.password ? '******' : 'not provided'}`);

--- a/src/mqttProxy.ts
+++ b/src/mqttProxy.ts
@@ -3,6 +3,7 @@ import { Aedes, Client as AedesClient, ConnectPacket } from 'aedes';
 import * as net from 'net';
 import { DeviceManager } from './deviceManager.js';
 import logger from './logger.js';
+import { redactUrlCredentials } from './utils/redact.js';
 
 export interface MqttProxyConfig {
   /** Port for the proxy MQTT server */
@@ -196,7 +197,7 @@ export class MqttProxy {
     };
 
     logger.info(
-      `MQTT Proxy connecting to main broker at ${this.config.mainBrokerUrl} with client ID ${this.config.proxyClientId}`,
+      `MQTT Proxy connecting to main broker at ${redactUrlCredentials(this.config.mainBrokerUrl)} with client ID ${this.config.proxyClientId}`,
     );
 
     const client = mqtt.connect(this.config.mainBrokerUrl, options);

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,0 +1,54 @@
+import { redactSecrets, redactUrlCredentials } from './redact.js';
+
+describe('redactUrlCredentials', () => {
+  it.each`
+    input                                                       | expected
+    ${'mqtt://user:secret@broker:1883'}                         | ${'mqtt://user:***@broker:1883'}
+    ${'mqtts://user:secret@broker:8883/path'}                   | ${'mqtts://user:***@broker:8883/path'}
+    ${'ws://user:secret@broker:9001'}                           | ${'ws://user:***@broker:9001'}
+    ${'mqtt://user:se@cr:et@broker:1883'}                       | ${'mqtt://user:***@broker:1883'}
+    ${'mqtt://:secret@broker:1883'}                             | ${'mqtt://:***@broker:1883'}
+    ${'Connecting to mqtt://user:secret@broker:1883 with id x'} | ${'Connecting to mqtt://user:***@broker:1883 with id x'}
+    ${'MQTT_BROKER_URL=mqtt://user:secret@broker:1883'}         | ${'MQTT_BROKER_URL=mqtt://user:***@broker:1883'}
+    ${'a mqtt://a:1@h and mqtt://b:2@h'}                        | ${'a mqtt://a:***@h and mqtt://b:***@h'}
+  `('masks the password in "$input"', ({ input, expected }) => {
+    expect(redactUrlCredentials(input)).toBe(expected);
+  });
+
+  it.each`
+    input                               | reason
+    ${'mqtt://broker:1883'}             | ${'no credentials'}
+    ${'mqtt://user@broker:1883'}        | ${'username only'}
+    ${'mqtt://user:@broker:1883'}       | ${'empty password'}
+    ${'homeassistant/HMA-1/device/abc'} | ${'not a URL'}
+    ${''}                               | ${'empty string'}
+  `('leaves "$input" untouched ($reason)', ({ input }) => {
+    expect(redactUrlCredentials(input)).toBe(input);
+  });
+
+  it('is idempotent', () => {
+    const once = redactUrlCredentials('mqtt://user:secret@broker:1883');
+
+    expect(redactUrlCredentials(once)).toBe(once);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('masks passwords and credentials embedded in URLs', () => {
+    const config = {
+      brokerUrl: 'mqtt://user:secret@broker:1883',
+      username: 'user',
+      password: 'secret',
+      mainBrokerPassword: 'secret',
+      topicPrefix: 'hm2mqtt',
+    };
+
+    expect(JSON.parse(JSON.stringify(config, redactSecrets))).toEqual({
+      brokerUrl: 'mqtt://user:***@broker:1883',
+      username: 'user',
+      password: '***',
+      mainBrokerPassword: '***',
+      topicPrefix: 'hm2mqtt',
+    });
+  });
+});

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -61,14 +61,46 @@ describe('redactDeep', () => {
     expect(redactDeep(error)).toBe(error);
   });
 
-  it('survives a cyclic object', () => {
+  it('masks password fields, at the top level and nested', () => {
+    expect(redactDeep({ password: 'secret', nested: { mainBrokerPassword: 'secret' } })).toEqual({
+      password: '***',
+      nested: { mainBrokerPassword: '***' },
+    });
+  });
+
+  it('leaves an empty or absent password alone', () => {
+    expect(redactDeep({ password: '', otherPassword: null })).toEqual({
+      password: '',
+      otherPassword: null,
+    });
+  });
+
+  it('replaces a cycle with a marker instead of passing it through', () => {
     const cyclic: Record<string, unknown> = { brokerUrl: 'mqtt://user:secret@broker:1883' };
     cyclic.self = cyclic;
 
-    expect(() => redactDeep(cyclic)).not.toThrow();
-    expect((redactDeep(cyclic) as Record<string, unknown>).brokerUrl).toBe(
-      'mqtt://user:***@broker:1883',
-    );
+    const redacted = redactDeep(cyclic) as Record<string, unknown>;
+
+    expect(redacted.brokerUrl).toBe('mqtt://user:***@broker:1883');
+    expect(redacted.self).toBe('[circular]');
+  });
+
+  it('keeps redacting the same object in two places of the same tree', () => {
+    const shared = { brokerUrl: 'mqtt://user:secret@broker:1883' };
+
+    expect(redactDeep({ first: shared, second: shared })).toEqual({
+      first: { brokerUrl: 'mqtt://user:***@broker:1883' },
+      second: { brokerUrl: 'mqtt://user:***@broker:1883' },
+    });
+  });
+
+  it('never lets a value deeper than it walks through unredacted', () => {
+    let deep: Record<string, unknown> = { brokerUrl: 'mqtt://user:secret@broker:1883' };
+    for (let i = 0; i < 40; i++) {
+      deep = { nested: deep };
+    }
+
+    expect(JSON.stringify(redactDeep(deep))).not.toContain('secret');
   });
 });
 

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,4 +1,4 @@
-import { redactSecrets, redactUrlCredentials } from './redact.js';
+import { redactDeep, redactSecrets, redactUrlCredentials } from './redact.js';
 
 describe('redactUrlCredentials', () => {
   it.each`
@@ -33,6 +33,45 @@ describe('redactUrlCredentials', () => {
   });
 });
 
+describe('redactDeep', () => {
+  it('masks credentials in nested strings without touching the input', () => {
+    const input = {
+      brokerUrl: 'mqtt://user:secret@broker:1883',
+      nested: { proxy: { mainBrokerUrl: 'mqtt://user:secret@broker:1883' } },
+      urls: ['mqtt://user:secret@broker:1883', 'mqtt://broker:1883'],
+      port: 1883,
+      enabled: true,
+      missing: null,
+    };
+
+    expect(redactDeep(input)).toEqual({
+      brokerUrl: 'mqtt://user:***@broker:1883',
+      nested: { proxy: { mainBrokerUrl: 'mqtt://user:***@broker:1883' } },
+      urls: ['mqtt://user:***@broker:1883', 'mqtt://broker:1883'],
+      port: 1883,
+      enabled: true,
+      missing: null,
+    });
+    expect(input.brokerUrl).toBe('mqtt://user:secret@broker:1883');
+  });
+
+  it('passes non-plain objects through untouched', () => {
+    const error = new Error('connect failed for mqtt://user:secret@broker:1883');
+
+    expect(redactDeep(error)).toBe(error);
+  });
+
+  it('survives a cyclic object', () => {
+    const cyclic: Record<string, unknown> = { brokerUrl: 'mqtt://user:secret@broker:1883' };
+    cyclic.self = cyclic;
+
+    expect(() => redactDeep(cyclic)).not.toThrow();
+    expect((redactDeep(cyclic) as Record<string, unknown>).brokerUrl).toBe(
+      'mqtt://user:***@broker:1883',
+    );
+  });
+});
+
 describe('redactSecrets', () => {
   it('masks passwords and credentials embedded in URLs', () => {
     const config = {
@@ -50,5 +89,9 @@ describe('redactSecrets', () => {
       mainBrokerPassword: '***',
       topicPrefix: 'hm2mqtt',
     });
+  });
+
+  it('leaves an empty password alone', () => {
+    expect(redactSecrets('password', '')).toBe('');
   });
 });

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -28,43 +28,72 @@ export function redactUrlCredentials(value: string): string {
  * password fields are masked and credentials embedded in URLs are redacted.
  */
 export function redactSecrets(key: string, value: unknown): unknown {
-  // An empty password is left alone: masking it would suggest a password is
-  // configured when none is.
-  if (key.toLowerCase().includes('password') && value !== '') {
+  if (isSecret(key, value)) {
     return '***';
   }
   return typeof value === 'string' ? redactUrlCredentials(value) : value;
 }
 
-/**
- * How deep `redactDeep` walks into an object before giving up. Also what keeps
- * a cyclic object from recursing forever.
- */
-const MAX_DEPTH = 6;
+/** Guards against a pathological object blowing the stack. */
+const MAX_DEPTH = 32;
+
+const TOO_DEEP = '[redacted: too deep]';
+const CIRCULAR = '[circular]';
 
 /**
- * Returns a copy of `value` with the URL credentials masked in every string it
- * contains.
+ * Whether a value under a password-named key is worth masking. An empty or
+ * absent password is left alone: masking it would suggest a password is
+ * configured when none is.
+ */
+function isSecret(key: string, value: unknown): boolean {
+  return (
+    key.toLowerCase().includes('password') && value !== '' && value !== null && value !== undefined
+  );
+}
+
+/**
+ * Returns a copy of `value` with the secrets masked in every string it
+ * contains: URL credentials anywhere, and the value of any password-named key.
  *
  * Plain objects and arrays are walked; anything else - an Error, a Buffer, a
  * class instance - is passed through untouched so whatever serializes it later
- * still sees the object it expects. The input is never mutated.
+ * still sees the object it expects. Errors reach the log through the message
+ * string, which is redacted in full.
+ *
+ * The input is never mutated. A cycle or an object too deep to walk is replaced
+ * by a marker rather than passed through, so nothing escapes unredacted.
  */
-export function redactDeep(value: unknown, depth = 0): unknown {
+export function redactDeep(value: unknown, depth = 0, ancestors = new WeakSet<object>()): unknown {
   if (typeof value === 'string') {
     return redactUrlCredentials(value);
   }
-  if (value === null || typeof value !== 'object' || depth >= MAX_DEPTH) {
+  if (value === null || typeof value !== 'object') {
     return value;
   }
-  if (Array.isArray(value)) {
-    return value.map(entry => redactDeep(entry, depth + 1));
-  }
+
   const prototype = Object.getPrototypeOf(value);
-  if (prototype !== Object.prototype && prototype !== null) {
+  if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
     return value;
   }
-  return Object.fromEntries(
-    Object.entries(value).map(([key, entry]) => [key, redactDeep(entry, depth + 1)]),
-  );
+  if (ancestors.has(value)) {
+    return CIRCULAR;
+  }
+  if (depth >= MAX_DEPTH) {
+    return TOO_DEEP;
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map(entry => redactDeep(entry, depth + 1, ancestors));
+    }
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        isSecret(key, entry) ? '***' : redactDeep(entry, depth + 1, ancestors),
+      ]),
+    );
+  } finally {
+    ancestors.delete(value);
+  }
 }

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,35 @@
+/**
+ * Matches the credentials part of a URL: the scheme, everything up to the last
+ * `@` (a raw `@` inside a password is not encoded by every user) and that `@`.
+ */
+const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)([^\s/?#]*)@/gi;
+
+/**
+ * Masks the password of every URL credential found in a string.
+ *
+ * Broker URLs may carry their credentials inline (`mqtt://user:pass@host:1883`),
+ * so anything logging one would otherwise write the broker password to the log
+ * in plaintext (issue #424). The username is kept: it helps when reading logs
+ * and is not a secret.
+ */
+export function redactUrlCredentials(value: string): string {
+  return value.replace(URL_CREDENTIALS, (match, scheme: string, userInfo: string) => {
+    const separator = userInfo.indexOf(':');
+    // Nothing to hide: either a bare `user@host` or an empty password.
+    if (separator < 0 || separator === userInfo.length - 1) {
+      return match;
+    }
+    return `${scheme}${userInfo.slice(0, separator)}:***@`;
+  });
+}
+
+/**
+ * `JSON.stringify` replacer that keeps secrets out of logged configuration:
+ * password fields are masked and credentials embedded in URLs are redacted.
+ */
+export function redactSecrets(key: string, value: unknown): unknown {
+  if (key.toLowerCase().includes('password')) {
+    return '***';
+  }
+  return typeof value === 'string' ? redactUrlCredentials(value) : value;
+}

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -28,8 +28,43 @@ export function redactUrlCredentials(value: string): string {
  * password fields are masked and credentials embedded in URLs are redacted.
  */
 export function redactSecrets(key: string, value: unknown): unknown {
-  if (key.toLowerCase().includes('password')) {
+  // An empty password is left alone: masking it would suggest a password is
+  // configured when none is.
+  if (key.toLowerCase().includes('password') && value !== '') {
     return '***';
   }
   return typeof value === 'string' ? redactUrlCredentials(value) : value;
+}
+
+/**
+ * How deep `redactDeep` walks into an object before giving up. Also what keeps
+ * a cyclic object from recursing forever.
+ */
+const MAX_DEPTH = 6;
+
+/**
+ * Returns a copy of `value` with the URL credentials masked in every string it
+ * contains.
+ *
+ * Plain objects and arrays are walked; anything else - an Error, a Buffer, a
+ * class instance - is passed through untouched so whatever serializes it later
+ * still sees the object it expects. The input is never mutated.
+ */
+export function redactDeep(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') {
+    return redactUrlCredentials(value);
+  }
+  if (value === null || typeof value !== 'object' || depth >= MAX_DEPTH) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(entry => redactDeep(entry, depth + 1));
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, redactDeep(entry, depth + 1)]),
+  );
 }


### PR DESCRIPTION
## Summary

The MQTT broker password was being logged in plaintext when the broker URL was written to logs on startup. This is a security issue, especially in the Home Assistant add-on where the broker URL contains Home Assistant's own MQTT broker password. Broker URLs now appear redacted as `mqtt://user:***@host:1883` throughout the application and add-on logs.

## Changes

- **New utility module** (`src/utils/redact.ts`): 
  - `redactUrlCredentials()` masks passwords in URLs while preserving usernames
  - `redactSecrets()` is a `JSON.stringify` replacer that masks password fields and redacts URL credentials
  
- **Logger enhancement** (`src/logger.ts`):
  - Added `logMethodHook()` that redacts all logged strings and objects before they reach pino
  - Ensures credentials are masked regardless of which call site logs them
  
- **Application startup** (`src/index.ts`):
  - Replaced inline password-masking logic with calls to `redactUrlCredentials()` and `redactSecrets()`
  - Applies redaction when logging environment variables and configuration
  
- **MQTT client** (`src/mqttClient.ts`, `src/mqttProxy.ts`):
  - Redact broker URLs in connection log messages
  
- **Home Assistant add-on** (`ha_addon/run.sh`):
  - Added `redact_url_credentials()` bash function to mask passwords in shell output
  - Applied to environment variable and configuration debug output
  - Redacts the broker URL before logging it on startup

- **Tests**:
  - Added comprehensive test suite for redaction functions (`src/utils/redact.test.ts`)
  - Added regression test in `src/logger.test.ts` for the `logMethodHook`
  - Added regression test in `src/mqttClient.test.ts` to verify broker password is not logged

- **Documentation** (`CHANGELOG.md`):
  - Added entry under `[Next]` describing the fix

## Validation

- All existing tests pass
- New tests cover redaction logic, logger hook behavior, and MQTT client logging
- Redaction is idempotent (applying it twice yields the same result)
- Username is preserved in redacted URLs (helps with log readability)
- Empty passwords and URLs without credentials are left untouched

https://claude.ai/code/session_01FverpsMTwpeSEefJAZAeGj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - MQTT broker passwords are now masked as `***` in startup, connection, configuration, environment, and debug logs.
  - Embedded credentials are protected across supported broker URL formats while usernames and URL structure remain visible.
  - Sensitive password fields and credentials nested in logged data are redacted.

- **Bug Fixes**
  - Prevented credentials from appearing in broker and proxy connection logs.
  - Added a warning when configuration details cannot be safely printed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->