### PR TITLE
Venus E Mini: second-generation commands, and document the two generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors, a *Discharge Depth* control, a *Bluetooth Advertising* switch and a *Restart* button. Beta: some values may be wrong, the controls were taken from the Marstek app rather than confirmed on a device, and both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
 - Venus: New *Battery Health* sensor, showing the battery's state of health. Reported by control firmware 149.2 and later, so it appears only on devices new enough to send it (PR #437)
 - Venus: Fifteen further readings the device sends but nobody had a meaning for are now published as raw diagnostic sensors, disabled by default, so they can be correlated against what your device is doing. If you work out what one of them means, please say so (PR #437)
-- Docs: New [Venus firmware generations](docs/venus-generations.md) page. Marstek's Venus line splits into two firmware generations that use different command numbers and different MQTT topics; the Venus E Mini, Venus X and Venus G are the second. Useful if you script against the devices directly (PR #437)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors plus a *Bluetooth Advertising* switch, which shows the last value you set because the device does not report it back. Beta: some values may be wrong, and the sensors and the switch may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
+- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors plus a *Bluetooth Advertising* switch, which shows the last value you set rather than the device's own state. Beta: some values may be wrong, and the sensors and the switch may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 ### Added
 
 - Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Beta: some values may be wrong and the sensors may still change (discussion #425, PR #429, PR #430, PR #433)
-- Venus E Mini: New *Bluetooth Advertising* switch, turning the device's Bluetooth advertising on and off. The device does not report the setting back, so the switch shows the last value you set. Beta: the command was taken from the Marstek app rather than confirmed on a device (PR #436)
-- Venus E Mini: Six further readings from the CT power response are now published as disabled-by-default sensors. Their meaning is not confirmed, so they are named after the raw values, alongside the existing unnamed readings (PR #436)
+- Venus E Mini: New *Bluetooth Advertising* switch, turning the device's Bluetooth advertising on and off. The device does not report the setting back, so the switch shows the last value you set. Beta: the command was taken from the Marstek app rather than confirmed on a device (PR #437)
+- Venus E Mini: Six further readings from the CT power response are now published as disabled-by-default sensors. Their meaning is not confirmed, so they are named after the raw values, alongside the existing unnamed readings (PR #437)
 
 ### Fixed
 
-- Venus E Mini: The per-phase CT power sensors were requested with the wrong command and would never have appeared. The Marstek app asks this model for power readings with a different command than it uses for the other Venus models, which is the one hm2mqtt had been sending (PR #436)
+- Venus E Mini: The per-phase CT power sensors were requested with the wrong command and would never have appeared. The Marstek app asks this model for power readings with a different command than it uses for the other Venus models, which is the one hm2mqtt had been sending (PR #437)
 - The MQTT broker password no longer shows up in the log. On startup, the broker URL was written to the log with its credentials in plaintext, which meant sharing a log for troubleshooting could hand out the broker password. In the Home Assistant add-on this affected the password of Home Assistant's own MQTT broker. Broker URLs now appear as `mqtt://user:***@host:1883` (fixes #424, PR #435)
 
 ## [1.10.0] - 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 
 ### Added
 
-- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Monitoring only. Beta: some values may be wrong and the sensors may still change (discussion #425, PR #429, PR #430, PR #433)
+- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Beta: some values may be wrong and the sensors may still change (discussion #425, PR #429, PR #430, PR #433)
+- Venus E Mini: New *Bluetooth Advertising* switch, turning the device's Bluetooth advertising on and off. The device does not report the setting back, so the switch shows the last value you set. Beta: the command was taken from the Marstek app rather than confirmed on a device (PR #436)
+- Venus E Mini: Six further readings from the CT power response are now published as disabled-by-default sensors. Their meaning is not confirmed, so they are named after the raw values, alongside the existing unnamed readings (PR #436)
 
 ### Fixed
 
+- Venus E Mini: The per-phase CT power sensors were requested with the wrong command and would never have appeared. The Marstek app asks this model for power readings with a different command than it uses for the other Venus models, which is the one hm2mqtt had been sending (PR #436)
 - The MQTT broker password no longer shows up in the log. On startup, the broker URL was written to the log with its credentials in plaintext, which meant sharing a log for troubleshooting could hand out the broker password. In the Home Assistant add-on this affected the password of Home Assistant's own MQTT broker. Broker URLs now appear as `mqtt://user:***@host:1883` (fixes #424, PR #435)
 
 ## [1.10.0] - 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 
 - Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors, a *Discharge Depth* control, a *Bluetooth Advertising* switch and a *Restart* button. Beta: some values may be wrong, the controls were taken from the Marstek app rather than confirmed on a device, and both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
+- Venus: New *Battery Health* sensor, showing the battery's state of health. Reported by control firmware 149.2 and later, so it appears only on devices new enough to send it (PR #437)
+- Venus: Fifteen further readings the device sends but nobody had a meaning for are now published as raw diagnostic sensors, disabled by default, so they can be correlated against what your device is doing. If you work out what one of them means, please say so (PR #437)
 - Docs: New [Venus firmware generations](docs/venus-generations.md) page. Marstek's Venus line splits into two firmware generations that use different command numbers and different MQTT topics; the Venus E Mini, Venus X and Venus G are the second. Useful if you script against the devices directly (PR #437)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,10 @@
 
 ### Added
 
-- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Beta: some values may be wrong and the sensors may still change (discussion #425, PR #429, PR #430, PR #433)
-- Venus E Mini: New *Bluetooth Advertising* switch, turning the device's Bluetooth advertising on and off. The device does not report the setting back, so the switch shows the last value you set. Beta: the command was taken from the Marstek app rather than confirmed on a device (PR #437)
-- Venus E Mini: Six further readings from the CT power response are now published as disabled-by-default sensors. Their meaning is not confirmed, so they are named after the raw values, alongside the existing unnamed readings (PR #437)
+- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors plus a *Bluetooth Advertising* switch, which shows the last value you set because the device does not report it back. Beta: some values may be wrong, and the sensors and the switch may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
 
 ### Fixed
 
-- Venus E Mini: The per-phase CT power sensors were requested with the wrong command and would never have appeared. The Marstek app asks this model for power readings with a different command than it uses for the other Venus models, which is the one hm2mqtt had been sending (PR #437)
 - The MQTT broker password no longer shows up in the log. On startup, the broker URL was written to the log with its credentials in plaintext, which meant sharing a log for troubleshooting could hand out the broker password. In the Home Assistant add-on this affected the password of Home Assistant's own MQTT broker. Broker URLs now appear as `mqtt://user:***@host:1883` (fixes #424, PR #435)
 
 ## [1.10.0] - 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ### Added
 
-- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors plus a *Bluetooth Advertising* switch, which shows the last value you set rather than the device's own state. Beta: some values may be wrong, and the sensors and the switch may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
+- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors, a *Discharge Depth* control, a *Bluetooth Advertising* switch and a *Restart* button. Beta: some values may be wrong, the controls were taken from the Marstek app rather than confirmed on a device, and both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
+- Docs: New [Venus firmware generations](docs/venus-generations.md) page. Marstek's Venus line splits into two firmware generations that use different command numbers and different MQTT topics; the Venus E Mini, Venus X and Venus G are the second. Useful if you script against the devices directly (PR #437)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -750,7 +750,16 @@ Venus commands above.
   someone confirms the direction on a device.
 
 **Beta.** This command was read out of the Marstek app rather than captured from
-a real device, so it has not been confirmed end to end.
+a real device, so it has not been confirmed end to end. The command number is
+confirmed for this model; the `adv=` parameter is borrowed from the older Venus
+line and still wants checking on a device — see below.
+
+The Venus E Mini belongs to a second generation of Marstek's Venus firmware,
+together with the Venus X and Venus G. It uses different command numbers from
+the Venus C/D/E this project already supports — depth of discharge, the LED,
+setting the time and reading network info all moved — and a different MQTT
+topic namespace. That is why it has its own command list here rather than
+sharing the Venus one.
 
 The app has three further commands for this model that hm2mqtt does not expose:
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The device type can be one of the following:
 - **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
 - **VNSA-X**: (e.g. VNSA-1) Venus A
 - **VNSD-X**: (e.g. VNSD-1) Venus D
-- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors only, none of the Venus write commands apply to it yet
+- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus a single *Bluetooth Advertising* switch. None of the other Venus write commands apply to it.
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus
@@ -690,7 +690,7 @@ homeassistant/{component}/{node_id}/{object_id}/config
 - `phase-diagnosis`: Starts grid-phase detection. Progress shows up on the *CT Status* sensor.
 
 ### Venus Device Commands
-Applies to HMG/VNSE3/VNSA/VNSD. The Venus E Mini (VNSEMINI) only exposes sensors for now; none of the commands below are available on it yet.
+Applies to HMG/VNSE3/VNSA/VNSD. None of the commands below are available on the Venus E Mini (VNSEMINI), which has its own, much smaller command set — see [Venus E Mini Commands](#venus-e-mini-commands).
 - `working-mode`: Sets working mode (`automatic`, `manual`, `trading`, or `ai`). The `ai` value expands to `cd=2,md=5,nl=1` (AI mode requires both `md=5` and `nl=1`).
 - `recharge-mode`: Sets the grid recharge mode (`singlePhase` or `threePhase`)
 - `meter-mac`: Sets the MAC address used when configuring an external meter (12 hex digits, no separators; `:`/`-` in the input are stripped). The device does not report this back, so the entity shows the last value set.
@@ -735,6 +735,22 @@ The `wiringCheck` value is the app's own verification step — it runs that befo
 enabling. The matching *Parallel Mode* entity reports the current state (*Turned
 Off*, *Wiring Check*, *Turned On*, or *Unknown* on units that do not support
 parallel operation).
+
+### Venus E Mini Commands
+
+Applies to VNSEMINI. Despite the name this model shares almost nothing with the
+Venus commands above.
+
+- `bluetooth-advertising`: Turns the device's Bluetooth advertising on or off.
+  The Mini does not report the setting back, so the *Bluetooth Advertising*
+  switch shows the last value that was set rather than the device's own state.
+
+**Beta.** This command was read out of the Marstek app rather than captured from
+a real device, so it has not been confirmed end to end. Three further commands
+the app has for this model are deliberately not exposed: configuring the
+device's server (it would repoint the unit at a different broker), configuring
+its WiFi (it carries network credentials), and setting the recharge type (the
+accepted values are not known, and the device only ever reports `0` back).
 
 ### Jupiter Device Commands
 

--- a/README.md
+++ b/README.md
@@ -748,29 +748,25 @@ Venus commands above.
   "advertising on" is not established, and a switch wired the wrong way round
   would show the opposite of reality — so it stays on the last value set until
   someone confirms the direction on a device.
+- `discharge-depth`: Sets the usable-discharge percentage, 30-90%. The device
+  reports the setting back, so the *Discharge Depth* entity shows its real
+  state.
+- `restart`: Reboots the device. Disabled by default.
 
-**Beta.** This command was read out of the Marstek app rather than captured from
-a real device, so it has not been confirmed end to end. The command number is
-confirmed for this model; the `adv=` parameter is borrowed from the older Venus
-line and still wants checking on a device — see below.
+**Beta.** These commands were read out of the Marstek app rather than captured
+from a real device, so they have not been confirmed end to end.
 
-The Venus E Mini belongs to a second generation of Marstek's Venus firmware,
-together with the Venus X and Venus G. It uses different command numbers from
-the Venus C/D/E this project already supports — depth of discharge, the LED,
-setting the time and reading network info all moved — and a different MQTT
-topic namespace. That is why it has its own command list here rather than
-sharing the Venus one.
+The Venus E Mini runs a second generation of Marstek's Venus firmware, together
+with the Venus X and Venus G. It numbers its commands differently from the
+Venus C/D/E — depth of discharge, the LED, setting the time and reading network
+info all moved — and uses a different MQTT topic namespace. That is why it has
+its own command list here rather than sharing the Venus one. See
+[docs/venus-generations.md](docs/venus-generations.md) for the full map.
 
-The app has three further commands for this model that hm2mqtt does not expose:
-
-- **Shelly scan.** The device scans its own network for Shelly energy meters and
-  reports what it found — id, MAC, IP, signal strength, model and firmware
-  version for each. Not exposed because the reply is a JSON array, which
-  hm2mqtt's parser cannot represent yet; it needs parser work rather than just
-  a command.
-- **Configure WiFi**, which carries network credentials.
-- **Set recharge type**, whose accepted values are not known — the device only
-  ever reports `0` back.
+Three further commands the app has for this model are not exposed: configuring
+the device's server and setting the recharge type, neither of whose accepted
+values are known, and configuring WiFi, which carries network credentials and
+has no MQTT form anyway.
 
 ### Jupiter Device Commands
 

--- a/README.md
+++ b/README.md
@@ -736,6 +736,11 @@ enabling. The matching *Parallel Mode* entity reports the current state (*Turned
 Off*, *Wiring Check*, *Turned On*, or *Unknown* on units that do not support
 parallel operation).
 
+Venus devices also report a *Battery Health* sensor (state of health) on control
+firmware 149.2 and later, plus a set of raw diagnostic sensors for fields the
+device sends that have no confirmed meaning. All of the raw ones are disabled by
+default. See [docs/venus-generations.md](docs/venus-generations.md).
+
 ### Venus E Mini Commands
 
 Applies to VNSEMINI. Despite the name this model shares almost nothing with the

--- a/README.md
+++ b/README.md
@@ -750,11 +750,18 @@ Venus commands above.
   someone confirms the direction on a device.
 
 **Beta.** This command was read out of the Marstek app rather than captured from
-a real device, so it has not been confirmed end to end. Three further commands
-the app has for this model are deliberately not exposed: configuring the
-device's server (it would repoint the unit at a different broker), configuring
-its WiFi (it carries network credentials), and setting the recharge type (the
-accepted values are not known, and the device only ever reports `0` back).
+a real device, so it has not been confirmed end to end.
+
+The app has three further commands for this model that hm2mqtt does not expose:
+
+- **Shelly scan.** The device scans its own network for Shelly energy meters and
+  reports what it found — id, MAC, IP, signal strength, model and firmware
+  version for each. Not exposed because the reply is a JSON array, which
+  hm2mqtt's parser cannot represent yet; it needs parser work rather than just
+  a command.
+- **Configure WiFi**, which carries network credentials.
+- **Set recharge type**, whose accepted values are not known — the device only
+  ever reports `0` back.
 
 ### Jupiter Device Commands
 

--- a/README.md
+++ b/README.md
@@ -742,8 +742,12 @@ Applies to VNSEMINI. Despite the name this model shares almost nothing with the
 Venus commands above.
 
 - `bluetooth-advertising`: Turns the device's Bluetooth advertising on or off.
-  The Mini does not report the setting back, so the *Bluetooth Advertising*
-  switch shows the last value that was set rather than the device's own state.
+  The *Bluetooth Advertising* switch shows the last value that was set rather
+  than the device's own state. The Mini most likely does report the setting back
+  in the field behind the *Bluetooth Lock (Raw)* sensor, but which value means
+  "advertising on" is not established, and a switch wired the wrong way round
+  would show the opposite of reality — so it stays on the last value set until
+  someone confirms the direction on a device.
 
 **Beta.** This command was read out of the Marstek app rather than captured from
 a real device, so it has not been confirmed end to end. Three further commands

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The device type can be one of the following:
 - **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
 - **VNSA-X**: (e.g. VNSA-1) Venus A
 - **VNSD-X**: (e.g. VNSD-1) Venus D
-- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus a single *Bluetooth Advertising* switch. None of the other Venus write commands apply to it.
+- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus *Discharge Depth*, *Bluetooth Advertising* and *Restart* controls. None of the other Venus write commands apply to it.
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -1,0 +1,185 @@
+# The two generations of Venus firmware
+
+Marstek's Venus line splits into two firmware generations that speak different
+MQTT dialects. They share a wire format — `cd=<n>,<key>=<value>` — but assign
+different numbers to the same commands, and connect over different topics.
+
+This matters because hm2mqtt currently implements the first generation. The
+Venus E Mini belongs to the second, and Venus X and Venus G are unsupported
+second-generation models.
+
+Everything here was read out of the Marstek Android app (`com.hamedata.marstek`
+1.6.72, snapshot `830f4f59e7969c70b595182826435c19`) with
+[marstool](https://github.com/tomquist/marstool). None of it has been confirmed
+against hardware — see [Confidence](#confidence).
+
+## Telling them apart
+
+|                | First generation | Second generation |
+| -------------- | ---------------- | ----------------- |
+| Products       | Venus C, Venus E, Venus A, Venus D | Venus X, Venus G, Venus E Mini |
+| Device types   | `HMG`, `VNSE3`, `VNSA`, `VNSD` (and the regional `VNSE3CH`, `VNSE3AU`, `VNSDCH`, `VNSACH`, `VDAC`, `VEPRO`, `VAAC2`, `VNSE4`) | `VENX`, `VNSG`, `VNSGPV`, `VNSEMINI` |
+| App code       | `pages/Ac_Coupler`, commands built by `CommonCommand` | `modules/devices`, commands built by `DataVenus*` tables and `venus_model.dart` |
+| MQTT topics    | `hame_energy/<type>/App/<mac>/ctrl` | `marstek_energy/<type>/App/<hashed id>/ctrl` |
+| Strategy class | `VenusMqttStrategy` | `VNXMqttStrategy` |
+
+`mqtt_factory` is what settles the grouping: it routes `VNSEMINI` behind
+`VNXMqttStrategy` alongside `VENX`, `VNSG` and `VNSGPV`. `MqttSendMixin.TOPIC`
+in that tree builds the `marstek_energy` topic with the hashed device id, where
+`CommonCommand` builds `hame_energy` with the plain MAC.
+
+## Where the numbering collides
+
+Only some commands moved. These are the ones where both generations implement
+the same thing under different numbers — the traps when reading one generation's
+code while working on the other:
+
+| Command             | 1st gen | 2nd gen |
+| ------------------- | ------- | ------- |
+| Depth of discharge  | `cd=56,dod=` | `cd=44,do=` |
+| Set LED             | `cd=59,led=` | `cd=56,led=` |
+| Set device time     | `cd=4,yy=,mm=,rr=,hh=,mn=` | `cd=33` |
+| Network info        | `cd=26` | `cd=03` |
+| Restart / reboot    | `cd=10` | `cd=61` |
+
+And these agree, which is why the split is easy to miss:
+
+| Command             | Both generations |
+| ------------------- | ---------------- |
+| Read device info    | `cd=1` / `cd=01` |
+| Set working mode    | `cd=2,md=` / `cd=02,md=` |
+| Factory reset       | `cd=5` / `cd=05` |
+| Set CT / meter type | `cd=18,meter=` |
+| Get CT power        | `cd=19` |
+| Bluetooth advertising | `cd=55,adv=` |
+
+The second generation writes its numbers zero-padded (`cd=01`, `cd=05`) where
+hm2mqtt sends them bare. The first generation's B2500 code does the same, and
+real devices evidently parse the number rather than the string, so this appears
+to be cosmetic.
+
+## Second-generation command map
+
+The second generation layers its command tables: a base every model inherits,
+plus per-model additions. Parameter names come from
+`modules/devices/model/venus_model.dart`, whose setters name them directly; the
+numbers come from the `CMD_*` descriptors in each model's entity file.
+
+### Base — inherited by every second-generation model
+
+Declared in `modules/devices/entity/dev_data.dart` (the `VxCmd` mixin).
+
+| Command | Payload | App name |
+| ------- | ------- | -------- |
+| Read device info | `cd=01` | `CMD_GET_DEVICE_INFO` |
+| Network info | `cd=03` | `CMD_GET_NET_INFO` |
+| Error code | `cd=04` | `CMD_GET_ERROR_CODE` |
+| Factory reset | `cd=05` | `CMD_SET_RESET_TO_FACTORY` |
+| Set working mode | `cd=02,md=<n>` | `CMD_SET_WORK_MODE` |
+| Set CT / meter | `cd=18,meter=<n>` | `CMD_SET_CT` |
+| Set device time | `cd=33` | `CMD_SET_TIME` |
+| Depth of discharge | `cd=44,do=<pct>` | `CMD_SET_DOD` |
+| Access power | `cd=46,cv=<n>` | `CMD_SET_ACCESS_POWER` |
+| Anti-reverse-flow | `cd=54,am=<n>` | `CMD_SET_ANTL_REVERSE` |
+| Bluetooth advertising | `cd=55,adv=<0\|1>` | `CMD_SET_BLUETOOTH_STATE` |
+| Reboot | `cd=61` | `CMD_SET_REBOOT` |
+| Configure WiFi | *(Bluetooth only — no MQTT form)* | `CMD_SET_WIFI` |
+| Manual mode config | `cd=` *(built at the call site)* | `CMD_SET_MODE_MANUAL_INFO` |
+
+### Venus X — `dev_venus_x.dart`
+
+Adds, on top of the base:
+
+| Command | Payload | App name |
+| ------- | ------- | -------- |
+| Get NOW power | `cd=59` | `CMD_GET_NOW_POWER` |
+| Get CT power | `cd=19` | `CMD_GET_CT_POWER` |
+| Get config info | `cd=01` | `CMD_GET_CONFIG_INFO` |
+| Set LED | `cd=56,led=<n>` | `CMD_SET_LED_STATE` |
+| Discharge grid power | `cd=57,on_grid=<n>` | `CMD_SET_DISCHARGE_GRID_POWER` |
+| CT phase auto-check | `cd=58` | `CMD_SET_CT_PHASE_AUTO_CHECK` |
+| Configure server | `cd=60,ser=<n>` | `CMD_SET_SERVER` |
+| Shelly Pro 3EM port | `cd=62,shelly_pro=<port>` | `CMD_SET_SHELLY_PRO_3EM_PORT` |
+| Grid power standard | `cd=38,grid_sta=<n>` | `CMD_SET_GRID_POWER_STANDARD` |
+| Access power | `cd=46,cv=<n>` | `CMD_SET_ACCESS_POWER` |
+
+### Venus G — `dev_venus_g.dart`
+
+| Command | Payload | App name |
+| ------- | ------- | -------- |
+| Battery pack info | `cd=62` | `CMD_GET_BATTERY_PACK_INFO` |
+
+Note `cd=62` means something different here than on the Venus X, which uses it
+for the Shelly port. Numbers are not stable across models within a generation
+either — always read the model's own table.
+
+### Venus E Mini — `dev_venus_b.dart`
+
+| Command | Payload | App name |
+| ------- | ------- | -------- |
+| Get NOW power | `cd=59` | `CMD_GET_NOW_POWER` |
+| Bluetooth advertising | `cd=55,adv=<0\|1>` | `CMD_SET_BLUETOOTH_STATE` |
+| Configure server | `cd=60,ser=<n>` | `CMD_SET_SERVER` |
+| Recharge type | `cd=63,ct_chg_type=<n>` | `CMD_SET_CT_CHARGE_TYPE` |
+| Configure WiFi | *(Bluetooth only)* | `CMD_SET_WIFI` |
+
+The Mini has no `cd=19`, which is why hm2mqtt polls it for power with `cd=59`.
+
+## A `cd=60` ambiguity worth knowing about
+
+`cd=60` carries two different meanings depending on which parameter it takes.
+The second-generation device command is `cd=60,ser=<n>`, matching its label
+"配置服务器" (configure server), and the Mini reports the setting back as `ser`
+in its `cd=1` payload.
+
+Separately, `NewHomeMqttTool.getScanShellyList` builds `cd=60` with `mod=1` /
+`mod=0` to start and stop a **Shelly scan**, and the device answers with the
+Shelly energy meters it found on its own network:
+
+```
+cd=60,[{"id":"Shellypro3em63-2cbcbbb83378","mac":"2CBCBBB83378","ip":"10.6.138.80",
+        "rssi":-68,"model":"SPEM-003CEBEU63","name":null,"ver":"1.4.0"}, …]
+```
+
+`cd=61` (`connectShellRPC`) then connects to a chosen one. That is the same
+number the second generation uses for reboot, on a different code path — so
+`cd=60` and `cd=61` both need the parameter to disambiguate them. The Shelly
+reply is a JSON array, which hm2mqtt's `key=value` parser cannot represent, so
+none of the Shelly flow is implemented.
+
+## What hm2mqtt implements
+
+Of the second generation, only the Venus E Mini is supported, and only partly:
+
+- `cd=1` runtime payload — parsed
+- `cd=59` power readings — polled
+- `cd=55,adv=` bluetooth advertising — implemented
+- `cd=44,do=` depth of discharge — implemented
+- `cd=61` reboot — implemented
+
+Everything else in the tables above is unimplemented. Venus X and Venus G have
+no device definitions at all.
+
+## Confidence
+
+Read from one app build, and not confirmed against hardware. Specifically:
+
+- **Numbers and parameter names** come from the app's own command tables and
+  setters, so they are what the app sends. They are not proof of what the
+  firmware accepts.
+- **Value domains** are mostly unknown. The app rarely encodes the accepted
+  range in the command builder, so `md=`, `ser=`, `cv=`, `am=`, `grid_sta=`
+  and `ct_chg_type=` have no documented value set here.
+- **Polarity** is unknown wherever a boolean is involved. `led=` is a good
+  example: the Mini reports its LED state in `leds` inverted (`leds=0` means
+  the LED is on), and nothing says whether `led=` follows the same convention.
+- A later app release can move a number or add a model. Re-read rather than
+  trusting this page for a build other than 1.6.72.
+
+Reproduce any row with:
+
+```sh
+marstool app disasm --app <app> --blutter-out ./blutter-out
+marstool app rules  --blutter-out ./blutter-out --class CommonCommand --member setCtType
+marstool mqtt topics --app <app> --device-type VNSEMINI-0 --device-id 001122334455
+```

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -51,7 +51,7 @@ And these agree, which is why the split is easy to miss:
 | Set working mode    | `cd=2,md=` / `cd=02,md=` |
 | Factory reset       | `cd=5` / `cd=05` |
 | Set CT / meter type | `cd=18,meter=` |
-| Get CT power        | `cd=19` |
+| Get CT power        | `cd=19` — but not on the Venus E Mini, which has no `cd=19` and uses `cd=59` |
 | Bluetooth advertising | `cd=55,adv=` |
 
 The first generation has no reboot command at all, on Venus. `cd=10` is not one:
@@ -140,10 +140,11 @@ in its `cd=1` payload.
 
 Separately, `NewHomeMqttTool.getScanShellyList` builds `cd=60` with `mod=1` /
 `mod=0` to start and stop a **Shelly scan**, and the device answers with the
-Shelly energy meters it found on its own network:
+Shelly energy meters it found on its own network (shape as in the app's
+demo-mode fixture, with the MAC and address replaced by placeholders):
 
-```
-cd=60,[{"id":"Shellypro3em63-2cbcbbb83378","mac":"2CBCBBB83378","ip":"10.6.138.80",
+```text
+cd=60,[{"id":"Shellypro3em63-aabbccddeeff","mac":"AABBCCDDEEFF","ip":"192.0.2.10",
         "rssi":-68,"model":"SPEM-003CEBEU63","name":null,"ver":"1.4.0"}, …]
 ```
 

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -8,12 +8,11 @@ This matters because hm2mqtt currently implements the first generation. The
 Venus E Mini belongs to the second, and Venus X and Venus G are unsupported
 second-generation models.
 
-Everything here was read out of the Marstek Android app (`com.hamedata.marstek`
-1.6.72, snapshot `830f4f59e7969c70b595182826435c19`) with
-[marstool](https://github.com/tomquist/marstool). The first generation's half
-has since been cross-checked against real device firmware — see
-[Cross-checked against firmware](#cross-checked-against-firmware). The second
-generation's has not; see [Confidence](#confidence).
+Everything here was read out of the Marstek Android app's compiled Dart
+(`com.hamedata.marstek` 1.6.72, snapshot `830f4f59e7969c70b595182826435c19`).
+The first generation's half has since been cross-checked against real device
+firmware — see [Cross-checked against firmware](#cross-checked-against-firmware).
+The second generation's has not; see [Confidence](#confidence).
 
 ## Telling them apart
 
@@ -215,10 +214,11 @@ Read from one app build, and not confirmed against hardware. Specifically:
 - A later app release can move a number or add a model. Re-read rather than
   trusting this page for a build other than 1.6.72.
 
-Reproduce any row with:
+To re-derive any row: the app ships as a Flutter AOT snapshot, so disassembling
+`libapp.so` gives back the command tables named above. The numbers live in each
+model's `CMD_*` members, the parameter names in `venus_model.dart`'s setters,
+and the device-type-to-number branch tables in `CommonCommand`.
 
-```sh
-marstool app disasm --app <app> --blutter-out ./blutter-out
-marstool app rules  --blutter-out ./blutter-out --class CommonCommand --member setCtType
-marstool mqtt topics --app <app> --device-type VNSEMINI-0 --device-id 001122334455
-```
+The firmware side needs no tooling beyond `strings`: the control images are
+unencrypted ARM Cortex-M binaries, and both the `cd=1` response format string
+and the parameter names the MQTT handler parses are readable in the clear.

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -10,8 +10,10 @@ second-generation models.
 
 Everything here was read out of the Marstek Android app (`com.hamedata.marstek`
 1.6.72, snapshot `830f4f59e7969c70b595182826435c19`) with
-[marstool](https://github.com/tomquist/marstool). None of it has been confirmed
-against hardware — see [Confidence](#confidence).
+[marstool](https://github.com/tomquist/marstool). The first generation's half
+has since been cross-checked against real device firmware — see
+[Cross-checked against firmware](#cross-checked-against-firmware). The second
+generation's has not; see [Confidence](#confidence).
 
 ## Telling them apart
 
@@ -40,7 +42,7 @@ code while working on the other:
 | Set LED             | `cd=59,led=` | `cd=56,led=` |
 | Set device time     | `cd=4,yy=,mm=,rr=,hh=,mn=` | `cd=33` |
 | Network info        | `cd=26` | `cd=03` |
-| Restart / reboot    | `cd=10` | `cd=61` |
+| Reboot              | *(none — see below)* | `cd=61` |
 
 And these agree, which is why the split is easy to miss:
 
@@ -52,6 +54,11 @@ And these agree, which is why the split is easy to miss:
 | Set CT / meter type | `cd=18,meter=` |
 | Get CT power        | `cd=19` |
 | Bluetooth advertising | `cd=55,adv=` |
+
+The first generation has no reboot command at all, on Venus. `cd=10` is not one:
+on this family it is `GET_FC41D_INFO`, the WiFi module version query, and it is
+only the *B2500* that restarts with `cd=10`. Reaching for that number on a Venus
+queries the WiFi module instead.
 
 The second generation writes its numbers zero-padded (`cd=01`, `cd=05`) where
 hm2mqtt sends them bare. The first generation's B2500 code does the same, and
@@ -159,6 +166,38 @@ Of the second generation, only the Venus E Mini is supported, and only partly:
 
 Everything else in the tables above is unimplemented. Venus X and Venus G have
 no device definitions at all.
+
+## Cross-checked against firmware
+
+The first generation's side of this page has since been checked against real
+device firmware, from the community archive at
+[sphings79/marstek-firmware-archiv](https://github.com/sphings79/marstek-firmware-archiv).
+The Venus control firmware images are unencrypted ARM Cortex-M binaries whose
+strings include the `cd=1` response format string and the parameter names the
+MQTT handler parses, so they say what the *device* accepts rather than what one
+client happens to send.
+
+Three things that came out of it, from `VNSD-0` control 150:
+
+- **There is no reboot command on the first generation.** The only reboot string
+  in the image is `system will reboot!`, sitting next to `Reset, clear all…`,
+  `Reset, clear part…` and `Reset, clear cert…` — rebooting is a side effect of
+  the reset command, not a command of its own. `cd=61` really is new in the
+  second generation.
+- **`cd=5` has a third variant.** The image contains `rs=1`, `rs=2` *and*
+  `rs=3`, matching those three reset strings. Only `rs=1` and `rs=2` are
+  documented in [venus.md](venus.md), and the app never sends `rs=3`. It is
+  present in every archived build back to v147, and in `VNSA-0` and `VNSE3-0`
+  too. Which `rs` value maps to which variant is inferred from their order in
+  the binary, not proven — the strings have no literal-pool references to
+  follow.
+- **`ct_dev=` and `ip=` are real.** Both appear in the firmware's parameter
+  table, confirming the app-side readings of the conditional third meter
+  parameter and of `setP1MeterIp`.
+
+Feature timing lines up with the archive's own changelog: `soh` appears in
+control 149.2, `peak_status`/`peak_power` in 150 — the release that lists "Add
+Peak-shaving function".
 
 ## Confidence
 

--- a/src/device/venus.ts
+++ b/src/device/venus.ts
@@ -87,6 +87,41 @@ enum CommandType {
   SET_PEAK_SHAVING = 63,
 }
 
+// Fields the control firmware sends in its cd=1 response that neither the
+// Marstek app nor this project has a meaning for. Read out of the firmware's
+// own response format string (see docs/venus-generations.md), so the device
+// really does send them - what is missing is what they mean. Published
+// verbatim and disabled by default, so the values can be correlated without
+// asserting semantics.
+//
+// Three more fields from that format string are deliberately left out, because
+// they are not plain integers and would be mangled by `number()`:
+//
+// - `id` is a pipe-separated 5-tuple (`id=%d|%d|%d|%d|%d`)
+// - `ei` is a 64-bit hex value (`ei=%llx`)
+// - `eb` is a hex value (`eb=%x`)
+//
+// `bl` is included here rather than wired to the Bluetooth Advertising switch:
+// that already reads bit 2 of `ble`, and nothing establishes that `bl` is the
+// same flag rather than a second, related one.
+const venusRawFields = [
+  'as',
+  'bl',
+  'bl_p',
+  'c_ratio',
+  'ctrl_r',
+  'gen',
+  'lf',
+  'lk',
+  'net',
+  'pl',
+  'tra_a',
+  'tra_i',
+  'tra_o',
+  'udp',
+  'vp',
+];
+
 // Minimum and maximum Depth of Discharge values based on Marstek app limits (30-88%).
 // NOTE: Experience has shown that these limits may change over time!
 const DOD_MIN = 30;
@@ -1255,6 +1290,55 @@ function registerRuntimeInfoMessage(message: BuildMessageFn) {
       }),
       { enabled: state => (state.peakShavingPower != null ? true : undefined) },
     );
+
+    // State of health. Added to the cd=1 response in control firmware 149.2,
+    // so it only appears on units new enough to send it. The same quantity is
+    // reported as `b_soh` in the cd=14 BMS response, where a real capture read
+    // 100 on a healthy pack - hence the percentage. That capture is the whole
+    // basis for the unit: no cd=1 payload carrying `soh` has been seen, so if
+    // a device ever reports something like 1000 here, the scale is wrong and
+    // this wants dividing by 10.
+    //
+    // Deliberately not device_class 'battery': that is the charge level, and
+    // Home Assistant would render state of health as if it were one.
+    field({ key: 'soh', path: ['batteryHealth'], transform: number() });
+    advertise(
+      ['batteryHealth'],
+      sensorComponent<number>({
+        id: 'battery_health',
+        name: 'Battery Health',
+        icon: 'mdi:battery-heart-variant',
+        unit_of_measurement: '%',
+        state_class: 'measurement',
+      }),
+      { enabled: state => (state.batteryHealth != null ? true : undefined) },
+    );
+
+    // Same key and meaning as on Jupiter, which already names it.
+    field({ key: 'htt_p', path: ['httpServerType'], transform: number() });
+    advertise(
+      ['httpServerType'],
+      sensorComponent<number>({
+        id: 'http_server_type',
+        name: 'HTTP Server Type',
+        enabled_by_default: false,
+      }),
+      { enabled: state => (state.httpServerType != null ? true : undefined) },
+    );
+
+    for (const key of venusRawFields) {
+      field({ key, path: ['raw', key], transform: number() });
+      advertise(
+        ['raw', key],
+        sensorComponent<number>({
+          id: `raw_${key}`,
+          name: `Raw ${key}`,
+          icon: 'mdi:help-circle-outline',
+          enabled_by_default: false,
+        }),
+        { enabled: state => (state.raw?.[key] != null ? true : undefined) },
+      );
+    }
 
     command('peak-shaving', {
       handler: ({ message, publishCallback, updateDeviceState }) => {

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -6,9 +6,12 @@ import {
 import { VenusMiniDeviceData, VenusMiniTimePeriod } from '../types.js';
 import {
   binarySensorComponent,
+  buttonComponent,
+  numberComponent,
   sensorComponent,
   switchComponent,
 } from '../homeAssistantDiscovery.js';
+import logger from '../logger.js';
 import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '../transforms.js';
 
 /**
@@ -26,25 +29,27 @@ import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '
  * verbatim as disabled-by-default sensors under `raw`/`ctRaw` rather than being
  * given a name that asserts a meaning.
  *
- * The app's table for this model lists five commands. Three are not implemented
- * here:
+ * This model runs Marstek's second-generation Venus firmware, along with the
+ * Venus X and Venus G. That generation numbers its commands differently from
+ * the Venus C/D/E in venus.ts - depth of discharge is `cd=44` here and `cd=56`
+ * there, the LED `cd=56` here and `cd=59` there - so nothing in venus.ts can
+ * be reused, and a number read off that file is more likely wrong than right.
+ * docs/venus-generations.md has the full map and how the two are told apart.
  *
- * - `cd=60` is the Shelly scan, despite the command table calling it
- *   "配置服务器" (configure server) - the "server" is the meter the device reads
- *   from, not a broker. `NewHomeMqttTool.getScanShellyList` builds it, the
- *   parameter is `mod=1`/`mod=0` to start and stop scanning, and the device
- *   answers with the Shellys it found on its own network:
- *   `cd=60,[{"id":…,"mac":…,"ip":…,"rssi":…,"model":…,"name":…,"ver":…}]`.
- *   `cd=61` then connects to one over RPC and `cd=62,shelly_pro=<port>` sets
- *   its port. Not implemented because the reply is a JSON array, which the
- *   key=value parser cannot represent - this needs parser work, not just a
- *   command.
- * - `CMD_SET_WIFI` (configure device WiFi) carries network credentials.
- * - `cd=63,ct_chg_type=<n>` (configure recharge type) takes a value whose
- *   domain is not in the app; the device reports the setting back as
- *   `rechg_type`, of which only 0 has ever been seen, so there is nothing to
- *   map a control onto yet.
+ * Not implemented from this model's command table:
+ *
+ * - `cd=60,ser=<n>` (configure server), whose value domain is not in the app.
+ *   The device reports the setting back as `rechg_type`'s neighbour `ser`, of
+ *   which only 0 has been seen.
+ * - `CMD_SET_WIFI` (configure device WiFi) carries network credentials, and is
+ *   Bluetooth-only anyway - it has no MQTT form.
+ * - `cd=63,ct_chg_type=<n>` (configure recharge type), also with no known
+ *   value domain; the device reports it back as `rechg_type`, only ever 0.
  */
+
+// The app's own setting screen enforces this range.
+const MINI_DOD_MIN = 30;
+const MINI_DOD_MAX = 90;
 
 const requiredMiniRuntimeInfoKeys = ['gp', 'lp', 'soc', 'be', 'pmu', 'wif_s', 'mq_s', 'm1', 'time'];
 function isVenusMiniRuntimeInfoMessage(values: Record<string, string>): boolean {
@@ -262,14 +267,36 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     field({ key: 'do', path: ['dischargeDepth'], transform: number() });
     advertise(
       ['dischargeDepth'],
-      sensorComponent<number>({
+      numberComponent({
         id: 'discharge_depth',
         name: 'Discharge Depth',
         device_class: 'battery',
         unit_of_measurement: '%',
-        state_class: 'measurement',
+        command: 'discharge-depth',
+        min: MINI_DOD_MIN,
+        max: MINI_DOD_MAX,
+        step: 1,
       }),
     );
+    // `cd=44,do=` is the second-generation form. The first-generation Venus
+    // models use `cd=56,dod=` for the same setting - see
+    // docs/venus-generations.md. Deliberately without the first generation's
+    // quirk of sending its maximum as 0: that is a property of that firmware,
+    // and nothing says this one shares it.
+    command('discharge-depth', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        const dod = /^\d+$/.test(message) ? parseInt(message, 10) : NaN;
+        if (Number.isNaN(dod) || dod < MINI_DOD_MIN || dod > MINI_DOD_MAX) {
+          logger.warn(
+            `Invalid depth of discharge value (should be ${MINI_DOD_MIN}-${MINI_DOD_MAX}):`,
+            message,
+          );
+          return;
+        }
+        updateDeviceState(() => ({ dischargeDepth: dod }));
+        publishCallback(`cd=44,do=${dod}`);
+      },
+    });
 
     // pmu matched the firmware version reported by the Hame cloud API for the
     // same device exactly.
@@ -825,6 +852,29 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
           message.toLowerCase() === 'true' || message.toLowerCase() === 'on' || message === '1';
         updateDeviceState(() => ({ bluetoothAdvertisingEnabled: enable }));
         publishCallback(`cd=55,adv=${enable ? 1 : 0}`);
+      },
+    });
+
+    // Reboot, `cd=61`. The first-generation Venus models restart with `cd=10`;
+    // this is the second generation's number for it. No parameters, so there
+    // is nothing here to get wrong beyond the number itself. Disabled by
+    // default, matching the reset buttons on the other families.
+    advertise(
+      [],
+      buttonComponent({
+        id: 'restart',
+        name: 'Restart',
+        icon: 'mdi:restart',
+        command: 'restart',
+        payload_press: 'PRESS',
+        enabled_by_default: false,
+      }),
+    );
+    command('restart', {
+      handler: ({ message, publishCallback }) => {
+        if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
+          publishCallback('cd=61');
+        }
       },
     });
   });

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -4,7 +4,11 @@ import {
   registerDeviceDefinition,
 } from '../deviceDefinition.js';
 import { VenusMiniDeviceData, VenusMiniTimePeriod } from '../types.js';
-import { binarySensorComponent, sensorComponent } from '../homeAssistantDiscovery.js';
+import {
+  binarySensorComponent,
+  sensorComponent,
+  switchComponent,
+} from '../homeAssistantDiscovery.js';
 import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '../transforms.js';
 
 /**
@@ -15,11 +19,22 @@ import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '
  * HMG/VNSE3/VNSA/VNSD family, so it gets its own definition here rather than
  * reusing anything in `venus.ts`.
  *
- * Only `cd=1` has been captured for this model, and no write/set command
- * formats have been verified against a real device, so this definition is
- * read-only. Fields whose meaning is not confirmed are exposed verbatim as
- * disabled-by-default sensors under `raw` rather than being given a name that
- * asserts a meaning.
+ * Only `cd=1` has been captured from a real device. The command formats here
+ * are read out of the Marstek app's own command table for this model rather
+ * than observed on hardware, so they are the app's ground truth but not yet
+ * confirmed end to end. Fields whose meaning is not confirmed are exposed
+ * verbatim as disabled-by-default sensors under `raw`/`ctRaw` rather than being
+ * given a name that asserts a meaning.
+ *
+ * The app's table for this model lists five commands. Three are deliberately
+ * not implemented here:
+ *
+ * - `cd=60` (configure server) would repoint the device at a different broker.
+ * - `CMD_SET_WIFI` (configure device WiFi) carries network credentials.
+ * - `cd=63,ct_chg_type=<n>` (configure recharge type) takes a value whose
+ *   domain is not in the app; the device reports the setting back as
+ *   `rechg_type`, of which only 0 has ever been seen, so there is nothing to
+ *   map a control onto yet.
  */
 
 const requiredMiniRuntimeInfoKeys = ['gp', 'lp', 'soc', 'be', 'pmu', 'wif_s', 'mq_s', 'm1', 'time'];
@@ -31,6 +46,10 @@ const requiredCtPowerKeys = ['power_a', 'power_b', 'power_c'];
 function isVenusMiniCtPowerMessage(values: Record<string, string>): boolean {
   return requiredCtPowerKeys.every(key => key in values);
 }
+
+// Keys the vendor app parses alongside power_a..power_s, with no confirmed
+// meaning. See registerVenusMiniCtPowerMessage.
+const venusMiniCtRawFields = ['d_p', 'ct_st', 'gn_pwr', 'gn_pwr1', 'gf_pwr', 'bat_pwr'] as const;
 
 function extractMiniAdditionalDeviceInfo(state: VenusMiniDeviceData) {
   return {
@@ -119,7 +138,7 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     pollInterval: globalPollInterval,
     controlsDeviceAvailability: true,
   };
-  message<VenusMiniDeviceData>(options, ({ field, advertise }) => {
+  message<VenusMiniDeviceData>(options, ({ field, advertise, command }) => {
     advertise(
       ['timestamp'],
       sensorComponent<string>({
@@ -738,24 +757,61 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         { enabled: state => (state.raw?.[key] != null ? true : undefined) },
       );
     }
+
+    // Bluetooth advertising, `cd=55,adv=1` to enable and `cd=55,adv=0` to
+    // disable. The Marstek app builds this command from the device type: the
+    // Venus variants take 55, Jupiter takes 57, and everything else — the Mini
+    // included — falls back to 55. The Mini's own command table names `cd=55`
+    // "set bluetooth advertising state", which agrees.
+    //
+    // Unlike the other Venus models, the Mini reports no advertising state in
+    // its cd=1 payload (`bbs` is the Bluetooth *lock* reading and does not
+    // track this), so the switch shows the last value hm2mqtt wrote and only
+    // appears once something has been written.
+    advertise(
+      ['bluetoothAdvertisingEnabled'],
+      switchComponent({
+        id: 'bluetooth_advertising',
+        name: 'Bluetooth Advertising',
+        icon: 'mdi:bluetooth',
+        command: 'bluetooth-advertising',
+        // Write-only: the Mini never reports advertising state, so the switch
+        // runs optimistic and shows the last value that was set.
+        optimistic: true,
+      }),
+    );
+    command('bluetooth-advertising', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        const enable =
+          message.toLowerCase() === 'true' || message.toLowerCase() === 'on' || message === '1';
+        updateDeviceState(() => ({ bluetoothAdvertisingEnabled: enable }));
+        publishCallback(`cd=55,adv=${enable ? 1 : 0}`);
+      },
+    });
   });
 }
 
 /**
- * Per-phase CT readings, requested with `cd=19` and answered with one key per
- * phase plus the three-phase total, all in watts — where the other Venus models
- * pack the same five values into a single pipe-separated `get_power` field.
+ * Per-phase CT readings, answered with one key per phase plus the three-phase
+ * total, all in watts — where the other Venus models pack the same five values
+ * into a single pipe-separated `get_power` field.
  *
  * `power_a`/`power_b`/`power_c` are phases A/B/C and `power_s` the three-phase
  * total; the phase order is established rather than inferred from the key
- * names. Unlike the `cd=1` fields above this has not been seen from a real
- * device — the unit these mappings were checked against reports `ct_type=0`,
- * meaning no external meter is configured, so it never answers `cd=19`. The
+ * names.
+ *
+ * Requested with `cd=59`. The Marstek app asks this model for power with
+ * `cd=59` ("get NOW statistics power") and never sends it `cd=19` at all —
+ * `cd=19` belongs to the other Venus variants, which declare both commands
+ * separately. hm2mqtt used to send `cd=19` here, which was a guess carried over
+ * from those variants. Neither number has been confirmed against a real Mini:
+ * the unit these mappings were checked against reports `ct_type=0`, meaning no
+ * external meter is configured, so it answers no power request at all. The
  * entities only appear once a device actually reports the keys.
  */
 function registerVenusMiniCtPowerMessage(message: BuildMessageFn) {
   const options = {
-    refreshDataPayload: 'cd=19',
+    refreshDataPayload: 'cd=59',
     isMessage: isVenusMiniCtPowerMessage,
     publishPath: 'ct',
     defaultState: {},
@@ -782,6 +838,26 @@ function registerVenusMiniCtPowerMessage(message: BuildMessageFn) {
           unit_of_measurement: 'W',
           state_class: 'measurement',
         }),
+      );
+    }
+
+    // The vendor app reads six more keys immediately after power_a..power_s in
+    // the same parser. The names suggest power readings — battery, grid, grid
+    // feed-in — but nothing in the app confirms a unit, a sign convention or
+    // what distinguishes gn_pwr from gn_pwr1, so they follow the same rule as
+    // the unconfirmed cd=1 fields above: published verbatim, disabled by
+    // default, no device_class that would assert a meaning.
+    for (const key of venusMiniCtRawFields) {
+      field({ key, path: ['ctRaw', key], transform: number() });
+      advertise(
+        ['ctRaw', key],
+        sensorComponent<number>({
+          id: `raw_${key}`,
+          name: `Raw ${key}`,
+          icon: 'mdi:help-circle-outline',
+          enabled_by_default: false,
+        }),
+        { enabled: state => (state.ctRaw?.[key] != null ? true : undefined) },
       );
     }
   });

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -768,10 +768,29 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     }
 
     // Bluetooth advertising, `cd=55,adv=1` to enable and `cd=55,adv=0` to
-    // disable. The Marstek app builds this command from the device type: the
-    // Venus variants take 55, Jupiter takes 57, and everything else — the Mini
-    // included — falls back to 55. The Mini's own command table names `cd=55`
-    // "set bluetooth advertising state", which agrees.
+    // disable.
+    //
+    // `cd=55` is solid: the Mini's own command table names it
+    // CMD_SET_BLUETOOTH_STATE, and CommonCommand.handleBleSwitch reaches the
+    // same number for a Mini through its fallback arm (Venus 55, Jupiter 57,
+    // everything else 55).
+    //
+    // The `adv=` parameter is NOT solid, and the reason matters. The app has
+    // two generations of Venus code. The first - Venus C/D/E, the HMG/VNSE3/
+    // VNSA/VNSD this repo already supports - lives in pages/Ac_Coupler with
+    // CommonCommand and talks over `hame_energy/…`. The second - Venus X,
+    // Venus G and this model - lives in modules/devices with its own
+    // DataVenus* command tables and talks over `marstek_energy/…` via
+    // VNXMqttStrategy. The two disagree on numbering wherever they both
+    // implement something: depth of discharge is 56 then 44, the LED 59 then
+    // 56, set-time 4 then 33, network info 26 then 03.
+    //
+    // `adv=` comes from handleBleSwitch, which is first-generation. The
+    // Mini's own second-generation descriptor is a bare `cd=55` whose
+    // parameter is filled in at the call site, and that call site has not been
+    // read. So the number is confirmed for this model and the parameter name
+    // is borrowed from the older line - worth confirming on a device before
+    // trusting it.
     //
     // Kept optimistic, but not because nothing reports the state back: `bbs`
     // in the cd=1 payload is the likely readback. The app's own label for

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -26,10 +26,19 @@ import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '
  * verbatim as disabled-by-default sensors under `raw`/`ctRaw` rather than being
  * given a name that asserts a meaning.
  *
- * The app's table for this model lists five commands. Three are deliberately
- * not implemented here:
+ * The app's table for this model lists five commands. Three are not implemented
+ * here:
  *
- * - `cd=60` (configure server) would repoint the device at a different broker.
+ * - `cd=60` is the Shelly scan, despite the command table calling it
+ *   "配置服务器" (configure server) - the "server" is the meter the device reads
+ *   from, not a broker. `NewHomeMqttTool.getScanShellyList` builds it, the
+ *   parameter is `mod=1`/`mod=0` to start and stop scanning, and the device
+ *   answers with the Shellys it found on its own network:
+ *   `cd=60,[{"id":…,"mac":…,"ip":…,"rssi":…,"model":…,"name":…,"ver":…}]`.
+ *   `cd=61` then connects to one over RPC and `cd=62,shelly_pro=<port>` sets
+ *   its port. Not implemented because the reply is a JSON array, which the
+ *   key=value parser cannot represent - this needs parser work, not just a
+ *   command.
  * - `CMD_SET_WIFI` (configure device WiFi) carries network credentials.
  * - `cd=63,ct_chg_type=<n>` (configure recharge type) takes a value whose
  *   domain is not in the app; the device reports the setting back as

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -764,10 +764,20 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     // included — falls back to 55. The Mini's own command table names `cd=55`
     // "set bluetooth advertising state", which agrees.
     //
-    // Unlike the other Venus models, the Mini reports no advertising state in
-    // its cd=1 payload (`bbs` is the Bluetooth *lock* reading and does not
-    // track this), so the switch shows the last value hm2mqtt wrote and only
-    // appears once something has been written.
+    // Kept optimistic, but not because nothing reports the state back: `bbs`
+    // in the cd=1 payload is the likely readback. The app's own label for
+    // cd=55 is "设置蓝牙广播状态" - set Bluetooth *broadcast state* - which is
+    // what bbs reads like, and it has only ever been seen as 0 or 1. What is
+    // missing is the polarity. The one hardware note on bbs (see
+    // bluetoothLockRaw above) says enabling the Bluetooth *lock* raises it,
+    // which would make it the inverse of advertising, and that the mapping
+    // across LED x lock combinations did not come out cleanly - so bbs may not
+    // be tracking this setting alone.
+    //
+    // A switch wired to the wrong polarity shows the opposite of reality,
+    // which is worse than showing nothing, so this stays optimistic until
+    // someone toggles it on a device and reports which way bbs moves. The
+    // other Venus models do report advertising back, in `ble` bit 2.
     advertise(
       ['bluetoothAdvertisingEnabled'],
       switchComponent({
@@ -775,8 +785,9 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Bluetooth Advertising',
         icon: 'mdi:bluetooth',
         command: 'bluetooth-advertising',
-        // Write-only: the Mini never reports advertising state, so the switch
-        // runs optimistic and shows the last value that was set.
+        // Optimistic: the readback is probably `bbs`, but its polarity is
+        // unconfirmed, so the switch shows the last value set instead of a
+        // state that might be inverted. See the note above.
         optimistic: true,
       }),
     );

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1773,6 +1773,42 @@ const commandTestCases: CommandTestCase[] = [
     input: '1',
     expectedOutput: 'cd=22,p1=1',
   },
+
+  // ============================================================
+  // VENUS E MINI COMMANDS
+  // ============================================================
+
+  // The Marstek app picks this command's number from the device type: the
+  // Venus variants take 55, Jupiter 57, and everything else — the Mini
+  // included — falls back to 55.
+  {
+    description: 'Venus E Mini bluetooth-advertising enable',
+    deviceType: 'VNSEMINI-0',
+    command: 'bluetooth-advertising',
+    input: 'true',
+    expectedOutput: 'cd=55,adv=1',
+  },
+  {
+    description: 'Venus E Mini bluetooth-advertising disable',
+    deviceType: 'VNSEMINI-0',
+    command: 'bluetooth-advertising',
+    input: 'false',
+    expectedOutput: 'cd=55,adv=0',
+  },
+  {
+    description: 'Venus E Mini bluetooth-advertising with on',
+    deviceType: 'VNSEMINI-0',
+    command: 'bluetooth-advertising',
+    input: 'on',
+    expectedOutput: 'cd=55,adv=1',
+  },
+  {
+    description: 'Venus E Mini bluetooth-advertising with 1',
+    deviceType: 'VNSEMINI-0',
+    command: 'bluetooth-advertising',
+    input: '1',
+    expectedOutput: 'cd=55,adv=1',
+  },
 ];
 
 describe('Device Commands', () => {

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1809,6 +1809,74 @@ const commandTestCases: CommandTestCase[] = [
     input: '1',
     expectedOutput: 'cd=55,adv=1',
   },
+
+  // Depth of discharge is cd=44 on this generation, where the Venus C/D/E use
+  // cd=56 - see docs/venus-generations.md.
+  {
+    description: 'Venus E Mini discharge-depth at the minimum',
+    deviceType: 'VNSEMINI-0',
+    command: 'discharge-depth',
+    input: '30',
+    expectedOutput: 'cd=44,do=30',
+  },
+  {
+    description: 'Venus E Mini discharge-depth at the maximum',
+    deviceType: 'VNSEMINI-0',
+    command: 'discharge-depth',
+    input: '90',
+    expectedOutput: 'cd=44,do=90',
+  },
+  {
+    description: 'Venus E Mini discharge-depth sends the maximum as itself, not 0',
+    deviceType: 'VNSEMINI-0',
+    command: 'discharge-depth',
+    input: '90',
+    expectedOutput: 'cd=44,do=90',
+  },
+  {
+    description: 'Venus E Mini discharge-depth below the minimum is rejected',
+    deviceType: 'VNSEMINI-0',
+    command: 'discharge-depth',
+    input: '29',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus E Mini discharge-depth above the maximum is rejected',
+    deviceType: 'VNSEMINI-0',
+    command: 'discharge-depth',
+    input: '91',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus E Mini discharge-depth rejects a non-integer',
+    deviceType: 'VNSEMINI-0',
+    command: 'discharge-depth',
+    input: '50.5',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus E Mini discharge-depth rejects junk',
+    deviceType: 'VNSEMINI-0',
+    command: 'discharge-depth',
+    input: '70foo',
+    expectedOutput: null,
+  },
+
+  // Reboot is cd=61 here; the Venus C/D/E restart with cd=10.
+  {
+    description: 'Venus E Mini restart with PRESS',
+    deviceType: 'VNSEMINI-0',
+    command: 'restart',
+    input: 'PRESS',
+    expectedOutput: 'cd=61',
+  },
+  {
+    description: 'Venus E Mini restart ignores an unrelated payload',
+    deviceType: 'VNSEMINI-0',
+    command: 'restart',
+    input: 'nope',
+    expectedOutput: null,
+  },
 ];
 
 describe('Device Commands', () => {

--- a/src/homeAssistantDiscovery.ts
+++ b/src/homeAssistantDiscovery.ts
@@ -36,7 +36,7 @@ export interface HaSensorComponent extends HaBaseStateComponent {
   state_class?: string;
 }
 
-export interface HaSwitchComponent extends HaBaseStateComponent {
+export interface HaSwitchComponent extends HaOptionalStateComponent {
   type: 'switch';
   command_topic: string;
   payload_on: string | number | boolean;
@@ -272,16 +272,20 @@ export const numberComponent =
   });
 export const switchComponent =
   (
-    definition: HaBaseStateComponentArgs & {
-      command: string;
-      retain?: boolean;
-    },
+    definition: HaBaseStateComponentArgs &
+      HaOptimisticComponentArgs & {
+        command: string;
+        retain?: boolean;
+      },
   ): HaStatefulAdvertiseBuilder<boolean> =>
   args => ({
-    ...baseStateSensor(definition)(args),
+    ...baseSensor(definition)(args),
+    // Deliberately valueTemplate(args) rather than the definition-aware form
+    // the other components use: a switch has never applied its defaultValue to
+    // the template, and folding one in here would change every existing switch.
+    ...stateSource(definition, args, () => valueTemplate(args)),
     type: 'switch',
     command_topic: commandTopic({ ...args, ...definition }),
-    value_template: valueTemplate(args),
     payload_on: 'true',
     payload_off: 'false',
     state_on: true,

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1568,10 +1568,11 @@ describe('MQTT Message Parser', () => {
     );
   });
 
-  test('parses the Venus E Mini per-phase CT payload (cd=19)', () => {
+  test('parses the Venus E Mini per-phase CT payload (cd=59)', () => {
     // Not from a real capture: the unit the cd=1 mappings were checked against
-    // reports ct_type=0, so it never answers cd=19. power_a/power_b/power_c are
-    // phases A/B/C and power_s the three-phase total, in watts.
+    // reports ct_type=0, so it never answers a power request at all.
+    // power_a/power_b/power_c are phases A/B/C and power_s the three-phase
+    // total, in watts.
     const message = 'power_a=230,power_b=0,power_c=-45,power_s=185,d_p=0';
     const parsed = parseMessage(message, 'VNSEMINI-0', 'venusMini123');
 
@@ -1580,8 +1581,27 @@ describe('MQTT Message Parser', () => {
     expect(result.phaseBPower).toBe(0);
     expect(result.phaseCPower).toBe(-45);
     expect(result.totalPhasePower).toBe(185);
-    // The cd=19 reply must not be mistaken for the cd=1 runtime message.
+    // The cd=59 reply must not be mistaken for the cd=1 runtime message.
     expect(parsed['data']).toBeUndefined();
+  });
+
+  test('publishes the unnamed Venus E Mini CT keys without touching cd=1 raw', () => {
+    const message =
+      'power_a=230,power_b=0,power_c=-45,power_s=185,d_p=0,ct_st=1,gn_pwr=-13,gn_pwr1=-13,gf_pwr=0,bat_pwr=-7';
+    const parsed = parseMessage(message, 'VNSEMINI-0', 'venusMini123');
+
+    const result = parsed['ct'] as VenusMiniDeviceData;
+    expect(result.ctRaw).toEqual({
+      d_p: 0,
+      ct_st: 1,
+      gn_pwr: -13,
+      gn_pwr1: -13,
+      gf_pwr: 0,
+      bat_pwr: -7,
+    });
+    // These live in their own record so the cd=1 message's `raw` survives the
+    // per-path state merge.
+    expect(result.raw).toBeUndefined();
   });
 
   test('maps Venus E Mini enum branches not covered by the primary capture', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1062,6 +1062,50 @@ describe('MQTT Message Parser', () => {
     expect(result.depthOfDischarge).toBeUndefined();
   });
 
+  test('parses the fields Venus control firmware 150 adds to cd=1', () => {
+    // Field order and names taken from the cd=1 printf format string in the
+    // VNSD-0 control firmware 150 binary, so this is the shape a real Venus D
+    // on that firmware sends. soh arrived in 149.2, peak_status/peak_power in
+    // 150. The trailing run from `lk` on is the part hm2mqtt had never read.
+    const message =
+      'cd=1,tot_i=8848,tot_o=7097,ele_d=537,ele_m=8848,grd_d=328,grd_m=7097,inc_d=0,inc_m=0,grd_f=0,grd_o=613,grd_t=3,gct_s=1,cel_s=3,cel_p=327,cel_c=64,err_t=0,err_a=0,dev_n=158,grd_y=0,wor_m=0,tim_0=0|0|0|0|0|0|0,cts_m=0,bac_u=0,tra_a=1,tra_i=2,tra_o=3,htt_p=1,prc_c=0,prc_d=1,wif_s=33,inc_a=0,set_v=0,mcp_w=2500,mdp_w=2500,ct_t=4,phase_t=1,dchrg_t=1,bms_v=212,fc_v=202409090159,wifi_n=XXX,seq_s=0,ctrl_r=1,par=255,gen=255,ble=3,shelly_p=1010,c_ratio=90,udp=0,api=1,net=1,port=30000,inv_v=115,id=2|0|0|0|0,lk=0,bp=291,ei=0,eb=0,rp=347,gp=801,vp=801,bl=1,dod=88,bl_p=-1,led=1,as=3,lf=0,pl=0,soh=98,peak_status=1,peak_power=600';
+    const parsed = parseMessage(message, 'VNSD-0', 'venus123');
+
+    expect(parsed).toHaveProperty('data');
+    const result = parsed['data'] as VenusDeviceData;
+
+    expect(result).toHaveProperty('batteryHealth', 98);
+    expect(result).toHaveProperty('httpServerType', 1);
+
+    // Unnamed fields land in `raw` under their own key.
+    expect(result.raw).toMatchObject({
+      as: 3,
+      bl: 1,
+      bl_p: -1,
+      c_ratio: 90,
+      ctrl_r: 1,
+      gen: 255,
+      lf: 0,
+      lk: 0,
+      net: 1,
+      pl: 0,
+      tra_a: 1,
+      tra_i: 2,
+      tra_o: 3,
+      udp: 0,
+      vp: 801,
+    });
+
+    // id is a pipe-separated tuple and ei/eb are hex, so none of the three is
+    // published as a number.
+    expect(result.raw).not.toHaveProperty('id');
+    expect(result.raw).not.toHaveProperty('ei');
+    expect(result.raw).not.toHaveProperty('eb');
+
+    // The switch still reads bit 2 of `ble`, not the separate `bl` field.
+    expect(result).toHaveProperty('bluetoothAdvertisingEnabled', false);
+  });
+
   test('parses Venus AI working mode (wor_m=5)', () => {
     const message =
       'cd=1,tot_i=8848,tot_o=7097,ele_d=537,ele_m=8848,grd_d=328,grd_m=7097,inc_d=0,inc_m=0,grd_f=0,grd_o=613,grd_t=3,gct_s=1,cel_s=3,cel_p=327,cel_c=64,err_t=0,err_a=0,dev_n=158,grd_y=0,wor_m=5,tim_0=0|0|0|0|0|0|0,cts_m=0,bac_u=0,tra_a=1,tra_i=0,tra_o=0,htt_p=0,prc_c=0,prc_d=1,wif_s=33,inc_a=0,set_v=0,mcp_w=2500,mdp_w=2500,ct_t=4,phase_t=1,dchrg_t=1,bms_v=212,fc_v=202409090159,wifi_n=XXX,seq_s=0,ctrl_r=1,par=255,gen=255,ble=3,shelly_p=1010,c_ratio=90,dod=88';

--- a/src/types.ts
+++ b/src/types.ts
@@ -627,6 +627,16 @@ export interface VenusDeviceData extends BaseDeviceData {
   calculatedBatteryPower?: number; // rp
   gridPower?: number; // gp
   parallelMode?: VenusParallelMode | 'unknown'; // par
+  batteryHealth?: number; // soh, control firmware 149.2 and later
+  httpServerType?: number; // htt_p, same key and meaning as on Jupiter
+  /**
+   * Fields the control firmware sends in its cd=1 response that have no
+   * confirmed meaning. Keyed by their raw MQTT field name and published as
+   * disabled-by-default sensors, so the values are available for correlation
+   * without asserting semantics — the same treatment venusEMini.ts gives its
+   * unconfirmed fields.
+   */
+  raw?: Record<string, number>;
 }
 
 // Per-slot schedule direction reported by a Venus E Mini in ms{n}, confirmed

--- a/src/types.ts
+++ b/src/types.ts
@@ -718,7 +718,7 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   gridMode?: number; // gs (raw; grid mode, individual codes unknown)
   serverState?: number; // ser (raw; server state, individual codes unknown)
   rechargeType?: number; // rechg_type (raw; recharge type, individual codes unknown)
-  bluetoothAdvertisingEnabled?: boolean; // last value written with the bluetooth-advertising command; the Mini does not report advertising state back, so this is hm2mqtt's own record of what was set
+  bluetoothAdvertisingEnabled?: boolean; // last value written with the bluetooth-advertising command. `bbs` is the likely readback but its polarity is unconfirmed, so nothing parses it into this field yet - see venusEMini.ts
   timePeriods?: VenusMiniTimePeriod[];
   // cd=59 per-phase CT readings, in W. Only reported by a unit with an external
   // meter configured, so these stay unset on a device with ct_type=0.

--- a/src/types.ts
+++ b/src/types.ts
@@ -718,13 +718,19 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   gridMode?: number; // gs (raw; grid mode, individual codes unknown)
   serverState?: number; // ser (raw; server state, individual codes unknown)
   rechargeType?: number; // rechg_type (raw; recharge type, individual codes unknown)
+  bluetoothAdvertisingEnabled?: boolean; // last value written with the bluetooth-advertising command; the Mini does not report advertising state back, so this is hm2mqtt's own record of what was set
   timePeriods?: VenusMiniTimePeriod[];
-  // cd=19 per-phase CT readings, in W. Only reported by a unit with an external
+  // cd=59 per-phase CT readings, in W. Only reported by a unit with an external
   // meter configured, so these stay unset on a device with ct_type=0.
   phaseAPower?: number; // power_a
   phaseBPower?: number; // power_b
   phaseCPower?: number; // power_c
   totalPhasePower?: number; // power_s
+  // Further cd=59 keys the vendor app reads next to power_a..power_s, with no
+  // confirmed meaning. Kept in their own record rather than in `raw` below:
+  // device state is merged per publish path, so one shared record would let
+  // whichever of the two messages arrived last erase the other's keys.
+  ctRaw?: Record<string, number>;
   // Fields observed in the payload with no confirmed meaning, keyed by their
   // raw MQTT field name (eg, cv, ct (bare, distinct from ct_type), gn, ar,
   // aw, apt, e1-e7, tgb/tgp). Exposed as disabled-by-default sensors so the


### PR DESCRIPTION
The second-generation wire formats here come from the Marstek app, not from a device. Someone with a Venus E Mini should confirm before this merges.

## The finding this rests on

Marstek's Venus line is **two firmware generations**, and hm2mqtt only knew about the first.

|                | First generation | Second generation |
| -------------- | ---------------- | ----------------- |
| Products       | Venus C, E, A, D — `HMG`, `VNSE3`, `VNSA`, `VNSD` | Venus X, Venus G, **Venus E Mini** |
| App code       | `pages/Ac_Coupler` + `CommonCommand` | `modules/devices` + `DataVenus*` |
| Topics         | `hame_energy/…/` | `marstek_energy/…/` |
| Strategy       | `VenusMqttStrategy` | `VNXMqttStrategy` |

`mqtt_factory` routes `VNSEMINI` behind `VNXMqttStrategy` alongside `VENX`, `VNSG` and `VNSGPV`, and `MqttSendMixin.TOPIC` in that tree builds `marstek_energy` topics.

Where both generations implement the same thing, the numbers moved: depth of discharge `56` → `44`, LED `59` → `56`, set-time `4` → `33`, network info `26` → `03`. Working mode, factory reset, CT/meter, get-CT-power and bluetooth happen to agree, which is why the split is easy to miss.

**`docs/venus-generations.md`** is new and carries the whole thing: how to tell the generations apart, every collision, and the full second-generation command map for the shared base, Venus X, Venus G and the Mini. Venus X and Venus G have no device definitions today, so that map is also the groundwork for them.

## Venus E Mini

**Its power request is `cd=59`, not `cd=19`.** `DataVenusX` declares `cd=19` (`CMD_GET_CT_POWER`) and `cd=59` (`CMD_GET_NOW_POWER`) as separate commands; the Mini's table has only `cd=59`. The old poll could not have been answered, so the per-phase CT sensors would never have appeared. (Unreleased, so this never reached anyone.)

**Six further keys published.** `d_p`, `ct_st`, `gn_pwr`, `gn_pwr1`, `gf_pwr`, `bat_pwr` sit immediately after `power_a`..`power_s` in `DevVenusB.inflateMqttData`. Nothing confirms a unit or sign convention, so they follow this file's rule for unconfirmed fields: verbatim, disabled by default, no `device_class`. They live in their own `ctRaw` record — device state merges per publish path, so one shared record would let whichever message arrived last erase the other's keys. There's a test for that.

**Bluetooth advertising** `cd=55,adv=<0|1>`, **discharge depth** `cd=44,do=<30..90>` (the device reports `do` back, so the read-only sensor becomes a real control), and **restart** `cd=61`, disabled by default.

Parameter names are not guessed: `venus_model.dart` names them one setter per command — `setDOD` → `do=`, `setBluetoothState` → `adv=`, `setLEDState` → `led=`, `setServer` → `ser=`, `setCT` → `meter=`, and so on.

Discharge depth deliberately omits the first generation's quirk of sending its maximum as `0` — that's a property of that firmware, and nothing says this one shares it.

## Venus C/D/E, from real firmware

Checked the first generation against device firmware from the community archive at [sphings79/marstek-firmware-archiv](https://github.com/sphings79/marstek-firmware-archiv). The control images are unencrypted ARM Cortex-M binaries whose strings include the `cd=1` response format string and the parameter names the MQTT handler parses — so they say what the *device* accepts, not what one client happens to send.

Of the 79 fields `VNSD-0` control 150 sends in `cd=1`, hm2mqtt read 59. Added:

- **`soh` as a Battery Health sensor.** New in control 149.2, so it appears only once a device reports it. The same quantity is `b_soh` in the `cd=14` BMS response, where a real capture read `100` on a healthy pack — that's the whole basis for the percent unit, since no `cd=1` payload carrying `soh` has been seen. If a device ever reports `1000`, the scale is wrong and it wants a `divide(10)`. Not `device_class: battery`: that's charge level, and HA would render state of health as one.
- **`htt_p` as HTTP Server Type**, the same key Jupiter already names.
- **15 raw diagnostics**, disabled by default: `as bl bl_p c_ratio ctrl_r gen lf lk net pl tra_a tra_i tra_o udp vp`.

Three fields from that format string are left out because `number()` would mangle them: `id` is a pipe-separated 5-tuple, `ei` is `%llx`, `eb` is `%x`. And `bl` goes to raw rather than to the Bluetooth Advertising switch, which reads bit 2 of `ble` — nothing establishes the two are the same flag.

The firmware also settles two things the app could not:

- **There is no reboot on the first generation.** The only reboot string is `system will reboot!`, sitting next to `Reset, clear all…` / `Reset, clear part…` / `Reset, clear cert…` — rebooting is a side effect of reset. `cd=61` is genuinely new in the second generation, and `cd=10` is `GET_FC41D_INFO` here, not the B2500's restart.
- **`cd=5` has an undocumented third variant.** The image carries `rs=1`, `rs=2` *and* `rs=3`, matching those three reset strings, in every archived build back to v147 and on `VNSA-0` and `VNSE3-0` too. The app never sends `rs=3`. Which value maps to which variant is inferred from their order in the binary, not proven — the strings have no literal-pool references to follow.

Feature timing matches the archive's changelog: `soh` in 149.2, `peak_status`/`peak_power` in 150, the release that lists "Add Peak-shaving function".

## One shared change

`switchComponent` had no optimistic support, unlike `textComponent` and `selectComponent`, so it now goes through the same `stateSource` helper and `HaSwitchComponent` extends `HaOptionalStateComponent`. Without it `discoveryStateTopics.test.ts` correctly rejects a switch advertising a state topic nothing publishes (#346). The template deliberately stays `valueTemplate(args)` rather than the definition-aware form the others use — a switch has never applied its `defaultValue` there, and changing that would affect every existing switch.

## Why the bluetooth switch is optimistic

Not because nothing reports back. `bbs` is the likely readback — the app's label for `cd=55` is *set Bluetooth broadcast state*, and `bbs` has only ever been seen as `0` or `1`. What's missing is the **polarity**: the one hardware note on `bbs` says enabling the Bluetooth *lock* raises it, which would make it the inverse, and the mapping across LED × lock combinations didn't come out cleanly. A switch wired backwards shows the opposite of reality, which is worse than showing nothing.

**Toggling it on a device and reporting which way `bbs` moves is the single most useful thing a reviewer with hardware could do.**

## Not implemented

| Command | Why not |
| --- | --- |
| `cd=60,ser=` (configure server) | Value domain unknown; the device only ever reports `ser=0` |
| `cd=63,ct_chg_type=` (recharge type) | Same — only `rechg_type=0` ever seen |
| `CMD_SET_WIFI` | Carries network credentials, and is Bluetooth-only — no MQTT form |
| Shelly scan | `NewHomeMqttTool.getScanShellyList` builds `cd=60` with `mod=1`/`mod=0`, and the device answers with a JSON array of the Shellys on its network. hm2mqtt's `key=value` parser can't represent that — parser work, not a command |

Note `cd=60` carries two meanings depending on its parameter: `ser=` configures the server, `mod=` runs the Shelly scan. Documented in the new docs page.

## Changelog

Mini support is unreleased, so its changes fold into the existing `[Next]` entry — no user-visible change to describe and nothing to file under Fixed. The Venus sensors get their own lines. The new docs page gets none: the changelog is for user-visible behaviour changes.

## How it was validated

```
npm run lint
npm run format:check
npm test -- --runInBand   # 629 passed
npm run build
```

New tests cover the `cd=59` reply, the `ctRaw`/`raw` separation, the four `bluetooth-advertising` input forms, the discharge-depth range and rejections, restart, and the Venus `cd=1` fields — that last one built from the firmware's own format string and field order.

**Not validated against hardware.** The unit the original Mini `cd=1` mappings came from reports `ct_type=0` — no external meter — so it answers no power request at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EU9u29MvKtGoCYhcR2r12


## Summary by CodeRabbit

- **New Features**
  - Added Venus E Mini controls for Bluetooth advertising, discharge depth, and device restart.
  - Added Venus battery health and HTTP server sensors.
  - Added optional raw diagnostic sensors for advanced monitoring.
  - Added support for Venus E Mini Bluetooth and CT data.

- **Documentation**
  - Documented Venus E Mini commands and Venus firmware generations.
  - Updated device capabilities and sensor documentation.

- **Bug Fixes**
  - Improved Home Assistant switch discovery for controls without reported state.
