### PR TITLE
Venus E Mini: the rest of the evidenced commands, and align the entities with the other Venus models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,17 @@ For every new or changed config option, treat the following as mandatory complet
 
 `CHANGELOG.md` is read by users, not developers.
 
-- Describe what the user saw and what changed for them, in a few sentences.
-- No internals: file, function or symbol names, data structures, code paths. If
-  a sentence only makes sense with the diff open, it belongs in the commit
-  message instead.
+- **Keep it short. One or two sentences.** Say what changed for the user and
+  stop. When in doubt, cut — an entry that is too terse costs a reader nothing,
+  one that is too long costs every reader.
+- **No implementation detail, and ideally no detail at all.** Not just file,
+  function or symbol names: also protocol fields, command numbers, entity id
+  lists, counts of things added, and enumerations of every new control. "The
+  same sensors and controls as the other Venus models" beats naming all nine of
+  them.
+- If a sentence only makes sense with the diff open, it belongs in the commit
+  message instead. The commit message and the PR body are where detail goes;
+  they have no length limit and the right audience.
 - End with the issue reference, plus the PR number once it exists:
   `(fixes #123, PR #124)`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors, a *Discharge Depth* control, a *Bluetooth Advertising* switch and a *Restart* button. Beta: some values may be wrong, the controls were taken from the Marstek app rather than confirmed on a device, and both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
+- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors plus *Discharge Depth*, *Working Mode*, *Meter Type*, *Meter MAC*, *Bluetooth Advertising*, *Restart* and *Factory Reset* controls. Beta: some values may be wrong, the controls were taken from the Marstek app rather than confirmed on a device, and both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
 - Venus: New *Battery Health* sensor, showing the battery's state of health. Reported by control firmware 149.2 and later, so it appears only on devices new enough to send it (PR #437)
 - Venus: Fifteen further readings the device sends but nobody had a meaning for are now published as raw diagnostic sensors, disabled by default, so they can be correlated against what your device is doing. If you work out what one of them means, please say so (PR #437)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors plus *Discharge Depth*, *Working Mode*, *Meter Type*, *Meter MAC*, *Bluetooth Advertising*, *Restart* and *Factory Reset* controls. Beta: some values may be wrong, the controls were taken from the Marstek app rather than confirmed on a device, and both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
+- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors plus *Depth of Discharge*, *Working Mode*, *Meter Type*, *Meter MAC*, *Bluetooth Advertising*, *Refresh*, *Get CT Power*, *Restart* and *Factory Reset* controls, named and behaving like the ones on the other Venus models. Beta: some values may be wrong, the controls were taken from the Marstek app rather than confirmed on a device, and both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
 - Venus: New *Battery Health* sensor, showing the battery's state of health. Reported by control firmware 149.2 and later, so it appears only on devices new enough to send it (PR #437)
 - Venus: Fifteen further readings the device sends but nobody had a meaning for are now published as raw diagnostic sensors, disabled by default, so they can be correlated against what your device is doing. If you work out what one of them means, please say so (PR #437)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 
 ### Added
 
-- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini. Sensors plus *Depth of Discharge*, *Working Mode*, *Meter Type*, *Meter MAC*, *Bluetooth Advertising*, *Refresh*, *Get CT Power*, *Restart* and *Factory Reset* controls, named and behaving like the ones on the other Venus models. Beta: some values may be wrong, the controls were taken from the Marstek app rather than confirmed on a device, and both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437)
+- Support the `VNSEMINI-X` device type (e.g. `VNSEMINI-0`): the Marstek Venus E Mini, with the same sensors and controls as the other Venus models where it has them. Beta: some readings may be wrong and the controls are unconfirmed on real hardware, so both may still change (discussion #425, PR #429, PR #430, PR #433, PR #437, PR #438)
 - Venus: New *Battery Health* sensor, showing the battery's state of health. Reported by control firmware 149.2 and later, so it appears only on devices new enough to send it (PR #437)
-- Venus: Fifteen further readings the device sends but nobody had a meaning for are now published as raw diagnostic sensors, disabled by default, so they can be correlated against what your device is doing. If you work out what one of them means, please say so (PR #437)
+- Venus: Further readings the device sends but nobody has a meaning for yet are now published as diagnostic sensors, disabled by default. If you work out what one of them means, please say so (PR #437)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The device type can be one of the following:
 - **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
 - **VNSA-X**: (e.g. VNSA-1) Venus A
 - **VNSD-X**: (e.g. VNSD-1) Venus D
-- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus *Discharge Depth*, *Working Mode*, *Bluetooth Advertising*, *Meter Type*, *Meter MAC*, *Restart* and *Factory Reset* controls. None of the other Venus write commands apply to it.
+- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus *Depth of Discharge*, *Working Mode*, *Bluetooth Advertising*, *Meter Type*, *Meter MAC*, *Refresh*, *Get CT Power*, *Restart* and *Factory Reset* controls, which carry the same names and options as their Venus counterparts. The remaining Venus write commands do not apply to it.
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus
@@ -756,10 +756,10 @@ Venus commands above.
 - `discharge-depth`: Sets the usable-discharge percentage, 30-90%. The device
   reports the setting back, so the *Discharge Depth* entity shows its real
   state.
-- `working-mode`: Sets the working mode (`selfConsumption`, `manual` or `ai`).
-  The mode codes differ from the Venus C/D/E ones above, so the option names
-  differ too. The device reports its current mode in the separate *Operating
-  Mode* sensor; the *Working Mode* select shows the last value that was set.
+- `working-mode`: Sets the working mode (`automatic`, `manual` or `ai`) — the
+  same option names as the Venus command above, though this model sends
+  different codes for them and has no `trading` mode. The device reports its
+  mode back, so the *Working Mode* entity shows its real state.
 - `meter-mac`: Sets the MAC address used when configuring an external meter
   (12 hex digits, no separators). Shows the last value set. Disabled by default.
 - `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`,

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The device type can be one of the following:
 - **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
 - **VNSA-X**: (e.g. VNSA-1) Venus A
 - **VNSD-X**: (e.g. VNSD-1) Venus D
-- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus *Discharge Depth*, *Bluetooth Advertising* and *Restart* controls. None of the other Venus write commands apply to it.
+- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus *Discharge Depth*, *Working Mode*, *Bluetooth Advertising*, *Meter Type*, *Meter MAC*, *Restart* and *Factory Reset* controls. None of the other Venus write commands apply to it.
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus
@@ -756,7 +756,19 @@ Venus commands above.
 - `discharge-depth`: Sets the usable-discharge percentage, 30-90%. The device
   reports the setting back, so the *Discharge Depth* entity shows its real
   state.
+- `working-mode`: Sets the working mode (`selfConsumption`, `manual` or `ai`).
+  The mode codes differ from the Venus C/D/E ones above, so the option names
+  differ too. The device reports its current mode in the separate *Operating
+  Mode* sensor; the *Working Mode* select shows the last value that was set.
+- `meter-mac`: Sets the MAC address used when configuring an external meter
+  (12 hex digits, no separators). Shows the last value set. Disabled by default.
+- `meter-type`: Configures the external meter (`ct001`, `shellyPro3em`, `ct002`,
+  `ct003`, `shellyEmGen3`, `shellyProEm50` or `ecoTracker`) — the same command
+  and the same meter codes as the other families. For CT002/CT003 and the Shelly
+  EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero
+  MAC. Shows the last value set. Disabled by default.
 - `restart`: Reboots the device. Disabled by default.
+- `factory-reset`: Resets the device to factory settings. Disabled by default.
 
 **Beta.** These commands were read out of the Marstek app rather than captured
 from a real device, so they have not been confirmed end to end.
@@ -768,10 +780,26 @@ info all moved — and uses a different MQTT topic namespace. That is why it has
 its own command list here rather than sharing the Venus one. See
 [docs/venus-generations.md](docs/venus-generations.md) for the full map.
 
-Three further commands the app has for this model are not exposed: configuring
-the device's server and setting the recharge type, neither of whose accepted
-values are known, and configuring WiFi, which carries network credentials and
-has no MQTT form anyway.
+The rest of the app's commands for this model are not exposed, in every case
+because the values they accept are not known:
+
+- Configuring the device's server, and setting the recharge type — neither has a
+  documented value set, and pointing a device at a different server can take it
+  off the network.
+- The grid-connection power limit (the 800 W / 1500 W setting). The app does not
+  set this over MQTT at all; it goes through Marstek's cloud, which then
+  provisions the device. hm2mqtt shows the result in the *Feed-in Power Limit*
+  sensor but cannot change it.
+- Anti-reverse-flow, which takes three parameters of which only one has a
+  guessable meaning.
+- Setting the device time. The parameters are known but not whether the clock
+  fields are meant to be local or UTC, and getting that wrong sets the clock off
+  by your timezone offset.
+- Reading the network info and error code, whose replies have a shape nothing
+  here can parse yet.
+- Manual-mode scheduling, which the app assembles per call and the device
+  reports nothing back about.
+- Configuring WiFi, which carries network credentials and has no MQTT form.
 
 ### Jupiter Device Commands
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The device type can be one of the following:
 - **VNSE3-X**: (e.g. VNSE3-0) Venus E 3.0
 - **VNSA-X**: (e.g. VNSA-1) Venus A
 - **VNSD-X**: (e.g. VNSD-1) Venus D
-- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus *Depth of Discharge*, *Working Mode*, *Bluetooth Advertising*, *Meter Type*, *Meter MAC*, *Refresh*, *Get CT Power*, *Restart* and *Factory Reset* controls, which carry the same names and options as their Venus counterparts. The remaining Venus write commands do not apply to it.
+- **VNSEMINI-X**: (e.g. VNSEMINI-0) Venus E Mini — **beta**; sensors plus *Depth of Discharge*, *Working Mode*, *Bluetooth Advertising*, *Meter Type*, *Meter MAC*, *Refresh*, *Get CT Power*, *Restart* and *Factory Reset* controls. These share their names with the Venus ones and their options where the two overlap, but the ranges are the model's own: this one has no *Trading* working mode, and takes a depth of discharge of 30-90% against the Venus 30-88%. The remaining Venus write commands do not apply to it.
 - **HMN-X**: (e.g. HMN-1) Marstek Jupiter E
 - **HMM-X**: (e.g. HMM-1) Marstek Jupiter C
 - **JPLS-X**: (e.g. JPLS-8H) Jupiter Plus
@@ -767,6 +767,8 @@ Venus commands above.
   and the same meter codes as the other families. For CT002/CT003 and the Shelly
   EM Gen3/Pro EM50, set `meter-mac` first; Shelly Pro 3EM always uses an all-zero
   MAC. Shows the last value set. Disabled by default.
+- `refresh`: Refreshes the device data. Disabled by default.
+- `get-ct-power`: Gets current transformer power readings. Disabled by default.
 - `restart`: Reboots the device. Disabled by default.
 - `factory-reset`: Resets the device to factory settings. Disabled by default.
 
@@ -780,8 +782,9 @@ info all moved — and uses a different MQTT topic namespace. That is why it has
 its own command list here rather than sharing the Venus one. See
 [docs/venus-generations.md](docs/venus-generations.md) for the full map.
 
-The rest of the app's commands for this model are not exposed, in every case
-because the values they accept are not known:
+The rest of the app's commands for this model are not exposed. For most of them
+the reason is that the values they accept are not known; the grid-connection
+power limit is a different case, and is called out below:
 
 - Configuring the device's server, and setting the recharge type — neither has a
   documented value set, and pointing a device at a different server can take it

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -162,10 +162,40 @@ Of the second generation, only the Venus E Mini is supported, and only partly:
 - `cd=59` power readings — polled
 - `cd=55,adv=` bluetooth advertising — implemented
 - `cd=44,do=` depth of discharge — implemented
+- `cd=2,md=` working mode — implemented
+- `cd=18,meter=,mac=` meter type — implemented
+- `cd=5` factory reset — implemented
 - `cd=61` reboot — implemented
 
-Everything else in the tables above is unimplemented. Venus X and Venus G have
-no device definitions at all.
+Everything else in the tables above is unimplemented, in every case because the
+values it accepts are unknown rather than because the command is in doubt:
+`cd=60,ser=`, `cd=63,ct_chg_type=` and `cd=54,am=,aw=,ap=` have no documented
+value set; `cd=3` and `cd=4` are reads whose reply shape is unknown; `cd=33`
+has known parameters but an undetermined local-vs-UTC convention (see below);
+and manual-mode scheduling is assembled per call. Venus X and Venus G have no
+device definitions at all.
+
+### `cd=33` and the local-vs-UTC question
+
+`cd=33` takes `d`, `m`, `y`, `h`, `min`, `s` and `wy`. `wy` is the timezone
+offset in minutes — the same key, with the same meaning, that the B2500 uses on
+its own set-time command. On the B2500 the clock fields that accompany `wy` are
+UTC. The first-generation Venus `cd=4` has no `wy` at all and takes local time.
+The app calls `timeZoneOffset` once either way, which does not settle which
+convention `cd=33` follows, and choosing wrong sets the device clock off by the
+offset. Pressing the setting in the app while watching the device's reported
+`time` would resolve it in one go.
+
+### The 800 W / 1500 W limit is not a device command
+
+The Mini reports its grid-connection power limit as `gps` (0 = 800 W,
+1 = 1500 W), but there is no `cd=` that writes it. The app changes it through
+Marstek's cloud — the setter resolves to an HTTP call, the two wattages live in
+the app's HTTP API module, and the surrounding flow is an application-and-
+approval one (submit, "VIP power", upgrade status) that then provisions the
+device. `cd=46,cv=` (access power, literally "permission power") is the nearest
+device command and has no callers anywhere in the app. This is why the limit
+appears as a read-only sensor here.
 
 ## Cross-checked against firmware
 

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -167,6 +167,12 @@ Of the second generation, only the Venus E Mini is supported, and only partly:
 - `cd=5` factory reset — implemented
 - `cd=61` reboot — implemented
 
+The entities carry the same ids, names and option names as their counterparts
+on the first-generation Venus models, so an automation can treat the two alike;
+only the numbers on the wire differ. Where this model has no counterpart — the
+LED, backup power, peak shaving, surplus feed-in, the local API, the power
+limits — no entity is invented for it.
+
 Everything else in the tables above is unimplemented, in every case because the
 values it accepts are unknown rather than because the command is in doubt:
 `cd=60,ser=`, `cd=63,ct_chg_type=` and `cd=54,am=,aw=,ap=` have no documented

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -166,15 +166,22 @@ Of the second generation, only the Venus E Mini is supported, and only partly:
 - `cd=18,meter=,mac=` meter type — implemented
 - `cd=5` factory reset — implemented
 - `cd=61` reboot — implemented
+- `cd=1` refresh and `cd=59` get CT power — also exposed as buttons, so a poll
+  can be triggered on demand
 
-The entities carry the same ids, names and option names as their counterparts
-on the first-generation Venus models, so an automation can treat the two alike;
-only the numbers on the wire differ. Where this model has no counterpart — the
-LED, backup power, peak shaving, surplus feed-in, the local API, the power
-limits — no entity is invented for it.
+The entities carry the same ids and names as their counterparts on the
+first-generation Venus models, and the same option names where the two models
+have the same option, so an automation can treat them alike; only the numbers on
+the wire differ. The ranges are still each model's own — the Mini has no
+`trading` working mode, and takes a depth of discharge of 30-90% against the
+Venus 30-88%. Where this model has no counterpart at all — the LED, backup
+power, peak shaving, surplus feed-in, the local API, the power limits — no
+entity is invented for it.
 
-Everything else in the tables above is unimplemented, in every case because the
-values it accepts are unknown rather than because the command is in doubt:
+Everything else in the tables above is unimplemented. For all but one the reason
+is that the values it accepts are unknown rather than that the command is in
+doubt; the exception is the grid-connection power limit, which has no device
+command to implement (see below):
 `cd=60,ser=`, `cd=63,ct_chg_type=` and `cd=54,am=,aw=,ap=` have no documented
 value set; `cd=3` and `cd=4` are reads whose reply shape is unknown; `cd=33`
 has known parameters but an undetermined local-vs-UTC convention (see below);

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -3,13 +3,25 @@ import {
   globalPollInterval,
   registerDeviceDefinition,
 } from '../deviceDefinition.js';
-import { VenusMiniDeviceData, VenusMiniTimePeriod } from '../types.js';
+import {
+  VenusMiniDeviceData,
+  VenusMiniTimePeriod,
+  VenusMiniWorkingMode,
+  isValidMeterType,
+  isValidVenusMiniWorkingMode,
+  meterTypeCommandCodes,
+  meterTypeLabels,
+  resolveMeterMac,
+  venusMiniWorkingModeCommandCodes,
+} from '../types.js';
 import {
   binarySensorComponent,
   buttonComponent,
   numberComponent,
+  selectComponent,
   sensorComponent,
   switchComponent,
+  textComponent,
 } from '../homeAssistantDiscovery.js';
 import logger from '../logger.js';
 import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '../transforms.js';
@@ -36,15 +48,41 @@ import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '
  * be reused, and a number read off that file is more likely wrong than right.
  * docs/venus-generations.md has the full map and how the two are told apart.
  *
- * Not implemented from this model's command table:
+ * Not implemented, and why. Each of these is a real command in the app's
+ * tables; what is missing in every case is the set of values it accepts, which
+ * the app encodes at the call site rather than in the table:
  *
- * - `cd=60,ser=<n>` (configure server), whose value domain is not in the app.
- *   The device reports the setting back as `rechg_type`'s neighbour `ser`, of
- *   which only 0 has been seen.
+ * - `cd=60,ser=<n>` (configure server). No value domain, and pointing a device
+ *   at a different server can take it off the network. Reported back as `ser`,
+ *   of which only 0 has been seen.
+ * - `cd=63,ct_chg_type=<n>` (configure recharge type). No value domain;
+ *   reported back as `rechg_type`, only ever 0.
+ * - `cd=46,cv=<n>` (access power). This is the grid-connection power
+ *   entitlement - the app does not set it over MQTT at all, but through
+ *   Marstek's cloud, which then provisions the device; the 800/1500 W pair
+ *   lives in the app's HTTP API. The device reports the result as `gps`. Since
+ *   an export limit carries regulatory weight, guessing the units is not worth
+ *   the risk.
+ * - `cd=54,am=<n>,aw=<n>,ap=<n>` (anti-reverse-flow). Three parameters, only
+ *   the first of which has a guessable meaning.
+ * - `cd=3` / `cd=4` (network info, error code). These are reads, and the shape
+ *   of what comes back is not known, so there would be nothing to parse.
+ * - `cd=33` (set device time), whose parameters are known - d, m, y, h, min, s
+ *   and `wy` - but not whether the clock fields are local or UTC. `wy` is the
+ *   timezone offset in minutes, the same key the B2500 uses on its own
+ *   set-time command, and there the clock fields go as UTC while the
+ *   first-generation Venus `cd=4`, which has no `wy` at all, takes local time.
+ *   The app calls timeZoneOffset once either way, so it does not settle which
+ *   convention this command follows. Getting it wrong sets the device clock off
+ *   by the offset, which is the bug the B2500 shipped once already; and since
+ *   nothing here drives the Mini's schedules yet, a sync button would carry
+ *   that risk without buying anything. Pressing it in the app with a device
+ *   whose reported `time` is watched would settle it in one go.
+ * - Manual-mode scheduling. The app builds the `cd=` number at the call site,
+ *   and the device reports no schedule state at all, so there is nothing to
+ *   check an implementation against.
  * - `CMD_SET_WIFI` (configure device WiFi) carries network credentials, and is
  *   Bluetooth-only anyway - it has no MQTT form.
- * - `cd=63,ct_chg_type=<n>` (configure recharge type), also with no known
- *   value domain; the device reports it back as `rechg_type`, only ever 0.
  */
 
 // The app's own setting screen enforces this range.
@@ -418,6 +456,9 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         'unknown',
       ),
     });
+    // The sensor keeps the full map including `unknown`, so an unrecognised cm
+    // code is visible as such rather than silently reported as a real mode. The
+    // select below carries only the three settable modes.
     advertise(
       ['operatingMode'],
       sensorComponent<NonNullable<VenusMiniDeviceData['operatingMode']>>({
@@ -432,6 +473,38 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         },
       }),
     );
+
+    // Written rather than read: cm is the same setting, but a select whose
+    // state came from cm would flip back to "Self Consumption" whenever the
+    // device reported a code outside the three settable ones. The codes are
+    // the second generation's (0/2/3) and differ from venus.ts's (0/1/2/5).
+    advertise(
+      ['workingMode'],
+      selectComponent<VenusMiniWorkingMode>({
+        id: 'working_mode',
+        name: 'Working Mode',
+        icon: 'mdi:cog',
+        command: 'working-mode',
+        valueMappings: {
+          selfConsumption: 'Self Consumption',
+          manual: 'Manual',
+          ai: 'AI Optimization',
+        },
+        // Write-only, for the reason above: cm is read into the Operating Mode
+        // sensor instead.
+        optimistic: true,
+      }),
+    );
+    command('working-mode', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        if (!isValidVenusMiniWorkingMode(message)) {
+          logger.warn('Invalid working mode value:', message);
+          return;
+        }
+        updateDeviceState(() => ({ workingMode: message }));
+        publishCallback(`cd=2,md=${venusMiniWorkingModeCommandCodes[message]}`);
+      },
+    });
 
     // 0/1/2 are confirmed against a real device; 3, 4 and 5 come from the
     // state table the vendor app builds for this model, which labels 3 as
@@ -855,10 +928,11 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       },
     });
 
-    // Reboot, `cd=61`. The first-generation Venus models restart with `cd=10`;
-    // this is the second generation's number for it. No parameters, so there
-    // is nothing here to get wrong beyond the number itself. Disabled by
-    // default, matching the reset buttons on the other families.
+    // Reboot, `cd=61`. The first generation has no reboot command at all, so
+    // this is not a renumbering of anything - `cd=10` on those models is the
+    // WiFi-module version query, not a restart. No parameters, so there is
+    // nothing here to get wrong beyond the number itself. Disabled by default,
+    // matching the reset buttons on the other families.
     advertise(
       [],
       buttonComponent({
@@ -875,6 +949,88 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
           publishCallback('cd=61');
         }
+      },
+    });
+
+    // Factory reset, `cd=5`. Unlike the first generation's reset, which selects
+    // between clearing all/part/certificates with an `rs` parameter, this one
+    // takes none.
+    advertise(
+      [],
+      buttonComponent({
+        id: 'factory_reset',
+        name: 'Factory Reset',
+        icon: 'mdi:factory',
+        command: 'factory-reset',
+        payload_press: 'PRESS',
+        enabled_by_default: false,
+      }),
+    );
+    command('factory-reset', {
+      handler: ({ message, publishCallback }) => {
+        if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
+          publishCallback('cd=5');
+        }
+      },
+    });
+
+    // Meter type, `cd=18,meter=<n>,mac=<mac>` - the same command and the same
+    // meter codes as the other families, which is one of the few places the two
+    // generations agree. The device reports a meter code back in ct_type, but
+    // nothing establishes that it is the same numbering as `meter`, so this
+    // stays write-only rather than reading that field back.
+    advertise(
+      ['meterType'],
+      selectComponent<NonNullable<VenusMiniDeviceData['meterType']>>({
+        id: 'meter_type',
+        name: 'Meter Type',
+        icon: 'mdi:meter-electric',
+        command: 'meter-type',
+        valueMappings: meterTypeLabels,
+        optimistic: true,
+        enabled_by_default: false,
+      }),
+    );
+    command('meter-type', {
+      handler: ({ message, publishCallback, updateDeviceState }) => {
+        if (!isValidMeterType(message)) {
+          logger.warn('Invalid meter type value:', message);
+          return;
+        }
+        updateDeviceState(state => {
+          const mac = resolveMeterMac(message, state.meterMac);
+          if (mac === null) {
+            logger.warn(
+              `Meter type ${message} requires a MAC; set the "Meter MAC" entity before selecting it`,
+            );
+            return;
+          }
+          publishCallback(`cd=18,meter=${meterTypeCommandCodes[message]},mac=${mac}`);
+          return { meterType: message };
+        });
+      },
+    });
+
+    advertise(
+      ['meterMac'],
+      textComponent({
+        id: 'meter_mac',
+        name: 'Meter MAC',
+        icon: 'mdi:identifier',
+        command: 'meter-mac',
+        optimistic: true,
+        enabled_by_default: false,
+        pattern: '^[0-9A-Fa-f]{12}$',
+      }),
+    );
+    command('meter-mac', {
+      handler: ({ message, updateDeviceState }) => {
+        const mac = message.trim();
+        if (!/^[0-9A-Fa-f]{12}$/.test(mac)) {
+          logger.warn('Invalid meter MAC (expected 12 hex characters):', message);
+          return;
+        }
+        updateDeviceState(() => ({ meterMac: mac.toUpperCase() }));
       },
     });
   });

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -306,8 +306,8 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     advertise(
       ['dischargeDepth'],
       numberComponent({
-        id: 'discharge_depth',
-        name: 'Discharge Depth',
+        id: 'depth_of_discharge',
+        name: 'Depth of Discharge',
         device_class: 'battery',
         unit_of_measurement: '%',
         command: 'discharge-depth',
@@ -439,6 +439,11 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
+    // Working mode, cd=2. Backed by cm rather than write-only, matching the
+    // Working Mode select on the other Venus models: the device reports its
+    // mode, so there is no reason for the entity to show only what was last
+    // written. Unrecognised codes fall back to `automatic`, as they do there.
+    //
     // Only 0 (self-consumption) and 2 (manual) have been observed; a 3rd "AI
     // optimization" mode exists in the app UI but is greyed out as "coming
     // soon" - 3 is the code it will report, from the app's own work-mode
@@ -446,38 +451,16 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     // which schedule rule is enabled, not by this field itself.
     field({
       key: 'cm',
-      path: ['operatingMode'],
+      path: ['workingMode'],
       transform: map(
         {
-          '0': 'selfConsumption',
+          '0': 'automatic',
           '2': 'manual',
           '3': 'ai',
         },
-        'unknown',
+        'automatic',
       ),
     });
-    // The sensor keeps the full map including `unknown`, so an unrecognised cm
-    // code is visible as such rather than silently reported as a real mode. The
-    // select below carries only the three settable modes.
-    advertise(
-      ['operatingMode'],
-      sensorComponent<NonNullable<VenusMiniDeviceData['operatingMode']>>({
-        id: 'operating_mode',
-        name: 'Operating Mode',
-        icon: 'mdi:cog',
-        valueMappings: {
-          selfConsumption: 'Self Consumption',
-          manual: 'Manual',
-          ai: 'AI Optimization',
-          unknown: 'Unknown',
-        },
-      }),
-    );
-
-    // Written rather than read: cm is the same setting, but a select whose
-    // state came from cm would flip back to "Self Consumption" whenever the
-    // device reported a code outside the three settable ones. The codes are
-    // the second generation's (0/2/3) and differ from venus.ts's (0/1/2/5).
     advertise(
       ['workingMode'],
       selectComponent<VenusMiniWorkingMode>({
@@ -485,14 +468,16 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
         name: 'Working Mode',
         icon: 'mdi:cog',
         command: 'working-mode',
+        // `cm=0` is the self-consumption mode, which the Marstek app labels as
+        // such. The option is named "Automatic" to match the same mode on the
+        // other Venus models - an entity reports its state by option name, so
+        // diverging here would mean an automation that reads or sets the mode
+        // could not treat the models alike, for no functional gain.
         valueMappings: {
-          selfConsumption: 'Self Consumption',
+          automatic: 'Automatic',
           manual: 'Manual',
-          ai: 'AI Optimization',
+          ai: 'AI',
         },
-        // Write-only, for the reason above: cm is read into the Operating Mode
-        // sensor instead.
-        optimistic: true,
       }),
     );
     command('working-mode', {
@@ -952,6 +937,47 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       },
     });
 
+    // Refresh and Get CT Power, matching the same two buttons on the other
+    // Venus models. The numbers differ: this generation asks for power with
+    // `cd=59`, not `cd=19` - see registerVenusMiniCtPowerMessage.
+    advertise(
+      [],
+      buttonComponent({
+        id: 'refresh',
+        name: 'Refresh',
+        icon: 'mdi:refresh',
+        command: 'refresh',
+        payload_press: 'PRESS',
+        enabled_by_default: false,
+      }),
+    );
+    command('refresh', {
+      handler: ({ message, publishCallback }) => {
+        if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
+          publishCallback('cd=1');
+        }
+      },
+    });
+
+    advertise(
+      [],
+      buttonComponent({
+        id: 'get_ct_power',
+        name: 'Get CT Power',
+        icon: 'mdi:current-ac',
+        command: 'get-ct-power',
+        payload_press: 'PRESS',
+        enabled_by_default: false,
+      }),
+    );
+    command('get-ct-power', {
+      handler: ({ message, publishCallback }) => {
+        if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
+          publishCallback('cd=59');
+        }
+      },
+    });
+
     // Factory reset, `cd=5`. Unlike the first generation's reset, which selects
     // between clearing all/part/certificates with an `rs` parameter, this one
     // takes none.
@@ -960,7 +986,7 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       buttonComponent({
         id: 'factory_reset',
         name: 'Factory Reset',
-        icon: 'mdi:factory',
+        icon: 'mdi:delete-forever',
         command: 'factory-reset',
         payload_press: 'PRESS',
         enabled_by_default: false,

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1882,12 +1882,12 @@ const commandTestCases: CommandTestCase[] = [
   // Working mode. The second generation's codes are 0/2/3, where the Venus
   // C/D/E use 0/1/2/5 - taking those would select the wrong mode.
   {
-    description: 'Venus E Mini working-mode self consumption',
+    description: 'Venus E Mini working-mode automatic',
     deviceType: 'VNSEMINI-0',
     command: 'working-mode',
-    input: 'selfConsumption',
+    input: 'automatic',
     expectedOutput: 'cd=2,md=0',
-    expectedStateChanges: { workingMode: 'selfConsumption' },
+    expectedStateChanges: { workingMode: 'automatic' },
   },
   {
     description: 'Venus E Mini working-mode manual',
@@ -1904,17 +1904,19 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: 'cd=2,md=3',
   },
   {
-    description: 'Venus E Mini working-mode rejects the unknown placeholder',
-    deviceType: 'VNSEMINI-0',
-    command: 'working-mode',
-    input: 'unknown',
-    expectedOutput: null,
-  },
-  {
-    description: 'Venus E Mini working-mode rejects a first-generation mode name',
+    // `trading` is a Venus C/D/E mode with no counterpart here, so the shared
+    // option names stop short of it rather than mapping it to something else.
+    description: 'Venus E Mini working-mode rejects a mode this model lacks',
     deviceType: 'VNSEMINI-0',
     command: 'working-mode',
     input: 'trading',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus E Mini working-mode rejects junk',
+    deviceType: 'VNSEMINI-0',
+    command: 'working-mode',
+    input: 'notamode',
     expectedOutput: null,
   },
 

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1862,7 +1862,8 @@ const commandTestCases: CommandTestCase[] = [
     expectedOutput: null,
   },
 
-  // Reboot is cd=61 here; the Venus C/D/E restart with cd=10.
+  // Reboot is cd=61 here. The Venus C/D/E have no reboot command at all -
+  // cd=10 on those models is the WiFi-module version query.
   {
     description: 'Venus E Mini restart with PRESS',
     deviceType: 'VNSEMINI-0',
@@ -1875,6 +1876,108 @@ const commandTestCases: CommandTestCase[] = [
     deviceType: 'VNSEMINI-0',
     command: 'restart',
     input: 'nope',
+    expectedOutput: null,
+  },
+
+  // Working mode. The second generation's codes are 0/2/3, where the Venus
+  // C/D/E use 0/1/2/5 - taking those would select the wrong mode.
+  {
+    description: 'Venus E Mini working-mode self consumption',
+    deviceType: 'VNSEMINI-0',
+    command: 'working-mode',
+    input: 'selfConsumption',
+    expectedOutput: 'cd=2,md=0',
+    expectedStateChanges: { workingMode: 'selfConsumption' },
+  },
+  {
+    description: 'Venus E Mini working-mode manual',
+    deviceType: 'VNSEMINI-0',
+    command: 'working-mode',
+    input: 'manual',
+    expectedOutput: 'cd=2,md=2',
+  },
+  {
+    description: 'Venus E Mini working-mode ai',
+    deviceType: 'VNSEMINI-0',
+    command: 'working-mode',
+    input: 'ai',
+    expectedOutput: 'cd=2,md=3',
+  },
+  {
+    description: 'Venus E Mini working-mode rejects the unknown placeholder',
+    deviceType: 'VNSEMINI-0',
+    command: 'working-mode',
+    input: 'unknown',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus E Mini working-mode rejects a first-generation mode name',
+    deviceType: 'VNSEMINI-0',
+    command: 'working-mode',
+    input: 'trading',
+    expectedOutput: null,
+  },
+
+  // Factory reset takes no rs parameter on this generation.
+  {
+    description: 'Venus E Mini factory-reset with PRESS',
+    deviceType: 'VNSEMINI-0',
+    command: 'factory-reset',
+    input: 'PRESS',
+    expectedOutput: 'cd=5',
+  },
+  {
+    description: 'Venus E Mini factory-reset ignores an unrelated payload',
+    deviceType: 'VNSEMINI-0',
+    command: 'factory-reset',
+    input: 'nope',
+    expectedOutput: null,
+  },
+
+  // Meter type: the same cd=18 and the same meter codes as the other families.
+  {
+    description: 'Venus E Mini meter-type CT002 with configured MAC',
+    deviceType: 'VNSEMINI-0',
+    initialState: { meterMac: 'aabbccddeeff' },
+    command: 'meter-type',
+    input: 'ct002',
+    expectedOutput: 'cd=18,meter=3,mac=aabbccddeeff',
+    expectedStateChanges: { meterType: 'ct002' },
+  },
+  {
+    description: 'Venus E Mini meter-type Shelly Pro 3EM forces an all-zero MAC',
+    deviceType: 'VNSEMINI-0',
+    command: 'meter-type',
+    input: 'shellyPro3em',
+    expectedOutput: 'cd=18,meter=1,mac=000000000000',
+  },
+  {
+    description: 'Venus E Mini meter-type CT002 without a MAC is rejected',
+    deviceType: 'VNSEMINI-0',
+    command: 'meter-type',
+    input: 'ct002',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus E Mini meter-type rejects junk',
+    deviceType: 'VNSEMINI-0',
+    command: 'meter-type',
+    input: 'notameter',
+    expectedOutput: null,
+  },
+  {
+    description: 'Venus E Mini meter-mac stores an uppercased MAC',
+    deviceType: 'VNSEMINI-0',
+    command: 'meter-mac',
+    input: 'aabbccddeeff',
+    expectedOutput: null,
+    expectedStateChanges: { meterMac: 'AABBCCDDEEFF' },
+  },
+  {
+    description: 'Venus E Mini meter-mac rejects a malformed MAC',
+    deviceType: 'VNSEMINI-0',
+    command: 'meter-mac',
+    input: 'aabbcc',
     expectedOutput: null,
   },
 ];

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1503,7 +1503,7 @@ describe('MQTT Message Parser', () => {
     expect(result).toHaveProperty('wifiSignal', -41); // wifi_a=41 is an RSSI magnitude
     expect(result).toHaveProperty('ctType', 0);
     expect(result).toHaveProperty('ctPhase', 0);
-    expect(result).toHaveProperty('operatingMode', 'manual'); // cm=2
+    expect(result).toHaveProperty('workingMode', 'manual'); // cm=2
     expect(result).toHaveProperty('deviceState', 'standby'); // dev_sta=0
     expect(result).toHaveProperty('ledEnabled', true); // leds=0 is inverted: LED on
     expect(result).toHaveProperty('bluetoothLockRaw', 0);
@@ -1651,7 +1651,7 @@ describe('MQTT Message Parser', () => {
   test('maps Venus E Mini enum branches not covered by the primary capture', () => {
     // Synthesized from the per-field confirmations in
     // VENUS_MINI_IMPLEMENTATION_PROMPT.md to cover enum values the single
-    // real capture above doesn't exercise: operatingMode=selfConsumption
+    // real capture above doesn't exercise: workingMode=automatic
     // (cm=0), deviceState=charging (dev_sta=1), feedInPowerLimit=1500W
     // (gps=1), LED off (leds=1), and schedule direction=selfConsumption
     // (ms1=3).
@@ -1662,7 +1662,7 @@ describe('MQTT Message Parser', () => {
     expect(parsed).toHaveProperty('data');
     const result = parsed['data'] as VenusMiniDeviceData;
 
-    expect(result).toHaveProperty('operatingMode', 'selfConsumption');
+    expect(result).toHaveProperty('workingMode', 'automatic');
     expect(result).toHaveProperty('deviceState', 'charging');
     expect(result).toHaveProperty('feedInPowerLimit', '1500W');
     expect(result).toHaveProperty('ledEnabled', false); // leds=1 is inverted: LED off
@@ -1693,7 +1693,7 @@ describe('MQTT Message Parser', () => {
     // The app's AI mode is still greyed out as "coming soon", but 3 is the
     // code it reports.
     const ai = parseMessage(`${base},cm=3,dev_sta=0`, 'VNSEMINI-0', 'venusMini123');
-    expect((ai['data'] as VenusMiniDeviceData).operatingMode).toBe('ai');
+    expect((ai['data'] as VenusMiniDeviceData).workingMode).toBe('ai');
 
     // wifi_a is the magnitude of the RSSI, so the sensor reports it negated.
     expect((ai['data'] as VenusMiniDeviceData).wifiSignal).toBe(-41);

--- a/src/types.ts
+++ b/src/types.ts
@@ -666,6 +666,25 @@ export interface VenusMiniTimePeriod {
 // as "coming soon" in the app UI, and 3 is the code it will report.
 export type VenusMiniOperatingMode = 'selfConsumption' | 'manual' | 'ai' | 'unknown';
 
+// The modes the cd=2 command can select. `unknown` is deliberately absent: it
+// exists so an unrecognised cm code has somewhere to land, and is not something
+// a user can ask the device to enter.
+const validVenusMiniWorkingModes = ['selfConsumption', 'manual', 'ai'] as const;
+export type VenusMiniWorkingMode = (typeof validVenusMiniWorkingModes)[number];
+
+export function isValidVenusMiniWorkingMode(mode: string): mode is VenusMiniWorkingMode {
+  return validVenusMiniWorkingModes.includes(mode as VenusMiniWorkingMode);
+}
+
+// The `md` value each mode is sent as. These are the second generation's codes,
+// which differ from the Venus C/D/E's (0/1/2/5) in venus.ts - reading them off
+// that file would set the wrong mode.
+export const venusMiniWorkingModeCommandCodes: Record<VenusMiniWorkingMode, number> = {
+  selfConsumption: 0,
+  manual: 2,
+  ai: 3,
+};
+
 // Device state reported by a Venus E Mini in dev_sta. 0/1/2 are confirmed
 // against a real device; bypass and fault are the app's own labels for 3 and
 // 5, and 4 is a second discharging state whose difference from 2 is unknown.
@@ -715,6 +734,7 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   bluetoothLockRaw?: number; // bbs, direction confirmed (higher = more locked) but the absolute mapping across every LED x Bluetooth-lock combination is not, so kept as a raw diagnostic rather than a binary sensor
   feedInPowerLimit?: VenusMiniFeedInPowerLimit; // gps
   operatingMode?: VenusMiniOperatingMode; // cm
+  workingMode?: VenusMiniWorkingMode; // last value written with the working-mode command; cm is read into operatingMode instead
   deviceState?: VenusMiniDeviceState; // dev_sta
   batteryDischargedEnergyToday?: number; // dbd (Wh)
   batteryDischargedEnergyTotal?: number; // tbd (Wh)
@@ -729,6 +749,8 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   serverState?: number; // ser (raw; server state, individual codes unknown)
   rechargeType?: number; // rechg_type (raw; recharge type, individual codes unknown)
   bluetoothAdvertisingEnabled?: boolean; // last value written with the bluetooth-advertising command. `bbs` is the likely readback but its polarity is unconfirmed, so nothing parses it into this field yet - see venusEMini.ts
+  meterType?: MeterType; // last configured via cd=18. The device reports a meter code back in ct_type, but nothing establishes that it uses the same numbering as the `meter` the command takes, so this holds what was written rather than what was read
+  meterMac?: string; // MAC used when configuring the meter type
   timePeriods?: VenusMiniTimePeriod[];
   // cd=59 per-phase CT readings, in W. Only reported by a unit with an external
   // meter configured, so these stay unset on a device with ct_type=0.

--- a/src/types.ts
+++ b/src/types.ts
@@ -661,15 +661,12 @@ export interface VenusMiniTimePeriod {
   repeatRaw?: number; // re{n} (raw; meaning unconfirmed, possibly a weekday bitmask)
 }
 
-// Operating mode reported by a Venus E Mini in cm. Only 0 (self-consumption)
-// and 2 (manual) have been observed; the "AI optimization" mode is greyed out
-// as "coming soon" in the app UI, and 3 is the code it will report.
-export type VenusMiniOperatingMode = 'selfConsumption' | 'manual' | 'ai' | 'unknown';
-
-// The modes the cd=2 command can select. `unknown` is deliberately absent: it
-// exists so an unrecognised cm code has somewhere to land, and is not something
-// a user can ask the device to enter.
-const validVenusMiniWorkingModes = ['selfConsumption', 'manual', 'ai'] as const;
+// Working mode of a Venus E Mini, reported in cm and set with cd=2. Only 0
+// (self-consumption, named `automatic` to match the same mode on the other
+// Venus models) and 2 (manual) have been observed; the "AI optimization" mode
+// is greyed out as "coming soon" in the app UI, and 3 is the code it will
+// report.
+const validVenusMiniWorkingModes = ['automatic', 'manual', 'ai'] as const;
 export type VenusMiniWorkingMode = (typeof validVenusMiniWorkingModes)[number];
 
 export function isValidVenusMiniWorkingMode(mode: string): mode is VenusMiniWorkingMode {
@@ -680,7 +677,7 @@ export function isValidVenusMiniWorkingMode(mode: string): mode is VenusMiniWork
 // which differ from the Venus C/D/E's (0/1/2/5) in venus.ts - reading them off
 // that file would set the wrong mode.
 export const venusMiniWorkingModeCommandCodes: Record<VenusMiniWorkingMode, number> = {
-  selfConsumption: 0,
+  automatic: 0,
   manual: 2,
   ai: 3,
 };
@@ -733,8 +730,7 @@ export interface VenusMiniDeviceData extends BaseDeviceData {
   ledEnabled?: boolean; // leds, inverted: leds=0 means the LED is on
   bluetoothLockRaw?: number; // bbs, direction confirmed (higher = more locked) but the absolute mapping across every LED x Bluetooth-lock combination is not, so kept as a raw diagnostic rather than a binary sensor
   feedInPowerLimit?: VenusMiniFeedInPowerLimit; // gps
-  operatingMode?: VenusMiniOperatingMode; // cm
-  workingMode?: VenusMiniWorkingMode; // last value written with the working-mode command; cm is read into operatingMode instead
+  workingMode?: VenusMiniWorkingMode; // cm
   deviceState?: VenusMiniDeviceState; // dev_sta
   batteryDischargedEnergyToday?: number; // dbd (Wh)
   batteryDischargedEnergyTotal?: number; // tbd (Wh)


### PR DESCRIPTION
Draft — the command formats come from the Marstek app, not from a device. Someone with a Venus E Mini should confirm before this merges.

Follows #437. That PR added the Mini's own commands; this one adds the ones it inherits from the shared second-generation command set, and reconciles the entities with the equivalents on the Venus C/D/E.

## What changed

### Three more commands

| Command | Control | Where the values come from |
| --- | --- | --- |
| `cd=2,md=` | **Working Mode** select | The app's work-mode constructors: 0 = self-consumption, 2 = manual, 3 = AI. These are the second generation's codes and differ from the Venus C/D/E's 0/1/2/5 — reading those would select the wrong mode |
| `cd=18,meter=,mac=` | **Meter Type** + **Meter MAC** | Same command and same meter codes as the other families; parameter names from the app's own setter |
| `cd=5` | **Factory Reset** button | Takes no `rs` parameter on this generation, unlike the first generation's three-way reset |

Plus **Refresh** (`cd=1`) and **Get CT Power** (`cd=59`), the two buttons the other Venus models have that this one was missing.

### Entity alignment

The Mini's controls had been built model-first and diverged from the same settings elsewhere for no reason. Ids, names, icons and option names now match, so an automation can treat the two alike and only the numbers on the wire differ:

- `discharge_depth` / *Discharge Depth* → `depth_of_discharge` / *Depth of Discharge*.
- Factory Reset takes `mdi:delete-forever`, not `mdi:factory`.
- **Working mode is now one select backed by `cm`**, as it is on the other models, rather than a read-only *Operating Mode* sensor plus a write-only select. Its options become `automatic`/`manual`/`ai`, and `cm=0` maps to `automatic` for the same reason it does there: the option name is what the entity reports as its state, so diverging would split automations across models for no functional gain. Unrecognised codes fall back to `automatic` in both. `trading` has no counterpart here, so the shared naming stops short of it and that input is rejected.

This changes the published state path from `operatingMode` to `workingMode` and drops the `operating_mode` entity. Breaking for anyone reading it — but Mini support is unreleased, so nothing has shipped to break, and it folds into the existing `[Next]` entry rather than being filed as a change.

Settings this model has no counterpart for — the LED, backup power, peak shaving, surplus feed-in, the local API, the power limits — get no invented entity. None appears in its command tables, so an entity for one would advertise a control that does nothing.

## What is deliberately left out

Every remaining command in the app's tables for this model is real; what is missing in each case is the set of values it accepts, which the app encodes at the call site rather than in the table. Two are worth reviewer attention:

**`cd=33` (set device time) — the parameters are known, the convention is not.** It takes `d`, `m`, `y`, `h`, `min`, `s` and `wy`. `wy` is the timezone offset in minutes, the same key with the same meaning the B2500 uses on its own set-time command — and there the accompanying clock fields go as **UTC**, while the first-generation Venus `cd=4`, which has no `wy` at all, takes **local**. The Mini has `wy`, so it patterns with the B2500, but the app calls `timeZoneOffset` exactly once under either convention, so the disassembly does not discriminate. Choosing wrong sets the device clock off by the offset — the bug the B2500 shipped once already and needed a "press Sync Time again" note for. Nothing here drives the Mini's schedules yet, so a sync button would carry that risk and buy nothing.

*Setting the time in the app while watching the device's reported `time` come back would settle it in one press.*

**The 800 W / 1500 W grid limit has no device command at all.** The Mini reports it as `gps`, but the app does not set it over MQTT: the setter resolves to an HTTP call, the two wattages live in the app's HTTP API module, and the surrounding flow is an application-and-approval one that provisions the device from Marstek's cloud. `cd=46,cv=` — literally "permission power" — is the nearest device command and has no callers anywhere in the app. So it stays a read-only sensor, and the docs now say why rather than leaving it looking like an oversight.

The rest, with reasons recorded in the file header: `cd=60,ser=` and `cd=63,ct_chg_type=` (no documented value set, and repointing a device's server can take it off the network), `cd=54,am=,aw=,ap=` (three parameters, one guessable), `cd=3`/`cd=4` (reads whose reply shape is unknown), manual-mode scheduling (assembled per call site, no state reported back), and `CMD_SET_WIFI` (credentials, Bluetooth-only, no MQTT form).

## Also corrected

Two comments claimed the first-generation Venus reboots with `cd=10`. It has no reboot command at all, and `cd=10` there is the WiFi-module version query.

## How it was validated

```
npm run lint
npm run format:check
npm test -- --runInBand   # 642 passed
npm run build
```

New tests cover each command's payload and its rejections: the three working modes plus a first-generation mode name and junk, factory reset, meter type with and without a MAC, and the meter-MAC format check.

**Not validated against hardware.** As with #437, the wire formats are the app's ground truth, not a device's.


---
_Generated by [Claude Code](https://claude.ai/code/session_017EU9u29MvKtGoCYhcR2r12)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Venus E Mini support with working modes, meter configuration, depth-of-discharge settings, refresh, CT power, factory reset, and restart controls.
  * Added automatic, manual, and AI working modes, with Mini-specific operating limits.
* **Documentation**
  * Added guidance covering supported features, unavailable commands, disabled controls, meter behavior, and power-limit details.
* **Bug Fixes**
  * Improved Venus E Mini command handling and meter MAC reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->