### PR TITLE
Fix Venus E Mini runtime polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Restore telemetry updates for Venus E Mini devices (discussion #425)
 - The MQTT broker password no longer shows up in the log. On startup, the broker URL was written to the log with its credentials in plaintext, which meant sharing a log for troubleshooting could hand out the broker password. In the Home Assistant add-on this affected the password of Home Assistant's own MQTT broker. Broker URLs now appear as `mqtt://user:***@host:1883` (fixes #424, PR #435)
 
 ## [1.10.0] - 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Restore telemetry updates for Venus E Mini devices (discussion #425)
+- Restore telemetry updates for Venus E Mini devices (discussion #425, PR #439)
 - The MQTT broker password no longer shows up in the log. On startup, the broker URL was written to the log with its credentials in plaintext, which meant sharing a log for troubleshooting could hand out the broker password. In the Home Assistant add-on this affected the password of Home Assistant's own MQTT broker. Broker URLs now appear as `mqtt://user:***@host:1883` (fixes #424, PR #435)
 
 ## [1.10.0] - 2026-08-15

--- a/README.md
+++ b/README.md
@@ -772,8 +772,9 @@ Venus commands above.
 - `restart`: Reboots the device. Disabled by default.
 - `factory-reset`: Resets the device to factory settings. Disabled by default.
 
-**Beta.** These commands were read out of the Marstek app rather than captured
-from a real device, so they have not been confirmed end to end.
+**Beta.** The read-only refresh command has been confirmed on a real device.
+The other commands were read out of the Marstek app rather than captured from
+a real device, so they have not been confirmed end to end.
 
 The Venus E Mini runs a second generation of Marstek's Venus firmware, together
 with the Venus X and Venus G. It numbers its commands differently from the

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -166,7 +166,7 @@ Of the second generation, only the Venus E Mini is supported, and only partly:
 - `cd=18,meter=,mac=` meter type — implemented
 - `cd=5` factory reset — implemented
 - `cd=61` reboot — implemented
-- `cd=1` refresh and `cd=59` get CT power — also exposed as buttons, so a poll
+- `cd=01` refresh and `cd=59` get CT power — also exposed as buttons, so a poll
   can be triggered on demand
 
 The entities carry the same ids and names as their counterparts on the

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -59,10 +59,10 @@ on this family it is `GET_FC41D_INFO`, the WiFi module version query, and it is
 only the *B2500* that restarts with `cd=10`. Reaching for that number on a Venus
 queries the WiFi module instead.
 
-The second generation writes its numbers zero-padded (`cd=01`, `cd=05`) where
-hm2mqtt sends them bare. The first generation's B2500 code does the same, and
-real devices evidently parse the number rather than the string, so this appears
-to be cosmetic.
+The second generation writes its numbers zero-padded (`cd=01`, `cd=05`). This
+is significant for the Venus E Mini's device-info request: a real unit answered
+`cd=01` but did not answer the bare `cd=1`. Other commands may still accept
+either representation.
 
 ## Second-generation command map
 
@@ -158,7 +158,7 @@ none of the Shelly flow is implemented.
 
 Of the second generation, only the Venus E Mini is supported, and only partly:
 
-- `cd=1` runtime payload — parsed
+- `cd=01` runtime request and payload — parsed
 - `cd=59` power readings — polled
 - `cd=55,adv=` bluetooth advertising — implemented
 - `cd=44,do=` depth of discharge — implemented

--- a/src/device/venusEMini.test.ts
+++ b/src/device/venusEMini.test.ts
@@ -1,0 +1,11 @@
+import './registry.js';
+import { getDeviceDefinition } from '../deviceDefinition.js';
+
+describe('Venus E Mini', () => {
+  test('uses the zero-padded runtime data request required by the device', () => {
+    const definition = getDeviceDefinition('VNSEMINI-0');
+    const runtimeMessage = definition?.messages.find(message => message.publishPath === 'data');
+
+    expect(runtimeMessage?.refreshDataPayload).toBe('cd=01');
+  });
+});

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -954,7 +954,7 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     command('refresh', {
       handler: ({ message, publishCallback }) => {
         if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
-          publishCallback('cd=1');
+          publishCallback('cd=01');
         }
       },
     });

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -30,16 +30,16 @@ import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '
  * Marstek Venus E Mini, device type `VNSEMINI-X` (e.g. `VNSEMINI-0`).
  *
  * Despite the name, this model does not speak the protocol the other Venus
- * variants use: its `cd=1` response shares almost no field names with the
+ * variants use: its runtime response shares almost no field names with the
  * HMG/VNSE3/VNSA/VNSD family, so it gets its own definition here rather than
  * reusing anything in `venus.ts`.
  *
- * Only `cd=1` has been captured from a real device. The command formats here
- * are read out of the Marstek app's own command table for this model rather
- * than observed on hardware, so they are the app's ground truth but not yet
- * confirmed end to end. Fields whose meaning is not confirmed are exposed
- * verbatim as disabled-by-default sensors under `raw`/`ctRaw` rather than being
- * given a name that asserts a meaning.
+ * Only the runtime response to `cd=01` has been captured from a real device.
+ * The other command formats here are read out of the Marstek app's own command
+ * table for this model rather than observed on hardware, so they are the app's
+ * ground truth but not yet confirmed end to end. Fields whose meaning is not
+ * confirmed are exposed verbatim as disabled-by-default sensors under
+ * `raw`/`ctRaw` rather than being given a name that asserts a meaning.
  *
  * This model runs Marstek's second-generation Venus firmware, along with the
  * Venus X and Venus G. That generation numbers its commands differently from
@@ -182,7 +182,7 @@ const venusMiniRawFields = [
 
 function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
   const options = {
-    refreshDataPayload: 'cd=1',
+    refreshDataPayload: 'cd=01',
     isMessage: isVenusMiniRuntimeInfoMessage,
     publishPath: 'data',
     defaultState: {},

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1778,6 +1778,14 @@ const commandTestCases: CommandTestCase[] = [
   // VENUS E MINI COMMANDS
   // ============================================================
 
+  {
+    description: 'Venus E Mini refresh with PRESS',
+    deviceType: 'VNSEMINI-0',
+    command: 'refresh',
+    input: 'PRESS',
+    expectedOutput: 'cd=01',
+  },
+
   // The Marstek app picks this command's number from the device type: the
   // Venus variants take 55, Jupiter 57, and everything else — the Mini
   // included — falls back to 55.


### PR DESCRIPTION
Use the zero-padded `cd=01` request when polling Venus E Mini runtime telemetry.

Real-device testing confirmed that `cd=01` returns telemetry, while `cd=1` receives no response. The returned payload is already parsed correctly.

## Validation

- Tested read-only against a real Venus E Mini
- Added a regression test
- `npm run lint`
- `npm run format:check`
- `npm test -- --runInBand`
- `npm run build`

Related to #425.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored telemetry updates for Venus E Mini devices.
  - Updated Venus E Mini refresh requests to use the device-compatible zero-padded command format.

- **Documentation**
  - Confirmed that the Venus E Mini `refresh` command works on real hardware.
  - Clarified which commands remain unconfirmed and documented the significance of zero-padded command numbers.

- **Tests**
  - Added coverage verifying that Venus E Mini refresh requests use the correct format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->