### PR TITLE
Pad Venus E Mini command numbers to two characters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,11 @@ For every new or changed config option, treat the following as mandatory complet
 
 `CHANGELOG.md` is read by users, not developers.
 
+- **One entry per user-visible change, and none for unreleased work.** A fix to
+  something that is itself still under `[Next]` repairs a version nobody ever
+  ran; it goes in the commit message instead, and amend the `Added` entry if the
+  fix changes what that entry promises. Where one change has collected two
+  entries in a release, fold them into the better one.
 - **Keep it short. One or two sentences.** Say what changed for the user and
   stop. When in doubt, cut — an entry that is too terse costs a reader nothing,
   one that is too long costs every reader.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,11 +63,13 @@ For every new or changed config option, treat the following as mandatory complet
 
 `CHANGELOG.md` is read by users, not developers.
 
-- **One entry per user-visible change, and none for unreleased work.** A fix to
-  something that is itself still under `[Next]` repairs a version nobody ever
-  ran; it goes in the commit message instead, and amend the `Added` entry if the
-  fix changes what that entry promises. Where one change has collected two
-  entries in a release, fold them into the better one.
+- **One entry per user-visible change, and none for a fix to something
+  unreleased.** Everything under `[Next]` is unreleased, so it still earns its
+  entry; what does not is a *fix* to something that is itself still under
+  `[Next]`, which repairs a version nobody ever ran. That goes in the commit
+  message, and amend the `Added` entry if the fix changes what it promises.
+  Where one change has collected two entries in a release, fold them into the
+  better one.
 - **Keep it short. One or two sentences.** Say what changed for the user and
   stop. When in doubt, cut — an entry that is too terse costs a reader nothing,
   one that is too long costs every reader.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,13 +63,13 @@ For every new or changed config option, treat the following as mandatory complet
 
 `CHANGELOG.md` is read by users, not developers.
 
-- **One entry per user-visible change, and none for a fix to something
-  unreleased.** Everything under `[Next]` is unreleased, so it still earns its
-  entry; what does not is a *fix* to something that is itself still under
-  `[Next]`, which repairs a version nobody ever ran. That goes in the commit
-  message, and amend the `Added` entry if the fix changes what it promises.
-  Where one change has collected two entries in a release, fold them into the
-  better one.
+- **One entry per user-visible change, for the whole release.** A follow-up to
+  something already listed under `[Next]` does not get a second entry: update
+  that entry where the follow-up changes what it promises, and otherwise leave
+  it alone — a follow-up you would not have mentioned on its own does not become
+  worth mentioning by being a fix. The detail goes in the commit message. Where
+  one change has collected two entries in a release, fold them into the better
+  one.
 - **Keep it short. One or two sentences.** Say what changed for the user and
   stop. When in doubt, cut — an entry that is too terse costs a reader nothing,
   one that is too long costs every reader.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### Fixed
 
-- Restore telemetry updates for Venus E Mini devices (discussion #425, PR #439)
 - The MQTT broker password no longer shows up in the log. On startup, the broker URL was written to the log with its credentials in plaintext, which meant sharing a log for troubleshooting could hand out the broker password. In the Home Assistant add-on this affected the password of Home Assistant's own MQTT broker. Broker URLs now appear as `mqtt://user:***@host:1883` (fixes #424, PR #435)
 
 ## [1.10.0] - 2026-08-15

--- a/docs/venus-generations.md
+++ b/docs/venus-generations.md
@@ -59,10 +59,16 @@ on this family it is `GET_FC41D_INFO`, the WiFi module version query, and it is
 only the *B2500* that restarts with `cd=10`. Reaching for that number on a Venus
 queries the WiFi module instead.
 
-The second generation writes its numbers zero-padded (`cd=01`, `cd=05`). This
-is significant for the Venus E Mini's device-info request: a real unit answered
-`cd=01` but did not answer the bare `cd=1`. Other commands may still accept
-either representation.
+The second generation writes every command number as two characters, which for
+the single-digit ones means zero-padded: `cd=01`, `cd=02`, `cd=03`, `cd=04`,
+`cd=05`. On the Venus E Mini that is not cosmetic — a real unit answered `cd=01`
+and did not answer the bare `cd=1` — so hm2mqtt pads all of them for this model.
+
+That is not a rule about Marstek firmware in general. The first generation's
+B2500 code pads the same way (`cd=01`, `cd=03,md=0`, `cd=08,wy=`), yet hm2mqtt
+has always sent those bare and real B2500s answer, so on that firmware the
+padding really is decoration. The two generations differ in how the device
+matches the number, not in what the app writes.
 
 ## Second-generation command map
 
@@ -162,9 +168,9 @@ Of the second generation, only the Venus E Mini is supported, and only partly:
 - `cd=59` power readings — polled
 - `cd=55,adv=` bluetooth advertising — implemented
 - `cd=44,do=` depth of discharge — implemented
-- `cd=2,md=` working mode — implemented
+- `cd=02,md=` working mode — implemented
 - `cd=18,meter=,mac=` meter type — implemented
-- `cd=5` factory reset — implemented
+- `cd=05` factory reset — implemented
 - `cd=61` reboot — implemented
 - `cd=01` refresh and `cd=59` get CT power — also exposed as buttons, so a poll
   can be triggered on demand

--- a/src/device/venusEMini.ts
+++ b/src/device/venusEMini.ts
@@ -48,6 +48,12 @@ import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '
  * be reused, and a number read off that file is more likely wrong than right.
  * docs/venus-generations.md has the full map and how the two are told apart.
  *
+ * That generation also writes every command number as two characters - `cd=01`,
+ * `cd=02`, `cd=05` - and on this model the padding is not decoration: a real
+ * device answered `cd=01` and ignored the bare `cd=1`. Its firmware evidently
+ * matches the string rather than parsing the number, so every command below is
+ * padded the way the app sends it.
+ *
  * Not implemented, and why. Each of these is a real command in the app's
  * tables; what is missing in every case is the set of values it accepts, which
  * the app encodes at the call site rather than in the table:
@@ -65,7 +71,7 @@ import { divide, equalsBoolean, identity, map, negateIfPositive, number } from '
  *   the risk.
  * - `cd=54,am=<n>,aw=<n>,ap=<n>` (anti-reverse-flow). Three parameters, only
  *   the first of which has a guessable meaning.
- * - `cd=3` / `cd=4` (network info, error code). These are reads, and the shape
+ * - `cd=03` / `cd=04` (network info, error code). These are reads, and the shape
  *   of what comes back is not known, so there would be nothing to parse.
  * - `cd=33` (set device time), whose parameters are known - d, m, y, h, min, s
  *   and `wy` - but not whether the clock fields are local or UTC. `wy` is the
@@ -439,7 +445,7 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       }),
     );
 
-    // Working mode, cd=2. Backed by cm rather than write-only, matching the
+    // Working mode, `cd=02`. Backed by cm rather than write-only, matching the
     // Working Mode select on the other Venus models: the device reports its
     // mode, so there is no reason for the entity to show only what was last
     // written. Unrecognised codes fall back to `automatic`, as they do there.
@@ -487,7 +493,7 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
           return;
         }
         updateDeviceState(() => ({ workingMode: message }));
-        publishCallback(`cd=2,md=${venusMiniWorkingModeCommandCodes[message]}`);
+        publishCallback(`cd=02,md=${venusMiniWorkingModeCommandCodes[message]}`);
       },
     });
 
@@ -978,7 +984,7 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
       },
     });
 
-    // Factory reset, `cd=5`. Unlike the first generation's reset, which selects
+    // Factory reset, `cd=05`. Unlike the first generation's reset, which selects
     // between clearing all/part/certificates with an `rs` parameter, this one
     // takes none.
     advertise(
@@ -995,7 +1001,7 @@ function registerVenusMiniRuntimeInfoMessage(message: BuildMessageFn) {
     command('factory-reset', {
       handler: ({ message, publishCallback }) => {
         if (message.toLowerCase() === 'true' || message === '1' || message === 'PRESS') {
-          publishCallback('cd=5');
+          publishCallback('cd=05');
         }
       },
     });

--- a/src/deviceCommands.test.ts
+++ b/src/deviceCommands.test.ts
@@ -1894,7 +1894,7 @@ const commandTestCases: CommandTestCase[] = [
     deviceType: 'VNSEMINI-0',
     command: 'working-mode',
     input: 'automatic',
-    expectedOutput: 'cd=2,md=0',
+    expectedOutput: 'cd=02,md=0',
     expectedStateChanges: { workingMode: 'automatic' },
   },
   {
@@ -1902,14 +1902,14 @@ const commandTestCases: CommandTestCase[] = [
     deviceType: 'VNSEMINI-0',
     command: 'working-mode',
     input: 'manual',
-    expectedOutput: 'cd=2,md=2',
+    expectedOutput: 'cd=02,md=2',
   },
   {
     description: 'Venus E Mini working-mode ai',
     deviceType: 'VNSEMINI-0',
     command: 'working-mode',
     input: 'ai',
-    expectedOutput: 'cd=2,md=3',
+    expectedOutput: 'cd=02,md=3',
   },
   {
     // `trading` is a Venus C/D/E mode with no counterpart here, so the shared
@@ -1934,7 +1934,7 @@ const commandTestCases: CommandTestCase[] = [
     deviceType: 'VNSEMINI-0',
     command: 'factory-reset',
     input: 'PRESS',
-    expectedOutput: 'cd=5',
+    expectedOutput: 'cd=05',
   },
   {
     description: 'Venus E Mini factory-reset ignores an unrelated payload',


### PR DESCRIPTION
## Summary

Updates Venus E Mini command handling to consistently pad all command numbers to two characters (`cd=01`, `cd=02`, `cd=05`) to match the device firmware's string-matching behavior. The device firmware matches command strings literally rather than parsing numeric values, so padding is required for proper operation on this model.

## Changes

- **src/device/venusEMini.ts**: Updated all command invocations to use zero-padded two-character format (`cd=02` instead of `cd=2`, `cd=05` instead of `cd=5`). Added clarifying comments explaining why padding is necessary on this model.
- **src/deviceCommands.test.ts**: Updated test expectations to match the padded command format.
- **docs/venus-generations.md**: Clarified the distinction between first and second generation firmware regarding command number padding. The second generation writes padded numbers, but only the Venus E Mini requires this padding for proper device communication; the first generation B2500 accepts both formats.
- **CHANGELOG.md**: Removed a duplicate/unreleased entry per project conventions (one entry per user-visible change).
- **AGENTS.md**: Added guidance on changelog entry consolidation.

## Implementation Details

The Venus E Mini firmware matches command strings rather than parsing numeric values. Testing confirmed that the device responds to `cd=01` but ignores the bare `cd=1`. This differs from the first generation B2500, which accepts both formats despite the firmware also writing padded numbers.

All command numbers in the Venus E Mini implementation are now consistently padded to maintain compatibility with the device's string-matching behavior.

## Validation

- `npm run lint` ✓
- `npm run format:check` ✓
- `npm test -- --runInBand` ✓
- `npm run build` ✓

https://claude.ai/code/session_0156SPvsA15dNy4GVFFpyKkS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed working-mode and factory-reset commands for Venus E Mini devices by using the required zero-padded command numbers, improving compatibility with affected units.
  - Updated command formatting to ensure Venus E Mini devices correctly recognize supported control requests.

- **Documentation**
  - Clarified Venus device-generation command formatting and why zero-padding is required for Venus E Mini models.
  - Updated documented second-generation command examples for working mode, meter type, and factory reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->